### PR TITLE
fixes broken PEcAn BUILD 46efcd035e18337f0fbe53d426bbf6c779bce544

### DIFF
--- a/db/DESCRIPTION
+++ b/db/DESCRIPTION
@@ -28,3 +28,4 @@ Collate:
     'query.prior.R'
     'query.trait.data.R'
     'query.traits.R'
+    'utils.R'

--- a/db/R/utils.R
+++ b/db/R/utils.R
@@ -6,5 +6,12 @@
 ##' @export
 ##' @author David LeBauer
 db.exists <- function(){
+  if(!exists("settings")){
+    settings <- list(database = 
+                       list(userid = "bety", 
+                            passwd = "bety", 
+                            location = "localhost",
+                            name = "bety"))
+  }
   tryCatch(query.base.con(), error = function(e)TRUE)
 }


### PR DESCRIPTION
error causing break was 

```
----------------------------------------------------------------------
INSTALL db BROKEN
----------------------------------------------------------------------
* installing *source* package 'PEcAn.DB' ...
** R
Error in .install_package_code_files(".", instdir) :
files in '/home/kooper/autobuild/pecan/db/R' missing from 'Collate' field:
  db.exists.R
ERROR: unable to collate and parse R files for package 'PEcAn.DB'
* removing '/home/kooper/lib/R/PEcAn.DB'
```
