### PR TITLE
Fix for issue #23 - sensitivity.analysis start/end date

### DIFF
--- a/utils/R/read.settings.R
+++ b/utils/R/read.settings.R
@@ -121,7 +121,7 @@ check.settings <- function(settings) {
     }
 
     if(is.null(settings$sensitivity.analysis$end.date)) {
-      settings$sensitivity.analysis$start.date <- settings$run$end.date 
+      settings$sensitivity.analysis$end.date <- settings$run$end.date 
       logger.info("No end date passed to sensitivity.analysis - using the run end date (", settings$run$end.date, ").")
     }
   }


### PR DESCRIPTION
If not explicitly given, sensitivity.analysis start/end date default to the run's start/end date. #23 
