### PR TITLE
Removed dependencies in check.settings

### DIFF
--- a/utils/R/read.settings.R
+++ b/utils/R/read.settings.R
@@ -351,7 +351,7 @@ check.settings <- function(settings) {
   # check for workflow defaults
   if(database){
     if (settings$bety$write) {
-      if (!'workflow' %in% names(settings)) {
+      if ("model" %in% names(settings) && !'workflow' %in% names(settings)) {
         con <- db.open(settings$database)
         if(!is.character(con)){
           db.query(paste("INSERT INTO workflows (site_id, model_id, hostname, start_date, end_date, started_at, created_at, folder) values ('",


### PR DESCRIPTION
- The first commit sets default settings for the database if settings$database is null
- The second commit removes dependencies on 1) a database connection, 2) a model, and 3) a run. 

The goal of these changes is to make PEcAn more modular - e.g. if someone wants to just do the meta-analysis, model and run information should not be strictly required. But please let me know if I am missing something important.
