### PR TITLE
update to read.output() function.  Fixes issue #1812 in Redmine

### DIFF
--- a/utils/R/get.results.R
+++ b/utils/R/get.results.R
@@ -29,7 +29,6 @@ get.results <- function(settings) {
       variables = settings$sensitivity.analysis[
                  names(settings$sensitivity.analysis) == "variable"]
     }
-    
     for(pft.name in names(trait.samples)){
       
       traits <- names(trait.samples[[pft.name]])

--- a/utils/R/read.output.R
+++ b/utils/R/read.output.R
@@ -100,9 +100,16 @@ read.output <- function(runid, outdir, start.year=NA,
     "DOC_flux", "Fire_flux") # kgC m-2 d-1
   wflux = c("Evap", "TVeg", "Qs", "Qsb", "Rainf") # kgH20 m-2 d-1
   
+  # create list of *.nc years
+  nc.years <- as.vector(unlist(strsplit(list.files(path = outdir, pattern="\\.nc$", full.names=FALSE),".nc")))
+  # select only those *.nc years requested by user
+  keep <- which(nc.years >= as.numeric(start.year) & nc.years <= as.numeric(end.year))
   ncfiles <- list.files(path = outdir, pattern="\\.nc$", full.names=TRUE)
+  ncfiles <- ncfiles[keep]
+  # throw error if no *.nc files selected/availible
   if(length(ncfiles) == 0) logger.error("no netCDF files of model output present")
   
+  print(paste("Years: ",start.year," - ",end.year),sep="")
   result <- list()
   for(ncfile in ncfiles) {
     nc <- nc_open(ncfile)


### PR DESCRIPTION
Fixes an issue (#1812) in which repeat calls to run.sensitivity.analysis() using different years for the analysis didn't change the results. Updated read.output() to only select *.nc output files for the selected years.
