### PR TITLE
updated check.settings: models queried with model name and version

### DIFF
--- a/settings/R/read.settings.R
+++ b/settings/R/read.settings.R
@@ -276,26 +276,43 @@ check.settings <- function(settings) {
   # check modelid with values
   if(!is.null(settings$model)){
     if (is.null(settings$model$id)) {
-      settings$model$id <- -1
-    } else {
-      if(database && as.numeric(settings$model$id) >= 0){
-        model <- db.query(paste("SELECT * FROM models WHERE id =", settings$model$id), params=settings$database)
-      } else {
-        model <- data.frame(id=settings$model$id)
-        if (!is.null(settings$model$name)) {
-          model$model_type=settings$model$name
-        }
-        if (!is.null(settings$model$name)) {
-          model$model_path=paste0("hostname:", settings$model$binary)
+      if(database){
+        if(!is.null(settings$model$id)){
+          if(as.numeric(settings$model$id) >= 0){
+            model <- db.query(paste("SELECT * FROM models WHERE id =", settings$model$id), params=settings$database)
+            if(nrow(model) == 0) {
+              logger.error("There is no record of model_id = ", settings$model$id, "in database")
+            }
+          }
+        } else if (!is.null(settings$model$name)) {
+          model <- db.query(paste0("SELECT * FROM models WHERE model_name = '", settings$model$name,
+                                   "' or model_type = '", toupper(settings$model$name), "'",
+                                   " and model_path like '%", 
+                                   ifelse(settings$run$host$name == "localhost", Sys.info()[['nodename']], 
+                                          settings$run$host$name), "%' ",
+                                   ifelse(is.null(settings$model$revision), "", 
+                                          paste0(" and revision like '%", settings$model$revision, "%' "))), 
+                            params=settings$database)
+          if(nrow(model) > 1){
+            logger.warn("multiple records for", settings$model$name, "returned; using the most recent")
+            model <- model[which.max(ymd_hms(model$updated_at)), ]
+          } else if (nrow(model) == 0) {
+            logger.warn("Model", settings$model$name, "not in database")
+          }
+        } else if(database && is.null(settings$model$id) && is.null(settings$model$name)) {
+          logger.severe("no model settings given")
         }
       }
-      if(nrow(model) == 0) {
-        logger.error("There is no record of model_id = ", settings$model$id, "in database")
+      if (!is.null(settings$model$name)) {
+        model$model_type=settings$model$name
+      }
+      if (!is.null(settings$model$name)) {
+        model$model_path=paste0("hostname:", settings$model$binary)
       }
       if (!is.null(model$model_path)) {
         model$binary <- tail(strsplit(model$model_path, ":")[[1]], 1)        
       }
-
+      
       if (is.null(settings$model$name)) {
         if ((is.null(model$model_type) || model$model_type == "")) {
           logger.severe("No model type specified.")
@@ -305,7 +322,7 @@ check.settings <- function(settings) {
       } else if (model$model_type != settings$model$name) {
         logger.warn("Specified model type [", settings$model$name, "] does not match model_type in database [", model$model_type, "]")
       }
-
+      
       if (is.null(settings$model$binary)) {
         if ((is.null(model$binary) || model$binary == "")) {
           logger.severe("No model binary specified.")
@@ -317,7 +334,7 @@ check.settings <- function(settings) {
       }
     }
   }
-
+  
   # check siteid with values
   if(!is.null(settings$run$site)){
     if (is.null(settings$run$site$id)) {


### PR DESCRIPTION
Rob - these are the changes I proposed earlier, so that either model id or model$name + model$revision could be set. It would have been much easier to just use settings$model$id! Let me know if you think these are worth keeping.
