### PR TITLE
Fixsettings

### DIFF
--- a/settings/R/read.settings.R
+++ b/settings/R/read.settings.R
@@ -510,12 +510,11 @@ check.settings <- function(settings) {
     settings$run$host$rundir <- settings$rundir
     settings$run$host$outdir <- settings$modeloutdir
   }
-  logger.warn("Database is working ________________________________")
+
   # check/create the pft folders
   for (i in 1:length(settings$pfts)) {
     #if name tag specified not within pft, add it within a pft tag and warn the user
   
-    logger.warn("Database is working 111111111111111111111111111")
     #check if name tag within pft
     if (!"name" %in% names(settings$pfts[i]$pft)) {
       logger.severe(cat("No name specified for pft of index: ", i, ", please specify name"))


### PR DESCRIPTION
Added error checking in read.settings for 2 cases:
1. If user does not specify a name tag within a pft tag, a message will be thrown and the run will fail.
2. If user specifies a name tag within a pft, but the name is not an actual model name in the database, a message will be thrown and the run will fail. 
