### PR TITLE
Allometries: more documentation debugging. Error that’s persisted through...

### DIFF
--- a/modules/allometry/R/read.allom.data.R
+++ b/modules/allometry/R/read.allom.data.R
@@ -10,8 +10,8 @@
 #' @param field      raw field data
 #' @param parm       allometry equation file, Jenkins table 3
 #' @param nsim       number of Monte Carlo draws in numerical transforms
-#' @return \item{field}
-#'         \item{parm}
+#' @return \item{field}{Field Data}
+#'         \item{parm}{Compiled Allometries}
 read.allom.data <- function(pft.data, component, field, parm,nsim=10000) {
 
   allom <- list(parm=NULL,field=NULL)

--- a/modules/allometry/man/Table3.Rd
+++ b/modules/allometry/man/Table3.Rd
@@ -1,6 +1,7 @@
 \name{Table3_GTR-NE-319.v2}
 \docType{data}
 \title{Table3_GTR-NE-319.v2}
+\alias{Table3_GTR-NE-319.v2}
 \description{
 Jenkins et al. 2004 Allometry Table 3
 }

--- a/modules/allometry/man/read.allom.data.Rd
+++ b/modules/allometry/man/read.allom.data.Rd
@@ -21,7 +21,8 @@
   transforms}
 }
 \value{
-  \item{field} \item{parm}
+  \item{field}{Field Data}
+  \item{parm}{Compiled Equations}
 }
 \description{
   read.allom.data

--- a/modules/allometry/tests/run.all.R
+++ b/modules/allometry/tests/run.all.R
@@ -7,7 +7,7 @@
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
 library(testthat)
-library(PEcAn.qaqc)
+library(PEcAn.allometry)
 
 logger.setQuitOnSevere(FALSE)
-test_package("PEcAn.qaqc")
+test_package("PEcAn.allometry")


### PR DESCRIPTION
... the last few check-ins appears to be due to having copied run.all.R from another module
