### PR TITLE
get.sample was failing with one-parameter distributions

### DIFF
--- a/modules/priors/R/priors.R
+++ b/modules/priors/R/priors.R
@@ -173,7 +173,13 @@ pr.samp <- function(distn, parama, paramb, n) {
 ##' @export
 #--------------------------------------------------------------------------------------------------#
 get.sample <- function(prior, n) {
-  do.call(paste('r', prior$distn, sep=""), list(n, prior$parama, prior$paramb))
+  if(is.na(prior$paramb)){  
+    ## one parameter distributions
+    do.call(paste('r', prior$distn, sep=""), list(n, prior$parama))
+  } else {
+    ## two parameter distributions
+    do.call(paste('r', prior$distn, sep=""), list(n, prior$parama, prior$paramb))
+  }
 }
 #==================================================================================================#
 


### PR DESCRIPTION
 such as the exponential. Simple bug fix to not use parameter b when it's NA
