### PR TITLE
Tweak to make start.model.runs() wait for remote jobs.

### DIFF
--- a/utils/R/start.model.runs.R
+++ b/utils/R/start.model.runs.R
@@ -171,6 +171,7 @@ start.model.runs <- function(settings, write = TRUE){
     logger.debug("Waiting for the following jobs:", unlist(jobids, use.names=FALSE))
   }
 
+
   # check to see if all remote jobs are done
   while(length(jobids) > 0) {
     Sys.sleep(10)
@@ -185,7 +186,7 @@ start.model.runs <- function(settings, write = TRUE){
       } else {
         out <- system2("ssh", c(settings$run$host$name, args, recursive=TRUE), stdout=TRUE)
       }
-      if ((nchar(out) > 0) && (substring(out, nchar(out)-3) == "DONE")) {
+      if ((length(out) > 0) && (substring(out, nchar(out)-3) == "DONE")) {
         logger.debug("Job", jobids[run], "for run", format(run,scientific=FALSE), "finished")
         jobids[run] <- NULL
         if (!is.null(dbcon)) {


### PR DESCRIPTION
OK, so fairly new to git, completely new to pull request workflow... bear with me.

I made this one small change to start.model.runs.R so it would wait for my remote job on geo.bu.edu. Before the change, it would fail with an error. A few more details are in the commit message.

I put this on its own branch (trivial for so small a change, or still recommended?), and supposedly am offering that branch as a pull request... now.
