### PR TITLE
Tweak to make trait conversion (e.g. LMA->SLA) less random

### DIFF
--- a/db/R/query.trait.data.R
+++ b/db/R/query.trait.data.R
@@ -293,6 +293,7 @@ take.samples <- function(summary, sample.size = 10^6){
   if(is.na(summary$stat)){
     ans <- summary$mean
   } else {
+    set.seed(999)
     ans <- rnorm(sample.size, summary$mean, summary$stat)
   }
   return(ans)


### PR DESCRIPTION
Per discussion at gh-245, setting the random seed before doing trait conversion
should prevent re-run of meta-analysis when `forceupdate=AUTO` if traits really
haven't changed since last run.
