### PR TITLE
Add -l flag to allow 'module load XXX' to work

### DIFF
--- a/models/ed/inst/template.job
+++ b/models/ed/inst/template.job
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -l
 
 # redirect output
 exec 3>&1


### PR DESCRIPTION
If I try to run a qsub job on geo.bu.edu and it requires modules
I've loaded in my .bashrc (e.g., 'module load hdf5' in this case),
the job only works if my script has a '-l' flag after the shebang.

Apparently some users don't have this issue, but it doesn't seem like
the flag hurts anything even when its not needed.
