### PR TITLE
Fix previous edit that makes horrible failed test emails go to everyone

### DIFF
--- a/db/R/query.trait.data.R
+++ b/db/R/query.trait.data.R
@@ -293,7 +293,7 @@ take.samples <- function(summary, sample.size = 10^6){
   if(is.na(summary$stat)){
     ans <- summary$mean
   } else {
-    set.seed(999)
+    set.seed(0)
     ans <- rnorm(sample.size, summary$mean, summary$stat)
   }
   return(ans)


### PR DESCRIPTION
Sorry about this... I didn't know about the '--test' flag for build.sh (and it doesn't work for me anyway, but that's another story). 

My one change in Build #292 (also included in build #293) was to add a random seed. Which is different from the one used in the test script, hence the test output isn't as expected.

Changing the random seeds to match seems like an easy way to fix this, and running test.derive.traits.R manually seems to confirm that. But I still can't get `./build.sh --test` to work so I hope someone double-checks for me before merging this. 
