### PR TITLE
added test for sipnet on pecan2.bu.edu

### DIFF
--- a/tests/pecan2.bu.edu.sipnet.xml
+++ b/tests/pecan2.bu.edu.sipnet.xml
@@ -9,7 +9,7 @@
      <host>psql-pecan.bu.edu</host>
      <dbname>bety</dbname>
      <driver>PostgreSQL</driver>
-     <write>TRUE</write>
+     <write>FALSE</write>
     </bety>
   </database>
 


### PR DESCRIPTION
Added a tests/...xml file that allowed me to run `build.sh --test` successfully. I couldn't get an ED2 version to work yet, even though I am able to confirm that ED2 test runs work.
