### PR TITLE
integrators lat/lon/time changes from Josh

### DIFF
--- a/modules/data.atmosphere/R/met2CF.Ameriflux.R
+++ b/modules/data.atmosphere/R/met2CF.Ameriflux.R
@@ -1,3 +1,45 @@
+# helper function to copy variables and attributes from one
+# nc file to another. This will do conversion of the variables
+# as well as on the min/max values
+copyvals <- function(nc1, var1, nc2, var2, dim2, units2=NA, conv=NULL, missval=-6999.0, verbose=FALSE) {
+    vals <- ncvar_get(nc=nc1, varid=var1)
+    vals[vals==-6999 || vals==-9999] <- NA
+    if (!is.null(conv)) {
+      vals <- lapply(vals, conv)
+    }
+    if (is.na(units2)) {
+      units2 <- ncatt_get(nc=nc1, varid=var1, attname='units', verbose=verbose)$value
+    }
+    var <- ncvar_def(name=var2, units=units2, dim=dim2, missval=missval, verbose=verbose)
+    nc2 <- ncvar_add(nc=nc2, v=var, verbose=verbose)
+    ncvar_put(nc=nc2, varid=var2, vals=vals)
+    
+    # copy and convert attributes
+    att <- ncatt_get(nc1, var1, 'long_name')
+    if (att$hasatt) {
+      val <- att$value
+      ncatt_put(nc=nc2, varid=var2, attname='long_name', attval=val)
+    }
+    
+    att <- ncatt_get(nc1, var1, 'valid_min')
+    if (att$hasatt) {
+      val <- ifelse(is.null(conv), att$value, conv(att$value))
+      ncatt_put(nc=nc2, varid=var2, attname='valid_min', attval=val)
+    }
+    
+    att <- ncatt_get(nc1, var1, 'valid_max')
+    if (att$hasatt) {
+      val <- ifelse(is.null(conv), att$value, conv(att$value))
+      ncatt_put(nc=nc2, varid=var2, attname='valid_max', attval=val)
+    }
+    
+    att <- ncatt_get(nc1, var1, 'comment')
+    if (att$hasatt) {
+      val <- sub(', -9999.* = missing value, -6999.* = unreported value', '', att$value)
+      ncatt_put(nc=nc2, varid=var2, attname='comment', attval=val)
+    }
+}
+
 ##' Get meteorology variables from Ameriflux L2 netCDF files and convert to netCDF CF format
 ##'
 ##' @name met2CF.Ameriflux
@@ -11,10 +53,8 @@
 ##' @param overwrite should existing files be overwritten
 ##' 
 ##' @author Josh Mantooth, Mike Dietze, Elizabeth Cowdery
-met2CF.Ameriflux <- function(start_year, end_year, in.path, in.prefix, outfolder, overwrite=FALSE){
+met2CF.Ameriflux <- function(start_year, end_year, in.path, in.prefix, outfolder, overwrite=FALSE, verbose=FALSE){
   #---------------- Load libraries. -----------------------------------------------------------------#
-#  require(PEcAn.all)
-#  require(RPostgreSQL)
   require(ncdf4)
   #--------------------------------------------------------------------------------------------------#  
   
@@ -45,153 +85,146 @@ met2CF.Ameriflux <- function(start_year, end_year, in.path, in.prefix, outfolder
       next
     }
     
-    ## copy old file to new directory
-    file.copy(old.file, new.file, overwrite=TRUE)
+    #open raw ameriflux
+    nc <- nc_open(old.file,write=TRUE)
+        
+    # get dimension and site info
+    tdim <- nc1$dim[["DTIME"]]
+    loc <- ncatt_get(nc=nc1, varid=0, attname='site_location')
     
-    ### rename time dimension
-    system2("ncrename",paste("-d DTIME,time -v DTIME,time", new.file))
+    # create new coordinate dimensions based on site location lat/lon
+    lat <- ncdim_def(name='latitude', units='', vals=1:1, create_dimvar=FALSE)
+    lon <- ncdim_def(name='longitude',units='',vals=1:1, create_dimvar=FALSE)
+    time <- ncdim_def(name='time', units='', vals=tdim$vals, create_dimvar=TRUE, unlim=TRUE)
+    dim=list(lat,lon,time)
     
-    ### if reading ameriflux .nc file ###
-    nc <- nc_open(new.file,write=TRUE)
+    # copy lat attribute to latitude
+    vals <- rep(as.numeric(substr(loc$value,20,28)), tdim$len)
+    var <- ncvar_def(name="latitude",
+                     units="degree_north",
+                     dim=(list(lat,lon,time)), missval=as.numeric(-9999))
+    nc2 <- nc_create(filename=new.file, vars=var, verbose=verbose)
+    ncvar_put(nc=nc2, varid='latitude', vals=vals)
+
+    # copy lon attribute to longitude
+    vals <- rep(as.numeric(substr(loc$value,40,48)), tdim$len)
+    var <- ncvar_def(name="longitude",
+                     units="degree_east",
+                     dim=(list(lat,lon,time)), missval=as.numeric(-9999))
+    nc2 <- ncvar_add(nc=nc2, v=var, verbose=verbose)
+    ncvar_put(nc=nc2, varid='longitude', vals=vals)
     
-    #time dimension for adding new variables
-    tdim = nc$dim[["time"]]
-    
+    # Convert all variables, this will include conversions or computations
+    # to create values from original file. In case of conversions the steps
+    # will pretty much always be:
+    #  a) get values from original file
+    #  b) set -6999 and -9999 to NA
+    #  c) do unit conversions
+    #  d) create output variable
+    #  e) write results to new file
+
     # convert TA to air_temperature
-    ta <- ncvar_get(nc, varid="TA")
-    ta[ta==-6999 || ta==-9999] <- NA
-    # unit conversion
-    ta <- ta + 273.15
-    ncatt_put(nc=nc,varid='TA',attname='units',attval='degrees K') 
-    #ncvar_change_missval(nc, 'TA', -9999)
-    ncvar_put(nc,varid='TA',vals=ta)
-    nc <- ncvar_rename(nc=nc,'TA','air_temperature')
+    copyvals(nc1=nc1, var1='TA',
+             nc2=nc2, var2='air_temperature', units2='degrees K', dim2=dim, 
+             conv=function(x) { x + 273.15 }, verbose=verbose)
+    
+    # convert PRESS to air_pressure
+    copyvals(nc1=nc1, var1='PRESS',
+             nc2=nc2, var2='air_pressure', units2='Pa', dim2=dim, 
+             conv=function(x) { x * 1000 }, verbose=verbose)
     
     # convert TS1 to soil_temperature
-    # TODO: leave TS1 for now
-    ts <- ncvar_get(nc=nc,varid='TS1')
-    ts[ts==-6999 || ts==-9999] <- NA
-    # unit conversion
-    ts <- ts + 273.15
-    ts.var <- ncvar_def(name='soil_temperature',units='degrees K',dim=list(tdim),missval=-9999) #define netCDF variable, doesn't include longname and comments
-    nc <- ncvar_add(nc,v=ts.var,verbose=TRUE) #add variable to existing netCDF file
-    ncvar_put(nc,varid='soil_temperature',vals=ts)
-        
-    #convert wind speed and wind direction to U and V
-    wd <- ncvar_get(nc=nc,varid='WD') #wind direction
-    ws <- ncvar_get(nc=nc,varid='WS') #wind speed
-    sub <- which(ws > -6999 & wd > -6999)
-    w.miss <- pmin(ws[-sub],wd[-sub])
-    wd.sub <- wd[sub] #use wind direction coincident with windspeed
-    u = v = rep(NA,length(ws))
-    u[sub] <- ws[sub]*cos(wd.sub*(pi/180))
-    v[sub] <- ws[sub]*sin(wd.sub*(pi/180))
-    u[-sub] = w.miss
-    v[-sub] = w.miss
-    nc <- ncvar_rename(nc=nc,'WS','wind_speed') #CF name
-    nc <- ncvar_rename(nc=nc,'WD','wind_direction') #CF name
-    
-    #create u and v variables and insert into file
-    tdim = nc$dim[["time"]]
-    u.var <- ncvar_def(name='eastward_wind',units='m/s',dim=list(tdim),missval= -9999) #define netCDF variable, doesn't include longname and comments
-    nc <- ncvar_add(nc=nc,v=u.var,verbose=TRUE) #add variable to existing netCDF file
-    ncvar_put(nc,varid='eastward_wind',vals=u)
-    
-    v.var <- ncvar_def(name='northward_wind',units='m/s',dim=list(tdim),missval= -9999) #define netCDF variable, doesn't include longname and comments
-    nc <- ncvar_add(nc=nc,v=v.var,verbose=TRUE) #add variable to existing netCDF file
-    ncvar_put(nc,varid='northward_wind',vals=v)
-   
-    # convert PRESS to air_pressure
-    press <- ncvar_get(nc=nc,varid="PRESS")
-    press[press==-6999 || press==-9999] <- NA
-    # unit conversion
-    press <- press * 1000
-    ncatt_put(nc=nc,varid='PRESS',attname='units',attval='Pa') 
-    #ncvar_change_missval(nc, 'PRESS', -9999)
-    ncvar_put(nc,varid='PRESS',vals=press)
-    nc <- ncvar_rename(nc,'PRESS', 'air_pressure', verbose=TRUE)
-    
-    # convert PAR to surface_downwelling_photosynthetic_photon_flux_in_air
-    par <- ncvar_get(nc, varid="PAR")
-    par[par==-6999 || par==-9999] <- NA
-    # unit conversion
-    par <- par / 1e6
-    ncatt_put(nc=nc,varid='PAR',attname='units',attval='mol m-2 s-1') 
-    #ncvar_change_missval(nc, 'PAR', -9999)
-    ncvar_put(nc,varid='PAR',vals=par)
-    nc <- ncvar_rename(nc,'PAR','surface_downwelling_photosynthetic_photon_flux_in_air', verbose=TRUE)
+    copyvals(nc1=nc1, var1='TS1',
+             nc2=nc2, var2='soil_temperature', units2='degrees K', dim2=dim, 
+             conv=function(x) { x + 273.15 }, verbose=verbose)
+
+    # copy RH to relative_humidity
+    copyvals(nc1=nc1, var1='RH',
+             nc2=nc2, var2='relative_humidity', dim2=dim, 
+             verbose=verbose)
+
+    # convert RH to SH
+    rh <- ncvar_get(nc=nc1, varid="RH")
+    rh[rh==-6999 || rh==-9999] <- NA
+    rh <- rh / 100
+    ta <- ncvar_get(nc=nc1, varid="TA")
+    ta[ta==-6999 || ta==-9999] <- NA
+    ta <- ta + 273.15
+    sh <- rh2qair(rh=rh,T=ta)
+    var <- ncvar_def(name='specific_humidity', units='kg/kg', dim=dim, missval=-6999.0, verbose=verbose)
+    nc2 <- ncvar_add(nc=nc2, v=var, verbose=verbose)
+    ncvar_put(nc=nc2, varid='specific_humidity', vals=sh)
     
     # convert VPD to water_vapor_saturation_deficit
-    vpd <- ncvar_get(nc, varid="VPD")
-    vpd[vpd==-6999 || vpd==-9999] <- NA
-    # HACK This needs fixing
-    vpd[vpd<0] <- NA
-    # unit conversion
-    vpd <- vpd * 1000
-    ncatt_put(nc=nc,varid='VPD',attname='units',attval='Pa') 
-    #ncvar_change_missval(nc, 'VPD', -9999)
-    ncvar_put(nc,varid='VPD',vals=vpd)
-    nc <- ncvar_rename(nc,'VPD','water_vapor_saturation_deficit')
-    
-    # rename Rg to surface_downwelling_shortwave_flux
-    nc <- ncvar_rename(nc=nc,'Rg','surface_downwelling_shortwave_flux')
+    # HACK : conversion will make all values < 0 to be NA
+    copyvals(nc1=nc1, var1='VPD',
+             nc2=nc2, var2='water_vapor_saturation_deficit', units2='mol m-2 s-1', dim2=dim, 
+             conv=function(x) { ifelse(x<0, NA, x*1000) }, verbose=verbose)
 
-    # rename Rgl to surface_downwelling_longwave_flux
-    nc <- ncvar_rename(nc=nc,'Rgl','surface_downwelling_longwave_flux')
-    
-    #convert precipitation to CF standard
-    time <- ncvar_get(nc=nc,varid="time")
-    min <- 0.02083/30 #0.02083 time = 30 minutes
-    timestep <- round(x=mean(diff(time))/min,digits=1) #round to nearest 0.1 minute
-    prec <- ncvar_get(nc=nc,varid="PREC")
-    prec.sub <- which(prec > -6999)
-    prec.new <- prec[prec.sub]/timestep/60 #mm/s = kg/m2/s
-    prec <- replace(x=prec,list=prec.sub,values=prec.new)
-    ncatt_put(nc=nc,varid='PREC',attname='units',attval='kg/m^2/s') 
-    ncvar_put(nc=nc, varid='PREC',vals=prec)
-    nc <- ncvar_rename(nc=nc,'PREC','precipitation_flux')
-    
-    # convert RH to SH
-    rh <- ncvar_get(nc=nc,varid='RH')
-    rh.sub <- which(rh > -6999) #select non-missing data
-    rh.sh <- as.vector(rh.sub/100) #percent to proportion: needed for conversion
-    rh.sh <- replace(x=rh,list=rh.sub,values=rh.sh) #insert proportion values into RH vector
-    ta.rh <- ta[rh.sub] # use T coincident with RH
-    sh.miss <- rh2qair(rh=rh.sh[rh.sub],T=ta.rh) #conversion, doesn't include missvals. was rh2rv
-    sh <- replace(x=rh,list=rh.sub,values=sh.miss) #insert Kelvin values into vector
-    sh.var <- ncvar_def(name='specific_humidity',units='kg/kg',dim=list(tdim),missval= -9999) #define netCDF variable, doesn't include longname and comments
-    nc <- ncvar_add(nc=nc,v=sh.var,verbose=TRUE) #add variable to existing netCDF file
-    ncvar_put(nc,varid='specific_humidity',vals=sh)
-    ncatt_put(nc=nc,varid='RH',attname='units',attval='percent') 
-    nc <- ncvar_rename(nc=nc,'RH','relative_humidity')
-    
-    # fixing APARpct
-    ncatt_put(nc=nc,varid='APARpct',attname='units',attval='percent') 
-    # fixing ZL
-    ncatt_put(nc=nc,varid='ZL',attname='units',attval='m/m') 
-    
-    #get site location attribute
-    loc <- ncatt_get(nc=nc,varid=0,attname='site_location')
-   # lat.value <- rep(as.numeric(substr(loc$value,20,28)),tdim$len)
-   # lon.value <- rep(as.numeric(substr(loc$value,40,48)),tdim$len)
-    lat.value <- as.numeric(substr(loc$value,20,28))
-    lon.value <- as.numeric(substr(loc$value,40,48))
-    
-    #create new coordinate dimensions based on site location lat/lon
-    lat <- ncdim_def(name='latitude',units='',vals=1:1,create_dimvar=FALSE)
-    lon <- ncdim_def(name='longitude',units='',vals=1:1,create_dimvar=FALSE)
-    
-    #create site location variables
-    lat.var <- ncvar_def(name='latitude',units='degree_north',dim=list(lat),missval=-9999) 
-    nc <- ncvar_add(nc=nc,v=lat.var,verbose=TRUE) #add latitude to existing netCDF file
-    ncvar_put(nc,varid='latitude',vals=lat.value)
-    
-    lon.var <- ncvar_def(name='longitude',units='degree_east',dim=list(lon),missval=-9999) 
-    nc <- ncvar_add(nc=nc,v=lon.var,verbose=TRUE) #add longitude to existing netCDF file
-    ncvar_put(nc,varid='longitude',vals=lon.value)
-    
+    # copy Rg to surface_downwelling_shortwave_flux_in_air
+    copyvals(nc1=nc1, var1='Rg',
+             nc2=nc2, var2='surface_downwelling_shortwave_flux_in_air', dim2=dim, 
+             verbose=verbose)
+
+    # copy Rgl to surface_downwelling_longwave_flux_in_air
+    copyvals(nc1=nc1, var1='Rgl',
+             nc2=nc2, var2='surface_downwelling_longwave_flux_in_air', dim2=dim, 
+             verbose=verbose)
+
+    # convert PAR to surface_downwelling_photosynthetic_photon_flux_in_air
+    copyvals(nc1=nc1, var1='PAR',
+             nc2=nc2, var2='surface_downwelling_photosynthetic_photon_flux_in_air', units2='mol m-2 s-1', dim2=dim, 
+             conv=function(x) { x / 1e6 }, verbose=verbose)
+
+    # copy WD to wind_direction (not official CF)
+    copyvals(nc1=nc1, var1='WD',
+             nc2=nc2, var2='wind_direction', dim2=dim, 
+             verbose=verbose)
+
+    # copy WS to wind_speed
+    copyvals(nc1=nc1, var1='WS',
+             nc2=nc2, var2='wind_speed', dim2=dim, 
+             verbose=verbose)
+
+    # convert PREC to precipitation_flux
+    t <- tdim$vals
+    min <- 0.02083/30 # 0.02083 time = 30 minutes
+    timestep <- round(x=mean(diff(t))/min,digits=1) # round to nearest 0.1 minute
+    copyvals(nc1=nc1, var1='PREC',
+             nc2=nc2, var2='precipitation_flux', units2='kg/m^2/s', dim2=dim, 
+             conv=function(x) { x/timestep/60 }, verbose=verbose)
+
+    # convert wind speed and wind direction to eastward_wind and northward_wind
+    wd <- ncvar_get(nc=nc1, varid='WD') #wind direction
+    wd[wd==-6999 || wd==-9999] <- NA
+    ws <- ncvar_get(nc=nc1, varid='WS') #wind speed
+    ws[ws==-6999 || ws==-9999] <- NA
+    ew <- ws * cos(wd * (pi/180))
+    nw <- ws * sin(wd * (pi/180))
+    max <- ncatt_get(nc=nc1, varid='WS', 'valid_max')$value
+
+    var <- ncvar_def(name='eastward_wind', units='m/s', dim=dim, missval=-6999.0, verbose=verbose)
+    nc2 <- ncvar_add(nc=nc2, v=var, verbose=verbose)
+    ncvar_put(nc=nc2, varid='eastward_wind', vals=ew)
+    ncatt_put(nc=nc2, varid='eastward_wind', attname='valid_min', attval=-max)
+    ncatt_put(nc=nc2, varid='eastward_wind', attname='valid_max', attval=max)
+
+    var <- ncvar_def(name='northward_wind', units='m/s', dim=dim, missval=-6999.0, verbose=verbose)
+    nc2 <- ncvar_add(nc=nc2, v=var, verbose=verbose)
+    ncvar_put(nc=nc2, varid='northward_wind', vals=nw)
+    ncatt_put(nc=nc2, varid='northward_wind', attname='valid_min', attval=-max)
+    ncatt_put(nc=nc2, varid='northward_wind', attname='valid_max', attval=max)
+
+    # add global attributes from original file
+    cp.global.atts <- ncatt_get(nc=nc1, varid=0)
+    for(j in 1:length(cp.global.atts)){
+      ncatt_put(nc=nc2, varid=0, attname=names(cp.global.atts)[j], attval=cp.global.atts[[j]])
+    }
+
+    # done, close both files
     nc_close(nc)
-  }  ## end loop over files
+    nc_close(nc2)
+  }  ## end loop over years
   
   invisible(results)
 }   ## end netCDF CF conversion ##


### PR DESCRIPTION
@jam2767 and @mdietze please can you check this. I took the changes from Josh and looked at the outputs it generated and compared the graphs to the original code. The graphs looks similar except for precipitation_flux and specific_humidity.

For precipitation_flux I checked the new graph with the data from Ameriflux and it follows the same pattern, in the case of the original code the precipitation_flux seemed to be always 0.

For specific_humidity I get a different graph. Looking at the original code it seems there was an error:

``` R
    rh <- ncvar_get(nc=nc2,varid='RH')
    rh.sub <- which(rh > -6999) #select non-missing data
    rh.sh <- as.vector(rh.sub/100) #percent to proportion: needed for conversion
    rh.sh <- replace(x=rh,list=rh.sub,values=rh.sh) #insert proportion values into RH vector
    ta.rh <- ta[rh.sub] # use T coincident with RH
    sh.miss <- rh2qair(rh=rh.sh[rh.sub],T=ta.rh) #conversion, doesn't include missvals. was rh2rv
    sh <- replace(x=rh,list=rh.sub,values=sh.miss) #insert Kelvin values into vector
    sh.var <- ncvar_def(name='specific_humidity',units='kg/kg',dim=list(lat,lon,time),missval= -9999) #define netCDF variable, doesn't include longname and comments
    nc = ncvar_add(nc=nc2,v=sh.var,verbose=TRUE) #add variable to existing netCDF file
```

I think the bug sits in `rh.sub <- which(rh > -6999)` which returns the index of those that are >-6999, not the values. Next it takes the index and divides it by 100, not the value. Do I interpret that correctly? And is this indeed a bug in the original code?
