### PR TITLE
Fixes some errors in checking the PEcAn.BIOCRO package

### DIFF
--- a/models/biocro/DESCRIPTION
+++ b/models/biocro/DESCRIPTION
@@ -18,7 +18,9 @@ Depends:
     data.table,
     XML
 Suggests:
-    BioCro
+    BioCro,
+    testthat,
+    RPostgreSQL
 License: FreeBSD + file LICENSE
 Copyright: Energy Biosciences Institute, Authors
 LazyLoad: yes

--- a/models/biocro/tests/testthat.R
+++ b/models/biocro/tests/testthat.R
@@ -6,8 +6,8 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-library(testthat)
 library(PEcAn.utils)
+library(testthat)
 
 logger.setQuitOnSevere(FALSE)
-# test_check("PEcAn.BIOCRO")
+test_check("PEcAn.BIOCRO")


### PR DESCRIPTION
This should prevent the user from having issues in loading the the testthat package so long as they have it installed. additionally it addresses an error in loading the RPostgreSQL package. these packages are required for the tests to the PEcAn.BIOCRO package.
