### PR TITLE
query.priors: switch to using PFT ID

### DIFF
--- a/db/R/get.trait.data.R
+++ b/db/R/get.trait.data.R
@@ -74,7 +74,7 @@ get.trait.data.pft <- function(pft, modeltype, dbfiles, dbcon,
   spstr <- vecpaste(species$id)
 
   # get the priors
-  prior.distns <- query.priors(pft$name, vecpaste(trait.names), out = pft$outdir, con = dbcon)
+  prior.distns <- query.priors(pftid, vecpaste(trait.names), out = pft$outdir, con = dbcon)
   prior.distns <- prior.distns[which(!rownames(prior.distns) %in% names(pft$constants)),]
   traits <- rownames(prior.distns) 
 

--- a/db/R/query.prior.R
+++ b/db/R/query.prior.R
@@ -11,7 +11,7 @@
 ##'
 ##' @name query.priors
 ##' @title Query Priors
-##' @param pft String name of the PFT in the database
+##' @param pft ID number of the PFT in the database
 ##' @param trstr string of traits to query priors for
 ##' @param out output location
 ##' @param con database connection, can be list of arguments for connecting to database
@@ -38,7 +38,7 @@ query.priors <- function(pft, trstr=NULL, out=NULL, con=NULL,...){
       "join variables on priors.variable_id = variables.id",
       "join pfts_priors on pfts_priors.prior_id = priors.id",
       "join pfts on pfts.id = pfts_priors.pft_id",
-      "where pfts.name in (", vecpaste(pft), ")")
+      "where pfts.id = ", pft)
   if(is.null(trstr) || trstr == "''"){
     query.text = paste(query.text,";",sep="")
   } else {


### PR DESCRIPTION
which is unique, rather than pft$name, which may be duplicated across different modeltypes.
