### PR TITLE
use path/id fields in inputs #356

### DIFF
--- a/models/biocro/R/write.configs.BIOCRO.R
+++ b/models/biocro/R/write.configs.BIOCRO.R
@@ -104,9 +104,9 @@ write.config.BIOCRO <- function(defaults = NULL,
   
   ## Get the weather data generic
 
-  if(!is.null(settings$run$inputs$met)){
-      if(file.exists(settings$run$inputs$met)){
-          file.symlink(settings$run$inputs$met,
+  if(!is.null(settings$run$inputs$met$path)){
+      if(file.exists(settings$run$inputs$met$path)){
+          file.symlink(settings$run$inputs$met$path,
                        file.path(settings$rundir, run.id, "weather.csv"))
       } else {
           settings$site$met <- NULL

--- a/models/dalec/R/write.configs.dalec.R
+++ b/models/dalec/R/write.configs.dalec.R
@@ -83,7 +83,7 @@ write.config.DALEC <- function(defaults, trait.values, settings, run.id){
   ### WRITE JOB.SH
   jobsh = paste0("#!/bin/bash\n",settings$model$binary,
                  " $(cat ",rundir,"/",config.file.name,
-                 ") < ",as.character(settings$run$inputs$met),
+                 ") < ",as.character(settings$run$inputs$met$path),
                  " > ",outdir,"/out.txt\n",
 #                 'echo ".libPaths(',"'~/R/library');",
                  'echo "',

--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -126,7 +126,7 @@ write.config.ED2 <- function(defaults, trait.values, settings, run.id){
   
   jobsh <- gsub('@SITE_LAT@', settings$run$site$lat, jobsh)
   jobsh <- gsub('@SITE_LON@', settings$run$site$lon, jobsh)
-  jobsh <- gsub('@SITE_MET@', settings$run$inputs$met, jobsh)
+  jobsh <- gsub('@SITE_MET@', settings$run$inputs$met$path, jobsh)
   
   jobsh <- gsub('@SCRATCH_COPY@', copyscratch, jobsh)
   jobsh <- gsub('@SCRATCH_CLEAR@', clearscratch, jobsh)
@@ -237,7 +237,7 @@ write.config.ED2 <- function(defaults, trait.values, settings, run.id){
   
   ed2in.text <- gsub('@SITE_LAT@', settings$run$site$lat, ed2in.text)
   ed2in.text <- gsub('@SITE_LON@', settings$run$site$lon, ed2in.text)
-  ed2in.text <- gsub('@SITE_MET@', settings$run$inputs$met, ed2in.text)
+  ed2in.text <- gsub('@SITE_MET@', settings$run$inputs$me$path, ed2in.text)
   ed2in.text <- gsub('@MET_START@', metstart, ed2in.text)
   ed2in.text <- gsub('@MET_END@', metend, ed2in.text)
   
@@ -269,13 +269,13 @@ write.config.ED2 <- function(defaults, trait.values, settings, run.id){
   # Slightly overcomplicated to avoid error if path name happened to contain '.lat'
   
   # when pss or css not exists, case 0
-  if (is.null(settings$run$inputs$pss)|is.null(settings$run$inputs$css)){
+  if (is.null(settings$run$inputs$pss$path)|is.null(settings$run$inputs$css$path)){
     ed2in.text <- gsub('@INIT_MODEL@', 0, ed2in.text)
     ed2in.text <- gsub('@SITE_PSSCSS@', "", ed2in.text)
   }
   else{
-    prefix.pss <- sub(".lat.*", "", settings$run$inputs$css)
-    prefix.css <- sub(".lat.*", "", settings$run$inputs$pss)
+    prefix.pss <- sub(".lat.*", "", settings$run$inputs$css$path)
+    prefix.css <- sub(".lat.*", "", settings$run$inputs$pss$path)
     # pss and css prefix is not the same, kill
     if (!identical(prefix.pss , prefix.css)){
       logger.severe("ED2 css/pss/ files have different prefix")
@@ -284,8 +284,8 @@ write.config.ED2 <- function(defaults, trait.values, settings, run.id){
     else{
       value <- 2
       # site exists 
-      if (!is.null(settings$run$inputs$site)){
-        prefix.sites <- sub(".lat.*", "", settings$run$inputs$site)
+      if (!is.null(settings$run$inputs$site$path)){
+        prefix.sites <- sub(".lat.*", "", settings$run$inputs$site$path)
         # sites and pss have different prefix name, kill 
         if (!identical (prefix.sites, prefix.pss)){
           logger.severe("ED2 sites/pss/ files have different prefix")
@@ -303,12 +303,12 @@ write.config.ED2 <- function(defaults, trait.values, settings, run.id){
   
   ##----------------------------------------------------------------------
   
-  ed2in.text <- gsub('@ED_VEG@', settings$run$inputs$veg, ed2in.text)
-  ed2in.text <- gsub('@ED_SOIL@', settings$run$inputs$soil, ed2in.text)
-  ed2in.text <- gsub('@ED_LU@', settings$run$inputs$lu, ed2in.text)
-  ed2in.text <- gsub('@ED_THSUM@', ifelse(str_sub(settings$run$inputs$thsum, -1) == "/",
-                                          settings$run$inputs$thsum,
-                                          paste0(settings$run$inputs$thsum, "/")), ed2in.text)
+  ed2in.text <- gsub('@ED_VEG@', settings$run$inputs$veg$path, ed2in.text)
+  ed2in.text <- gsub('@ED_SOIL@', settings$run$inputs$soil$path, ed2in.text)
+  ed2in.text <- gsub('@ED_LU@', settings$run$inputs$lu$path, ed2in.text)
+  ed2in.text <- gsub('@ED_THSUM@', ifelse(str_sub(settings$run$inputs$thsum$path, -1) == "/",
+                                          settings$run$inputs$thsum$path,
+                                          paste0(settings$run$inputs$thsum$path, "/")), ed2in.text)
   
   ##----------------------------------------------------------------------
   ed2in.text <- gsub('@START_MONTH@', format(startdate, "%m"), ed2in.text)

--- a/models/linkages/R/write.config.LINKAGES.R
+++ b/models/linkages/R/write.config.LINKAGES.R
@@ -73,7 +73,7 @@ write.config.LINKAGES <- function(defaults=NULL, trait.values=NULL, settings, ru
   
   jobsh <- gsub('@SITE_LAT@', settings$run$site$lat, jobsh)
   jobsh <- gsub('@SITE_LON@', settings$run$site$lon, jobsh)
-  jobsh <- gsub('@SITE_MET@', settings$run$inputs$met, jobsh)
+  jobsh <- gsub('@SITE_MET@', settings$run$inputs$met$path, jobsh)
   
   jobsh <- gsub('@START_DATE@', settings$run$start.date, jobsh)
   jobsh <- gsub('@END_DATE@', settings$run$end.date, jobsh)

--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -21,10 +21,10 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
   writeLines(config.text, con = file.path(settings$rundir, run.id, "sipnet.in"))
   
   ### WRITE *.clim
-  template.clim <- settings$run$input$met      ## read from settings
+  template.clim <- settings$run$input$met$path      ## read from settings
   if(!is.null(inputs)){                       ## override if specified in inputs
     if('met' %in% names(inputs)){
-      template.clim <- inputs$met
+      template.clim <- inputs$met$path
     }
   }
   

--- a/models/template/R/write.config.MODEL.R
+++ b/models/template/R/write.config.MODEL.R
@@ -75,7 +75,7 @@ write.config.MODEL <- function(defaults, trait.values, settings, run.id){
   
   config.text <- gsub('@SITE_LAT@', settings$run$site$lat, config.text)
   config.text <- gsub('@SITE_LON@', settings$run$site$lon, config.text)
-  config.text <- gsub('@SITE_MET@', settings$run$site$met, config.text)
+  config.text <- gsub('@SITE_MET@', settings$run$inputs$met$path, config.text)
   config.text <- gsub('@MET_START@', settings$run$site$met.start, config.text)
   config.text <- gsub('@MET_END@', settings$run$site$met.end, config.text)
   config.text <- gsub('@START_MONTH@', format(startdate, "%m"), config.text)

--- a/modules/data.atmosphere/R/met.process.R
+++ b/modules/data.atmosphere/R/met.process.R
@@ -8,15 +8,12 @@
 ##' @param end_date the end date of the data to be downloaded (will only use the year part of the date)
 ##' @param model model_type name
 ##' @param host Host info from settings file
-##' @param bety  database settings from settings file
+##' @param dbparms  database settings from settings file
 ##' @param dir  directory to write outputs to
 ##' 
 ##' @author Elizabeth Cowdery, Michael Dietze
 met.process <- function(site, input_met, start_date, end_date, model, host, dbparms, dir, browndog=NULL){
   
-  require(RPostgreSQL)
-  
-  driver   <- "PostgreSQL"
   con      <- db.open(dbparms)
   
   username <- ""  

--- a/settings/R/read.settings.R
+++ b/settings/R/read.settings.R
@@ -35,46 +35,43 @@ check.inputs <- function(settings) {
   if (nrow(inputs) > 0) {
     for(i in 1:nrow(inputs)) {
       tag <- inputs$tag[i]
-      tagid <- paste0(tag, ".id")
       hostname <- settings$run$host$name
       allinputs <- allinputs[allinputs != tag]
 
-      # check if <tag.id> exists
-      if (!is.null(settings$run$inputs[[tagid]])) {
-        id <- settings$run$inputs[[tagid]]
-        file <- dbfile.file("Input", id, dbcon, hostname)
-        if (is.na(file)) {
-          logger.error("No file found for", tag, " and id", id, "on host", hostname)
-        } else {
-          if (is.null(settings$run$inputs[[tag]])) {
-            settings$run$inputs[[tag]] <- file
-          } else if (file != settings$run$inputs[[tag]]) {
-            logger.warn("Input file and id do not match for ", tag)
-          }
-        }
-      }
-      
-      # check if file exists
+      # check if tag exists
       if (is.null(settings$run$inputs[[tag]])) {
         if (inputs$required[i]) {
           logger.severe("Missing required input :", tag)
         } else {
           logger.info("Missing optional input :", tag)
         }
-        
-      } else {
-        # can we find the file so we can set the tag.id
-        if (is.null(settings$run$inputs[[tagid]])) {
-          id <- dbfile.id('Input', settings$run$inputs[[tag]], dbcon, hostname)
-          if (!is.na(id)) {
-            settings$run$inputs[[tagid]] <- id
+        next
+      }
+      
+      # check if <id> exists
+      if ("id" %in% names(settings$run$inputs[[tag]])) {
+        id <- settings$run$inputs[[tag]][['id']]
+        file <- dbfile.file("Input", id, dbcon, hostname)
+        if (is.na(file)) {
+          logger.error("No file found for", tag, " and id", id, "on host", hostname)
+        } else {
+          if (is.null(settings$run$inputs[[tag]][['path']])) {
+            settings$run$inputs[[tag]]['path'] <- file
+          } else if (file != settings$run$inputs[[tag]][['path']]) {
+            logger.warn("Input file and id do not match for ", tag)
           }
         }
+      } else if ("path" %in% names(settings$run$inputs[[tag]])) {
+        # can we find the file so we can set the tag.id
+        id <- dbfile.id('Input', settings$run$inputs[[tag]][['path']], dbcon, hostname)
+        if (!is.na(id)) {
+          settings$run$inputs[[tag]][['id']] <- id
+        }
       }
-
+      
       # check to see if format is right type
-      if (!is.null(settings$run$inputs[[tagid]])) {
-        formats <- db.query(paste0("SELECT format_id FROM inputs WHERE id=", settings$run$inputs[[tagid]]), con=dbcon)
+      if ("id" %in% names(settings$run$inputs[[tag]])) {
+        formats <- db.query(paste0("SELECT format_id FROM inputs WHERE id=", settings$run$inputs[[tag]][['id']]), con=dbcon)
         if (nrow(formats) > 1) {
           if (formats[1, 'format_id'] != inputs$format_id[i]) {
             logger.error("Format of input", tag, "does not match specified input.")
@@ -821,7 +818,7 @@ update.settings <- function(settings) {
     settings$model$name <- NULL
   }
 
-  # run$site$met is now run$inputs$met
+  # run$site$met is now run$inputs$met$path
   if (!is.null(settings$run$site$met)) {
     if (!is.null(settings$run$inputs$met)) {
       if (settings$run$site$met != settings$run$inputs$met) {
@@ -836,8 +833,42 @@ update.settings <- function(settings) {
     logger.info("Model tag has changed, please use <inputs><met> to specify",
                  "met file for a run. See also",
                  "https://github.com/PecanProject/pecan/wiki/PEcAn-Configuration#run_setup.")
-    settings$run$inputs$met <- settings$run$site$met
+    settings$run$inputs$met$path <- settings$run$site$met
     settings$run$site$met <- NULL
+  }
+  
+  # inputs now have path and id under tag
+  for(tag in names(settings$run$inputs)) {
+    if (grepl(".id$", tag)) {
+      tagid <- tag
+      tag <- substr(tagid, 1, nchar(tagid)-3)
+      if (tag %in% names(settings$run$inputs)) {
+        next
+      } else {
+        settings$run$inputs[[tag]]['id'] <- settings$run$inputs[[tagid]]
+        settings$run$inputs[[tagid]] <- null
+      }
+    } else {
+      if (!is.list(settings$run$inputs[[tag]])) {
+        path <- settings$run$inputs[[tag]]
+        settings$run$inputs[[tag]] <- list("path"=path)
+      }
+
+      tagid <- paste0(tag, ".id")
+      if (tagid %in% names(settings$run$inputs)) {
+        if ('id' %in% names(settings$run$inputs[[tag]])) {
+          if (settings$run$inputs[[tagid]] != settings$run$inputs[[tag]][['id']]) {
+            logger.severe("Please remove", tagid, "from inputs configuration.")
+          } else {
+            logger.info("Please remove", tagid, "from inputs configuration.")
+          }
+          settings$run$inputs[[tagid]] <- NULL
+        } else {
+          settings$run$inputs[[tag]][['id']] <- settings$run$inputs[[tagid]]
+          settings$run$inputs[[tagid]] <- NULL
+        }
+      }
+    }
   }
 
   # some specific ED changes
@@ -908,29 +939,49 @@ update.settings <- function(settings) {
   invisible(settings)
 }
 
-##' Add users database parameters to section.
+##' Add secret information from ~/.pecan.xml
 ##'
-##' Copies database section from ~/.pecan.xml to the settings. This allows
-##' a user to have their own unique database parameters, also when sharing
-##' the pecan.xml file we don't expose the database connection parameters.
+##' Copies certains sections from ~/.pecan.xml to the settings. This allows
+##' a user to have their own unique parameters also when sharing the
+##' pecan.xml file we don't expose these secrets.
+##' Currently this will copy the database and browndog sections
 ##'
-##' @title Add Users database
+##' @title Add Users secrets
 ##' @param settings settings file
 ##' @return will return the updated settings values
 ##' @author Rob Kooper
-addUsersDatabase <- function(settings) {
+addSecrets <- function(settings) {
   if (!file.exists("~/.pecan.xml")) {
     return(settings)
   }
   pecan <- xmlToList(xmlParse("~/.pecan.xml"))
-  for(db in names(pecan$database)) {
-    if (db %in% names(settings$database)) {
-      logger.info("Already have a section for", db)
-    } else {
-      logger.info("Imported section for", db)
-      settings$database[db] <- pecan$database[db]
+  
+  # always copy following sections
+  for(key in c('database')) {
+    for(section in names(pecan[[key]])) {
+      if (section %in% names(settings[section])) {
+        logger.info("Already have a section for", section)
+      } else {
+        logger.info("Imported section for", section)
+        settings[[key]][section] <- pecan[[key]][section]
+      }
     }
   }
+  
+  # only copy these sections if tag exists
+  for(key in c('browndog')) {
+    if (! key %in% names(settings)) next
+    
+    for(section in names(pecan[[key]])) {
+      if (section %in% names(settings[section])) {
+        logger.info("Already have a section for", section)
+      } else {
+        logger.info("Imported section for", section)
+        settings[[key]][section] <- pecan[[key]][section]
+      }
+    }
+  }  
+
   invisible(settings)
 }
 
@@ -1008,7 +1059,7 @@ read.settings <- function(inputfile = "pecan.xml", outputfile = "pecan.xml"){
 
   ## convert the xml to a list for ease and return
   settings <- xmlToList(xml)
-  settings <- addUsersDatabase(settings)
+  settings <- addSecrets(settings)
   settings <- update.settings(settings)
   settings <- check.settings(settings)
 
@@ -1032,5 +1083,5 @@ read.settings <- function(inputfile = "pecan.xml", outputfile = "pecan.xml"){
 ##=================================================================================================#
 
 ####################################################################################################
-### EOF.  End of R script file.  						
+### EOF.  End of R script file.              
 ####################################################################################################

--- a/tests/workflow.R
+++ b/tests/workflow.R
@@ -42,6 +42,45 @@ settings <- read.settings(settings.file)
 # remove status file
 unlink(file.path(settings$outdir, "STATUS"))
 
+# do conversions
+for(i in 1:length(settings$run$inputs)) {
+  input <- settings$run$inputs[[i]]
+  if (is.null(input)) next
+  if (length(input) == 1) next
+  
+  input.tag <- names(settings$run$input)[i]
+  
+  # fia database
+  if (input['input'] == 'fia') {
+    status.start("FIA2ED")
+    fia.to.psscss(settings)
+    status.end()
+  }
+  
+  # met conversion
+  if(input.tag == 'met') {
+    if(length(input) >= 1) {
+      if (is.null(settings$browndog)) {
+        status.start("MET Process")
+      } else {
+        status.start("BrownDog")
+      }
+      settings$run$inputs[[i]][['path']] <- PEcAn.data.atmosphere::met.process(
+        site       = settings$run$site, 
+        input_met  = settings$run$inputs$met,
+        start_date = settings$run$start.date,
+        end_date   = settings$run$end.date,
+        model      = settings$model$type,
+        host       = settings$run$host,
+        dbparms    = settings$database$bety, 
+        dir        = settings$run$dbfiles,
+        browndog   = settings$browndog)
+      status.end()
+    }
+  }
+}
+saveXML(listToXml(settings, "pecan"), file=file.path(settings$outdir, 'pecan.xml'))
+
 # get traits of pfts
 status.start("TRAIT")
 settings$pfts <- get.trait.data(settings$pfts, settings$model$type, settings$run$dbfiles, settings$database$bety, settings$meta.analysis$update)
@@ -53,49 +92,6 @@ status.start("META")
 if('meta.analysis' %in% names(settings)) {
   run.meta.analysis(settings$pfts, settings$meta.analysis$iter, settings$meta.analysis$random.effects, settings$meta.analysis$threshold, settings$run$dbfiles, settings$database$bety)
 }
-status.end()
-
-# do conversions
-status.start("CONVERSIONS")
-for(i in 1:length(settings$run$inputs)) {
-  input <- settings$run$inputs[[i]]
-  if (is.null(input)) next
-  if (length(input) == 1) next
-
-  # fia database
-  if (input['input'] == 'fia') {
-    fia.to.psscss(settings)
-  }
-
-  # met download
-  if (input['input'] == 'Ameriflux') {
-    # start/end date for weather
-    start_date <- settings$run$start.date
-    end_date <- settings$run$end.date
-
-    # site
-    site <- sub(".* \\((.*)\\)", "\\1", settings$run$site$name)
-
-    # download data
-    fcn <- paste("download", input['input'], sep=".")
-    do.call(fcn, list(site, file.path(settings$run$dbfiles, input['input']), start_date=start_date, end_date=end_date))
-
-    # convert to CF
-    met2CF.Ameriflux(file.path(settings$run$dbfiles, input['input']), site, file.path(settings$run$dbfiles, "cf"), start_date=start_date, end_date=end_date)
-
-    # gap filing
-    metgapfill(file.path(settings$run$dbfiles, "cf"), site, file.path(settings$run$dbfiles, "gapfill"), start_date=start_date, end_date=end_date)
-
-    # model specific
-    load.modelpkg(input['output'])
-    fcn <- paste("met2model", input['output'], sep=".")
-    r <- do.call(fcn, list(file.path(settings$run$dbfiles, "gapfill"), site, file.path(settings$run$dbfiles, input['output']), start_date=start_date, end_date=end_date))
-    settings$run$inputs[[i]] <- r[['file']]
-  }
-
-  # narr download
-}
-saveXML(listToXml(settings, "pecan"), file=file.path(settings$outdir, 'pecan.xml'))
 status.end()
 
 # write configurations

--- a/web/04-runpecan.php
+++ b/web/04-runpecan.php
@@ -175,6 +175,8 @@ fwrite($fh, "  </database>" . PHP_EOL);
 if ($browndog) {
   fwrite($fh, "  <browndog>" . PHP_EOL);  
   fwrite($fh, "    <url>${browndog_url}</url>" . PHP_EOL);  
+  fwrite($fh, "    <username>${browndog_username}</username>" . PHP_EOL);  
+  fwrite($fh, "    <password>${browndog_password}</password>" . PHP_EOL);  
   fwrite($fh, "  </browndog>" . PHP_EOL);  
 }
 
@@ -229,12 +231,15 @@ fwrite($fh, "    <inputs>" . PHP_EOL);
 foreach($_REQUEST as $key => $val) {
   if (substr($key, 0, 6) != "input_") continue;
   $tag=substr($key, 6);
+  fwrite($fh, "      <${tag}>" . PHP_EOL);
   if (is_numeric($val)) {
-    fwrite($fh, "      <${tag}.id>${val}</${tag}.id>" . PHP_EOL);
+    fwrite($fh, "        <id>${val}</id>" . PHP_EOL);
   } else {
     $parts=explode(".", $val, 2);
-    fwrite($fh, "      <${tag} input=\"${parts[0]}\" output=\"${parts[1]}\" />" . PHP_EOL);
+    fwrite($fh, "        <type>${parts[0]}</type>" . PHP_EOL);
+    fwrite($fh, "        <output>${parts[1]}</output>" . PHP_EOL);
   }
+  fwrite($fh, "      </${tag}>" . PHP_EOL);
 }
 fwrite($fh, "    </inputs>" . PHP_EOL);
 fwrite($fh, "    <start.date>${startdate}</start.date>" . PHP_EOL);

--- a/web/04-runpecan.php
+++ b/web/04-runpecan.php
@@ -236,7 +236,7 @@ foreach($_REQUEST as $key => $val) {
     fwrite($fh, "        <id>${val}</id>" . PHP_EOL);
   } else {
     $parts=explode(".", $val, 2);
-    fwrite($fh, "        <type>${parts[0]}</type>" . PHP_EOL);
+    fwrite($fh, "        <source>${parts[0]}</source>" . PHP_EOL);
     fwrite($fh, "        <output>${parts[1]}</output>" . PHP_EOL);
   }
   fwrite($fh, "      </${tag}>" . PHP_EOL);

--- a/web/config.example.php
+++ b/web/config.example.php
@@ -17,6 +17,8 @@ $db_fia_database="";
 
 # browdog information
 $browndog_url="";
+$browndog_username="";
+$browndog_password="";
 
 # R binary
 $Rbinary="/usr/bin/R";

--- a/web/workflow.R
+++ b/web/workflow.R
@@ -53,11 +53,7 @@ options(error=quote({
 # initialization
 # ----------------------------------------------------------------------
 # load the pecan settings
-
-# settings <- read.settings("pecan.xml")
-# read.settings does not work with the new tags <browndog> and tags in <met>
-# This is NOT a solution
-settings <- xmlToList(xmlParse("pecan.xml"))
+settings <- read.settings("pecan.xml")
 
 # remove existing STATUS file
 if (length(which(commandArgs() == "--continue")) == 0) {
@@ -80,17 +76,20 @@ if (length(which(commandArgs() == "--continue")) == 0) {
     
     # met conversion
     if(input.tag == 'met') {
-      if(length(input) >= 1) {  
-        status.start("MET Process")
-        
-        settings$run$inputs$path[[i]]  <-  PEcAn.data.atmosphere::met.process(
+      if(length(input) >= 1) {
+        if (is.null(settings$browndog)) {
+          status.start("MET Process")
+        } else {
+          status.start("BrownDog")
+        }
+        settings$run$inputs[[i]][['path']] <- PEcAn.data.atmosphere::met.process(
           site       = settings$run$site, 
           input_met  = settings$run$inputs$met,
           start_date = settings$run$start.date,
           end_date   = settings$run$end.date,
           model      = settings$model$type,
           host       = settings$run$host,
-          bety       = settings$database$bety, 
+          dbparms    = settings$database$bety, 
           dir        = settings$run$dbfiles,
           browndog   = settings$browndog)
         status.end()


### PR DESCRIPTION
All inputs now have a id and path fields that contains the information
needed for write configs.

Also added code to copy over url/username/password for browndog from
~/.pecan.xml, only if a browndog entry exists in pecan.xml