### PR TITLE
use real lat/lon for DRIVER file

### DIFF
--- a/models/ed/R/met2model.ED2.R
+++ b/models/ed/R/met2model.ED2.R
@@ -266,7 +266,7 @@ for(year in start_year:end_year) {
 
   ## write DRIVER file
   sites <- 1
-  metgrid <- c(1,1,1,1,floor(lon),floor(lat))
+  metgrid <- c(1,1,1,1,lon,lat)
   metvar <- c("nbdsf","nddsf","vbdsf","vddsf","prate","dlwrf","pres","hgt","ugrd","vgrd","sh","tmp","co2")
   nmet <- length(metvar)
   metfrq <- rep(dt,nmet)


### PR DESCRIPTION
no rounding of lat/lon, but use site info as center of polygon. The rounding would result in the site sometimes to fall outside of the polygon when running ED.

An [example](http://pecan.ncsa.illinois.edu/pecan/08-finished.php?workflowid=99000000020) of an ED run at Willow Creek (US-WCr) using Ameriflux.