### PR TITLE
Changed ED2IN template to use the hybrid timestep…

### DIFF
--- a/models/ed/inst/ED2IN.rgit
+++ b/models/ed/inst/ED2IN.rgit
@@ -567,7 +567,7 @@ $ED_NL
    !                       3.  Hybrid Stepping (BDF2 implicit step for the canopy air and  !
    !                           leaf temp, forward Euler for else, under development).      !
    !---------------------------------------------------------------------------------------!
-   NL%INTEGRATION_SCHEME = 1
+   NL%INTEGRATION_SCHEME = 3
    !---------------------------------------------------------------------------------------!
    ! RK4_TOLERANCE -- This is the relative tolerance for Runge-Kutta or Heun's             !
    !                  integration.  Larger numbers will make runs go faster, at the        !


### PR DESCRIPTION
The old ED2IN template was using the 4th order Runge-Kutta timestep, which is a lot slower than they hybrid time step with very little difference in results. Thus changed it to use the hybrid time step for the pecan ED2IN template.