### PR TITLE
Rewrote rh2qair to account for air pressure. Now true inverse of qair2rh

### DIFF
--- a/modules/data.atmosphere/R/metutils.R
+++ b/modules/data.atmosphere/R/metutils.R
@@ -38,10 +38,15 @@ qair2rh <- function(qair, temp, press = 1013.25){
 ##' @param rh relative humidity (proportion, not %)
 ##' @param T absolute temperature (Kelvin)
 ##' @export
-##' @author Mike Dietze
+##' @author Mike Dietze, Ankur Desai
 ##' @aliases rh2rv
-rh2qair <- function(rh, T){
-  qair <- rh * 2.541e6 * exp(-5415.0 / T) * 18/29
+rh2qair <- function(rh, T, press = 101325.0){
+  Tc <- T - 273.15
+  es <-  6.112 * exp((17.67 * Tc)/(Tc + 243.5))
+  e <- rh * es
+  p_mb <- press / 100.0
+  qair <- (0.622 * e) / (p_mb - (0.378 * e))
+  ##  qair <- rh * 2.541e6 * exp(-5415.0 / T) * 18/29
   return(qair)
 }
  


### PR DESCRIPTION
Still need to change units to be same for both functions and met2CF Ameriflux/CSV/ALMA and temporal downscaling need to pass pressure; two of these functions don’t read in pressure currently. qair2rh is called in met2model for BIOCRO/SIPNET and temporal downscaling, so if units change, these will need to change too.