### PR TITLE
Update to load.bety.sh to include temp BNL sync location

### DIFF
--- a/scripts/load.bety.sh
+++ b/scripts/load.bety.sh
@@ -127,6 +127,8 @@ if [ -z "${DUMPURL}" ]; then
 		DUMPURL="https://ebi-forecast.igb.illinois.edu/pecan/dump/bety.tar.gz"
 	elif [ "${REMOTESITE}" == "1" ]; then
 		DUMPURL="http://psql-pecan.bu.edu/sync/dump/bety.tar.gz"
+        elif [ "${REMOTESITE}" == "2" ]; then
+                DUMPURL="https://www.dropbox.com/s/wr8sldv080wa9y8/bety.tar.gz?dl=0"
 	else
 		echo "Don't know where to get data for site ${REMOTESITE}"
 		exit


### PR DESCRIPTION
@RobKooper  Let me know if you think this looks OK?  I tested this link with curl -L -o and it worked out for me; i.e. pulled the bety.tar.gz off the dropbox.

This is the temp link.  I will be updating once our sever is open to the world.  It will then be:
modex.test.bnl.gov/sync/dump/bety.tar.gz