### PR TITLE
bugfix filenames

### DIFF
--- a/modules/uncertainty/R/run.ensemble.analysis.R
+++ b/modules/uncertainty/R/run.ensemble.analysis.R
@@ -35,7 +35,11 @@ run.ensemble.analysis <- function(plot.timeseries=NA, ensemble.id=NULL,
   if(is.null(ensemble.id)) ensemble.id <- settings$ensemble$ensemble.id
   if(is.null(ensemble.id)) {
     # Try to just grab the most recent one
-    ens.ids <- dir(file.path(settings$outdir, "ensemble"))
+    ens.ids <- as.numeric(sub("ensemble.samples.", "", 
+                            sub(".Rdata", "",
+                              dir(settings$outdir, "ensemble.samples")
+               )))
+    
     if(length(ens.ids) > 0) {
       ensemble.id <- max(ens.ids)
     } else {

--- a/utils/R/get.analysis.filenames.r
+++ b/utils/R/get.analysis.filenames.r
@@ -16,7 +16,9 @@ ensemble.filename <- function(settings,
                               start.year  = settings$ensemble$start.year,
                               end.year    = settings$ensemble$end.year) {
 
-  if(is.null(ensemble.id)) ensemble.id <- "NOENSEMBLEID" # Not supposed to happen...
+  if(is.null(ensemble.id) || ensemble.id=="NA" || is.na(ensemble.id)) {
+    ensemble.id <- "NOENSEMBLEID" # Not supposed to happen...
+  }
   
   ensemble.dir <- settings$outdir
   
@@ -54,7 +56,9 @@ sensitivity.filename <- function(settings,
                               start.year  = settings$sensitivity.analysis$start.year,
                               end.year    = settings$sensitivity.analysis$end.year) {
 
-  if(is.null(ensemble.id)) ensemble.id <- "NOENSEMBLEID" # Not supposed to happen...
+  if(is.null(ensemble.id) || ensemble.id=="NA" || is.na(ensemble.id)) {
+    ensemble.id <- "NOENSEMBLEID" # Not supposed to happen...
+  }
 
   if(is.null(pft)) {
     # Goes in main output directory. 


### PR DESCRIPTION
Got a little bit kludgey, but should work. 

Once workflows (and maybe other functions?) are updated to avoid `sensitivity.analysis$ensemble.id = NULL` or `ensemble$ensemble.id = NULL`, the kludge won't be needed anyway. 

Actually, as far as I can tell, simply adding `settings <-` in front of `run.write.configs(...)` in all workflows would ensure that files are always saved with actual ensemble IDs, rather than the dummy "NOENSEMBLEID". That's because I modified `run.write.configs()` awhile back to add the SA and EA ensemble ids to `settings`, and invisibly return the updated list. But we can worry about that later. 