### PR TITLE
Pda.block+emulator

### DIFF
--- a/modules/assim.batch/R/pda.mcmc.recover.R
+++ b/modules/assim.batch/R/pda.mcmc.recover.R
@@ -14,7 +14,7 @@
 # settings$assim.batch <- pda.mcmc.recover(settings) # wrap up unfinished run
 # settings$assim.batch <- pda.mcmc(settings) # start new pda
 pda.mcmc.recover <- function(settings, params.id=NULL, param.names=NULL, prior.id=NULL, chain=NULL, 
-                     iter=NULL, adapt=NULL, adj.min=NULL, ar.target=NULL, jvar=NULL, n.knot=NULL) {
+                     iter=NULL, adapt=NULL, adj.min=NULL, ar.target=NULL, jvar=NULL, n.knot=NULL, burnin=NULL) {
 
   if(FALSE){
     params.id <- param.names <- prior.id <- chain <- iter <- NULL 
@@ -73,7 +73,7 @@ pda.mcmc.recover <- function(settings, params.id=NULL, param.names=NULL, prior.i
   settings$assim.batch$iter <- finish - nrow(params)
 
   ## Save outputs to plots, files, and db
-  settings <- pda.postprocess(settings, con, params, pname, prior, prior.ind)
+  settings <- pda.postprocess(settings, con, params, pname, prior, prior.ind, burnin)
 
   ## close database connection
   if(!is.null(con)) db.close(con)

--- a/modules/assim.batch/R/pda.utils.R
+++ b/modules/assim.batch/R/pda.utils.R
@@ -779,14 +779,15 @@ pda.plot.params <- function(settings, params.subset, prior.ind) {
 ##'
 ##' @author Ryan Kelly
 ##' @export
-pda.postprocess <- function(settings, con, params, pname, prior, prior.ind) {
+pda.postprocess <- function(settings, con, params, pname, prior, prior.ind, burnin=NULL) {
+  if(is.null(burnin)) burnin <- ceiling(min(2000,0.2*nrow(params)))
+
   ## Save params
   filename.mcmc <- file.path(settings$pfts$pft$outdir, 
                      paste0('mcmc.pda', settings$assim.batch$ensemble.id, '.Rdata'))
   save(params, file = filename.mcmc)
 
   ## Assess MCMC output
-  burnin <- ceiling(min(2000,0.2*nrow(params)))
   params.subset <- as.data.frame(params[burnin:nrow(params),prior.ind])
     names(params.subset) <- pname[prior.ind]
   pda.plot.params(settings, params.subset, prior.ind)

--- a/modules/uncertainty/R/get.samples.R
+++ b/modules/uncertainty/R/get.samples.R
@@ -8,7 +8,7 @@
 ##'
 ##' @author David LeBauer, Shawn Serbin
 ### Identify PFTs in the input settings.xml file
-get.parameter.samples <- function(pfts = settings$pfts){
+get.parameter.samples <- function(pfts = settings$pfts, posterior.files=rep(NA, length(settings$pfts))){
   require(coda)
   require(PEcAn.priors)
   num.pfts <- length(settings$pfts)
@@ -34,12 +34,21 @@ get.parameter.samples <- function(pfts = settings$pfts){
   ## Load PFT priors and posteriors
   for (i in seq_along(pft.names)){
     ## Load posteriors
-    fname = file.path(outdirs[i], 'post.distns.Rdata')
-    if(file.exists(fname)){
-      load(fname)
-      prior.distns = post.distns
+    if(!is.na(posterior.files[i])) {
+      # Load specified file
+      load(file.path(outdirs[i], posterior.files[i]))
+      if(!exists('prior.distns') & exists('post.distns')) {
+        prior.distns <- post.distns
+      }
     } else {
-      load(file.path(outdirs[i], 'prior.distns.Rdata'))
+      # Default to most recent posterior in the workflow, or the prior if there is none
+      fname = file.path(outdirs[i], 'post.distns.Rdata')
+      if(file.exists(fname)){
+        load(fname)
+        prior.distns = post.distns
+      } else {
+        load(file.path(outdirs[i], 'prior.distns.Rdata'))
+      }
     }
     
     ### Load trait mcmc data (if exists)

--- a/utils/R/run.write.configs.R
+++ b/utils/R/run.write.configs.R
@@ -32,7 +32,7 @@ run.write.configs <- function(settings, write = TRUE, ens.sample.method="halton"
   scipen = getOption("scipen")
   options(scipen=12)
   get.parameter.samples(pfts = settings$pfts)
-  load(file.path(settings$outdir, "samples.Rdata"))
+  load(file.path(settings$outdir, "samples.Rdata"), posterior.files)
 
   require(coda)
   ## remove previous runs.txt

--- a/utils/R/run.write.configs.R
+++ b/utils/R/run.write.configs.R
@@ -31,8 +31,8 @@ run.write.configs <- function(settings, write = TRUE, ens.sample.method="halton"
   model = settings$model$type
   scipen = getOption("scipen")
   options(scipen=12)
-  get.parameter.samples(pfts = settings$pfts)
-  load(file.path(settings$outdir, "samples.Rdata"), posterior.files)
+  get.parameter.samples(pfts = settings$pfts, posterior.files)
+  load(file.path(settings$outdir, "samples.Rdata"))
 
   require(coda)
   ## remove previous runs.txt


### PR DESCRIPTION
Fixed conflict with some of @dlebauer 's changes since v1.4.3, that had disabled a feature I added to allow `run.write.configs()` to be called on a specific prior. or post.distns file. 