### PR TITLE
Informative met names 453

### DIFF
--- a/web/03-inputs.php
+++ b/web/03-inputs.php
@@ -89,7 +89,7 @@ while ($row = @$stmt->fetch(PDO::FETCH_ASSOC)) {
 $stmt->closeCursor();
 
 // get list of files
-$stmt = $pdo->prepare("SELECT tag, inputs.id, dbfiles.file_name, sites.sitename, inputs.start_date, inputs.end_date" .
+$stmt = $pdo->prepare("SELECT tag, inputs.name AS input_name, inputs.id, dbfiles.file_name, sites.sitename, inputs.start_date, inputs.end_date" .
                       " FROM sites, inputs, dbfiles, machines, modeltypes_formats, models, formats" .
                       " WHERE (inputs.site_id=${earth} OR inputs.site_id=?)" .
                       " AND inputs.id=dbfiles.container_id AND dbfiles.container_type='Input'" .
@@ -102,7 +102,11 @@ if (!$stmt->execute(array($siteid, $hostname, $modelid))) {
 }
 while ($row = @$stmt->fetch(PDO::FETCH_ASSOC)) {
   if ($row['tag'] == 'met') {
-    $row['name']="Weather " . substr($row['start_date'], 0, 4) . "-" . substr($row['end_date'], 0, 4);
+	if (empty($row['input_name'])){
+    		$row['name']="Weather " . substr($row['start_date'], 0, 4) . "-" . substr($row['end_date'], 0, 4);
+	} else {
+    		$row['name']= $row['input_name'];
+	}
   } else if ($row['file_name'] == '') {
     $row['name']=$row['sitename'];
   } else {
@@ -196,6 +200,14 @@ $stmt->closeCursor();
     if ($("#<?php echo $input['tag']; ?>").val() == null) {
       $("#next").attr("disabled", "disabled");
       $("#error").html("Missing value for <?php echo $input['name']; ?>");
+<?php if ($betydb != "") { ?>
+    } else {
+      var metlabeldiv = document.getElementById('metlabeldiv');
+      metlabeldiv.innerHTML="";
+	if (!(isNaN($("#met option:selected")[0].getAttribute("value")))) {
+      		metlabeldiv.innerHTML = " (Show in <a href=\"<?php echo $betydb; ?>/inputs/" + $("#met option:selected")[0].getAttribute("value") + "\" target=\"BETY\">BETY</a>)";
+	}
+<?php } ?>
     }
 <?php
     }
@@ -335,9 +347,9 @@ foreach($inputs as $input) {
   $name=substr($input['name'], 0, 20);
   $tag=$input['tag'];
   if ($input['required']) {
-    print "      <label>${name}<sup>*</sup></label>\n";
-  } else {
-    print "      <label>${name}</label>\n";
+    print "      <label id=\"metlabel\">${name}*<div id=\"metlabeldiv\"></div></label>\n";
+} else { 
+  print "      <label id=\"metlabel\">${name}<div id=\"metlabeldiv\"></div></label>\n";
   }
   print "      <select id=\"${tag}\" name=\"input_${tag}\" onChange=\"validate();\">\n";
   if (!$input['required']) {


### PR DESCRIPTION
This fix is for enhancement 453.  I am using the inputs.name field for the met names instead of "weather + year".
I also added the bety database link to this field label.
Now the met input.names field will need to be populated with values or the default logic of "weather+year" will show.
All modification were done in file 03-inputs.php