### PR TITLE
better version check

### DIFF
--- a/scripts/load.bety.sh
+++ b/scripts/load.bety.sh
@@ -224,7 +224,7 @@ else
   fi
 
   # find current schema version
-  VERSION=$( psql ${PG_OPT} -t -q -d "${DATABASE}" -c 'SELECT version FROM schema_migrations ORDER BY version DESC limit 1' | tr -d ' ' )
+  VERSION=$( psql ${PG_OPT} -t -q -d "${DATABASE}" -c 'SELECT md5(array_agg(version)::text) FROM (SELECT version FROM schema_migrations ORDER BY version) as v;' | tr -d ' ' )
 
   if [ ! -e "${DUMPDIR}/${VERSION}.schema" ]; then
     echo "EXPECTED SCHEMA version ${VERSION}"


### PR DESCRIPTION
now writes a triple to versions.txt
- number of migrations
- hash of all migrations combined
- latest migration applied

This will use the hash to check for version, even if an older migration
is applied this will make it so the version check still fails (step
closer for #160).