### PR TITLE
build: remove lock files if $FORCE = 'yes'

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -143,7 +143,7 @@ fi
 
 # remove lock files
 if [ "$FORCE" == "yes" ]; then
-  rm -rf ${R_LIBS_USER}/*LOCK*
+  rm -rf ${R_LIBS_USER}/00LOCK-*
 fi
   
 # when did the job run the last time?

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -141,6 +141,11 @@ if [ -e running -a "$FORCE" != "yes" ]; then
   exit
 fi
 
+# remove lock files
+if [ "$FORCE" == "yes" ]; then
+  rm -rf ${R_LIBS_USER}/*LOCK*
+fi
+  
 # when did the job run the last time?
 touch running
 touch lastrun


### PR DESCRIPTION
In order to prevent failed builds due to lock files, I added 

```sh
# remove lock files
if [ "$FORCE" == "yes" ]; then
  rm -rf ${R_LIBS_USER}/00LOCK-*
fi
```

Alternative would be to _always_ remove these files.

Not sure if this would have unintended consequences or if there is a more suitable approach.