### PR TITLE
Function 'year' is called without loading lubridate in met2CF.NARR

### DIFF
--- a/modules/data.atmosphere/R/met2CF.NARR.R
+++ b/modules/data.atmosphere/R/met2CF.NARR.R
@@ -15,6 +15,7 @@
 met2CF.NARR <- function(in.path, in.prefix, outfolder, start_date, end_date, overwrite=FALSE, verbose=FALSE, ...){
 
   require(ncdf4)
+  require(lubridate)
 
   dir.create(outfolder, showWarnings=FALSE, recursive=TRUE)
 


### PR DESCRIPTION
During met.process, the function convert.input runs ```met2CF.NARR``` effectively opening an instance in R. The ```lubridate``` package needs to be loaded again in order for the function to be able to use the function ```year```. This should close #723.

@ashiklom