### PR TITLE
met2model.ED: fix to building time dimension so it works with cruncep

### DIFF
--- a/models/ed/R/met2model.ED2.R
+++ b/models/ed/R/met2model.ED2.R
@@ -164,16 +164,30 @@ for(year in start_year:end_year) {
       hr <- c(hr,rep(NA,length(dtmp)))
     }
     rng <- length(doy) - length(ytmp):1 + 1
+    if(!all(rng>=0)){
+      skip = TRUE
+      logger.warn(paste(year,"is not a complete year and will not be included"))
+      break
+    }
     asec[rng] <- asec[rng] - asec[rng[1]]
     hr[rng] <- (asec[rng] - (dtmp-1)*86400)/86400*24
   }
-  mo <- day2mo(yr,doy)
   if(length(yr) < length(sec)){
     rng <- (length(yr)+1):length(sec)
+    if(!all(rng>=0)){
+      skip = TRUE
+      logger.warn(paste(year,"is not a complete year and will not be included"))
+      break
+    }
     yr[rng] <- rep(y+1,length(rng))
     doy[rng] <- rep(1:366,each=86400/dt)[1:length(rng)]
     hr[rng] <- rep(seq(0,length=86400/dt,by=dt/86400*24),366)[1:length(rng)]
   }
+  if(skip){
+    print("Skipping to next year")
+    next
+  }
+  
 
   ## calculate potential radiation
   ## in order to estimate diffuse/direct

--- a/scripts/install.dependencies.R
+++ b/scripts/install.dependencies.R
@@ -33,3 +33,15 @@ if(!("rhdf5" %in% installed.packages()[,"Package"])) {
   source("http://bioconductor.org/biocLite.R")
   biocLite('rhdf5')
 }
+
+# install graph for MCMCpack for allometry module
+if(!("graph" %in% installed.packages()[,"Package"])) {
+  source("http://bioconductor.org/biocLite.R")
+  biocLite('graph')
+}
+
+#install Rgraphviz for MCMCpack for allometry module
+if(!("Rgraphviz" %in% installed.packages()[,"Package"])) {
+  source("http://bioconductor.org/biocLite.R")
+  biocLite('Rgraphviz')
+}


### PR DESCRIPTION
This should close #725. The CRUNCEP met product is missing an observation, making a mismatch of time dimensions and observations when the met is formatted for the model. In this case, the required changes were already made to SIPNET's met2model script so it was a simple matter of doing the same thing and testing it.

@ashiklom @araiho not sure if we've rotated code reviewers yet so I mentioned you both.