### PR TITLE
Entering skip<- FALSE and mo<-day2mo() lines in met2model.ED2

### DIFF
--- a/models/ed/R/met2model.ED2.R
+++ b/models/ed/R/met2model.ED2.R
@@ -142,6 +142,7 @@ for(year in start_year:end_year) {
 
 
   ##build time variables (year, month, day of year)
+  skip <- FALSE
   nyr <- floor(length(sec)/86400/365*dt)
   yr <- NULL
   doy <- NULL
@@ -172,6 +173,7 @@ for(year in start_year:end_year) {
     asec[rng] <- asec[rng] - asec[rng[1]]
     hr[rng] <- (asec[rng] - (dtmp-1)*86400)/86400*24
   }
+  mo<-day2mo(yr,doy)
   if(length(yr) < length(sec)){
     rng <- (length(yr)+1):length(sec)
     if(!all(rng>=0)){


### PR DESCRIPTION
I made a mistake when I copy and pasted my changes from the script that I tested in the release candidate. I now tested these changes on the BU server, where I made the changes, and it does not throw errors at this step any more. 

Closes #737 @serbinsh. This should fix that error.