### PR TITLE
MAESPA: change to write.configs and template.job

### DIFF
--- a/models/maespa/R/write.config.MAESPA.R
+++ b/models/maespa/R/write.config.MAESPA.R
@@ -57,13 +57,16 @@ write.config.MAESPA <- function(defaults, trait.values, settings, run.id){
   if (!is.null(settings$run$host$job.sh)) {
     hostspecific <- paste(hostspecific, sep="\n", paste(settings$run$host$job.sh, collapse="\n"))
   }
-
+  
+  #MET FILE
+  metdat <- settings$run$input$met$path 
+  
   # create job.sh
   jobsh <- gsub('@HOSTSPECIFIC@', hostspecific, jobsh)
 
   jobsh <- gsub('@SITE_LAT@', settings$run$site$lat, jobsh)
   jobsh <- gsub('@SITE_LON@', settings$run$site$lon, jobsh)
-  #jobsh <- gsub('@SITE_MET@', settings$run$inputs$met, jobsh)
+  jobsh <- gsub('@SITE_MET@', metdat, jobsh)
   
   jobsh <- gsub('@START_DATE@', settings$run$start.date, jobsh)
   jobsh <- gsub('@END_DATE@', settings$run$end.date, jobsh)
@@ -73,7 +76,7 @@ write.config.MAESPA <- function(defaults, trait.values, settings, run.id){
   
   jobsh <- gsub('@BINARY@', settings$model$binary, jobsh)
   
-  writeLines(jobsh, con=file.path(settings$rundir, "job.sh"))
+  writeLines(jobsh, con=file.path(settings$rundir, run.id, "job.sh"))
   Sys.chmod(file.path(settings$rundir, run.id, "job.sh"))
   
 }

--- a/models/maespa/inst/template.job
+++ b/models/maespa/inst/template.job
@@ -13,9 +13,11 @@ mkdir -p "@OUTDIR@"
 # see if application needs running
 if [ ! -e "@OUTDIR@/.dat" ]; then
   cd "@RUNDIR@"
-  ln  -s "@SITE_MET@" example2
-  
-  "@BINARY@" > @OUTDIR@
+  cp -r  /fs/data5/pecan.models/maespa/inputfiles/example2 "@RUNDIR@"
+  cd example2
+
+  "@BINARY@"
+  mv *.dat "@OUTDIR@"
   STATUS=$?
   
   # check the status
@@ -28,7 +30,7 @@ if [ ! -e "@OUTDIR@/.dat" ]; then
   #echo "require (PEcAn.MAESPA)
 #model2netcdf.MAESPA('@OUTDIR@', @SITE_LAT@, @SITE_LON@, '@START_DATE@', '@END_DATE@')
 #" | R --vanilla
-#fi
+fi
 
 
 # copy readme with specs to output


### PR DESCRIPTION
Change to allow write.configs to read met from db. Also, fix to file path to job.sh so it could be chmoded correctly. 

Change to template.job because symbolic link did not have correct permissions so I just made it copy example input files directly.