### PR TITLE
detect error in ED

### DIFF
--- a/models/ed/inst/template.job
+++ b/models/ed/inst/template.job
@@ -18,7 +18,11 @@ if [ ! -e "@OUTDIR@/history.xml" ]; then
   cd "@RUNDIR@"
   
   "@BINARY@"
-  STATUS=$?
+  if grep -Fq '!!! FATAL ERROR !!!' "@OUTDIR@/logfile.txt"; then
+    STATUS=1
+  else
+    STATUS=0
+  fi
   
   # copy scratch if needed
   @SCRATCH_COPY@


### PR DESCRIPTION
This solves the issue for #761 where ED failures are not detected. Most
of the job scripts assume the model exits with 0 if everything was ok,
and anything else if there was an error code. ED always exits with 0.