### PR TITLE
add few checks in the pda.settings.bt function

### DIFF
--- a/modules/assim.batch/R/pda.utils.R
+++ b/modules/assim.batch/R/pda.utils.R
@@ -741,17 +741,17 @@ pda.settings.bt <- function(settings){
   
   iterations = as.numeric(settings$assim.batch$bt.settings$iter)
   optimize = settings$assim.batch$bt.settings$optimize
-  consoleUpdates = as.numeric(settings$assim.batch$bt.settings$consoleUpdates)
+  if(!is.null(consoleUpdates)) consoleUpdates = as.numeric(settings$assim.batch$bt.settings$consoleUpdates)
   parallel = settings$assim.batch$bt.settings$parallel
   adapt = settings$assim.batch$bt.settings$adapt
-  adaptationInverval = as.numeric(settings$assim.batch$bt.settings$adaptationInverval)
-  adaptationNotBefore = as.numeric(settings$assim.batch$bt.settings$adaptationNotBefore)
+  if(!is.null(adaptationInverval)) adaptationInverval = as.numeric(settings$assim.batch$bt.settings$adaptationInverval)
+  if(!is.null(adaptationNotBefore)) adaptationNotBefore = as.numeric(settings$assim.batch$bt.settings$adaptationNotBefore)
   initialParticles=list("prior",as.numeric(settings$assim.batch$bt.settings$n.initialParticles))
   DRlevels = as.numeric(settings$assim.batch$bt.settings$DRlevels)
   proposalScaling = settings$assim.batch$bt.settings$proposalScaling
   adaptationDepth = settings$assim.batch$bt.settings$adaptationDepth
   temperingFunction = settings$assim.batch$bt.settings$temperingFunction
-  gibbsProbabilities = as.numeric(unlist(settings$assim.batch$bt.settings$gibbsProbabilities))
+  if(!is.null(gibbsProbabilities)) gibbsProbabilities = as.numeric(unlist(settings$assim.batch$bt.settings$gibbsProbabilities))
   
 ## Generate proposal  
 # TODO: pass jump variances to proposalGenerator from settings

--- a/modules/assim.batch/R/pda.utils.R
+++ b/modules/assim.batch/R/pda.utils.R
@@ -747,7 +747,7 @@ pda.settings.bt <- function(settings){
   if(!is.null(adaptationInverval)) adaptationInverval = as.numeric(settings$assim.batch$bt.settings$adaptationInverval)
   if(!is.null(adaptationNotBefore)) adaptationNotBefore = as.numeric(settings$assim.batch$bt.settings$adaptationNotBefore)
   initialParticles=list("prior",as.numeric(settings$assim.batch$bt.settings$n.initialParticles))
-  DRlevels = as.numeric(settings$assim.batch$bt.settings$DRlevels)
+  if(!is.null(DRlevels)) DRlevels = as.numeric(settings$assim.batch$bt.settings$DRlevels)
   proposalScaling = settings$assim.batch$bt.settings$proposalScaling
   adaptationDepth = settings$assim.batch$bt.settings$adaptationDepth
   temperingFunction = settings$assim.batch$bt.settings$temperingFunction


### PR DESCRIPTION
I just found out that I need to add some checks for a few of the BayesianTools specific settings, otherwise if they're NULL (it's fine for them to be NULL but) as.numeric converts them to `numeric(0)` which causes an error.

@mdietze it would be great if it can make it to the VM