### PR TITLE
Fix for met2model.MAESPA

### DIFF
--- a/models/maespa/R/met2model.MAESPA.R
+++ b/models/maespa/R/met2model.MAESPA.R
@@ -113,9 +113,8 @@ met2model.MAESPA <- function(in.path, in.prefix, outfolder, start_date,
       # RH <- try(ncvar_get(nc,"relative_humidity"))# fraction
 
       if(!is.numeric(PAR)){
-        #This function, from data.atmosphere will convert SW, in this case RAD,
-        #to a photosynthetic flux in umol/m2/s
-        PAR <- sw2ppfd(RAD)
+        #This function, from data.atmosphere will convert SW to par in W/m2
+        PAR <- sw2par(RAD)
         }else{
           #convert 
           PAR <- udunits2::ud.convert(PAR,"mol","umol")
@@ -137,7 +136,7 @@ met2model.MAESPA <- function(in.path, in.prefix, outfolder, start_date,
       print("Skipping to next year")
       next
     }
-    tmp<-rbind(TAIR,PPT,RAD,PAR)
+    tmp<-rbind(TAIR,PPT,RAD)
 
     if(is.null(out)) {
       out = tmp


### PR DESCRIPTION
@mdekauwe thank you for all the fixes. I definitely need to improve on making my code cleaner and more readable. 

For ```SW``` I had read it in with the MAESPA variable name ```RAD```.  To get PAR from ```RAD``` we had a function in our data.atmosphere package that I've implemented here. 