### PR TITLE
Bug fixes to gday met2model

### DIFF
--- a/models/gday/R/met2model.GDAY.R
+++ b/models/gday/R/met2model.GDAY.R
@@ -28,7 +28,7 @@
 ##' @param overwrite should existing files be overwritten
 ##' @param verbose should the function be very verbose
 met2model.GDAY <- function(in.path, in.prefix, outfolder, start_date,
-                           end_date, ..., overwrite=FALSE,verbose=FALSE){
+                           end_date, ..., overwrite=FALSE, verbose=FALSE){
 
   ## GDAY driver format (.csv):
   ## 30min: year (-), doy (-; NB. leap years), hod (-), rainfall (mm 30 min-1),
@@ -67,8 +67,6 @@ met2model.GDAY <- function(in.path, in.prefix, outfolder, start_date,
                         enddate=c(end_date),
                         dbfile.name=out.file,
                         stringsAsFactors=FALSE)
-  print("internal results")
-  print(results)
 
   if (file.exists(out.file.full) && !overwrite) {
     logger.debug("File '", out.file.full,
@@ -79,7 +77,6 @@ met2model.GDAY <- function(in.path, in.prefix, outfolder, start_date,
   require(ncdf4)
   require(lubridate)
   require(PEcAn.data.atmosphere)
-  #  require(ncdf)
 
   ## check to see if the outfolder is defined, if not create directory for
   ## output
@@ -87,66 +84,25 @@ met2model.GDAY <- function(in.path, in.prefix, outfolder, start_date,
     dir.create(outfolder)
   }
 
-  ## For now setting this to be always true till I figure out how to
-  ## interface with the sub_daily param file. Should detech if met-data
-  ## is coarser than 30-min and swapped to day version?
-  sub_daily = TRUE
+  ## For now setting this to be false till we resolve the best route forward
+  sub_daily = FALSE
 
+  # Create an empty holder for each (hour)days translated met file
   out <- NULL
 
-  ## write the expected header information
-  if (sub_daily) {
-    ounits <- paste("#--,--,--,mm/30min,umol/m2/s,degC,degC,kPa,ppm,",
-                    "t/ha/30min,m/s,kPa", sep="")
-    ovar_names <- "#year,doy,hod,rain,par,tair,tsoil,vpd,co2,ndep,wind,press"
-
-    # Do we have a site name that we can append here?
-    out = rbind(out, "Site? 30-min met forcing")
-    out = rbind(out, paste("Created by met2model.GDAY.R:", Sys.Date()))
-    out = rbind(out, ounits)
-    out = rbind(out, ovar_names)
-  } else {
-    ounits <- paste("#--,--,degC,mm,degC,degC,degC,degC,degC,degC,kPa,kPa,",
-                    "ppm,t/ha/d,m/s,kPa,m/s,m/s,umol/m2/s,umol/m2/s", sep="")
-    ovar_names <- paste("#year,doy,tair,rain,tsoil,tam,tpm,tmin,tmax,tday,",
-                        "vpd_am,vpd_pm,co2,ndep,wind,press,wind_am,wind_pm,",
-                        "par_am,par_pm", sep="")
-
-    # Do we have a site name that we can append here?
-    out = rbind(out, "Site? 30-min met forcing")
-    out = rbind(out, paste("Created by met2model.GDAY.R:", Sys.Date()))
-    out = rbind(out, ounits)
-    out = rbind(out, ovar_names)
-  }
-
-  # get start/end year since inputs are specified on year basis
   start_year <- year(start_date)
   end_year <- year(end_date)
 
-  ## loop over files
-  # TODO need to filter out the data that is not inside start_date, end_date
   for (year in start_year:end_year) {
-    print(year)
     old.file <- file.path(in.path, paste(in.prefix, year, "nc", sep="."))
 
-    ## open netcdf
     nc <- nc_open(old.file)
-
-    ## convert time to seconds
-    sec   <- nc$dim$time$vals
-    sec = udunits2::ud.convert(sec,unlist(strsplit(nc$dim$time$units," "))[1],
-                               "seconds")
-    timestep.s=86400 #seconds in a day
-    ifelse(leap_year(year)==TRUE,
-           dt <- (366*24*60*60)/length(sec), #leap year
-           dt <- (365*24*60*60)/length(sec)) #non-leap year
-    tstep = round(timestep.s/dt)
-    dt = timestep.s/tstep #dt is now an integer
 
     ## extract variables
     lat <- ncvar_get(nc, "latitude")
     lon <- ncvar_get(nc, "longitude")
     Tair <- ncvar_get(nc, "air_temperature")  ## in Kelvin
+    Tair <- Tair + K_TO_DEG
     PAR <- try(ncvar_get(nc,
                      "surface_downwelling_photosynthetic_photon_flux_in_air"))
     PAR <- PAR * MOL_2_UMOL
@@ -156,20 +112,26 @@ met2model.GDAY <- function(in.path, in.prefix, outfolder, start_date,
     }
     CO2 <- try(ncvar_get(nc, "mole_fraction_of_carbon_dioxide_in_air"))
     SH <- try(ncvar_get(nc, "specific_humidity")) ## kg/kg
+    VPD <- try(ncvar_get(nc, "water_vapor_saturation_deficit")) ## Pa
+    if (!is.numeric(VPD)) {
+      RH = qair2rh(SH, Tair)
+      VPD = get.vpd(RH, Tair) * MB_2_KPA
+    } else {
+      VPD <- VPD * PA_2_KPA
+    }
+
     wind_speed  <- try(ncvar_get(nc, "wind_speed")) ## m/s
     air_pressure <- try(ncvar_get(nc, "air_pressure")) ## Pa
     ppt <- try(ncvar_get(nc, "precipitation_flux")) ## kg/m2/s
 
-
     nc_close(nc)
 
-    useCO2 = is.numeric(CO2)
-    if(useCO2)  CO2 <- CO2 * 1e6  ## convert from mole fraction (kg/kg) to ppm
-
     ## is CO2 present?
-    if (!is.numeric(CO2)){
-      logger.warn("CO2 not found in",old.file,"setting to default: 400 ppm")
-      CO2 = rep(400,length(Tair))
+    if (!is.numeric(CO2)) {
+      logger.warn("CO2 not found in", old.file, "setting to default: 400 ppm")
+      CO2 = rep(400, length(Tair))
+    } else {
+      CO2 <- CO2 * MOL_2_UMOL
     }
 
     if (sub_daily) {
@@ -179,142 +141,157 @@ met2model.GDAY <- function(in.path, in.prefix, outfolder, start_date,
       } else {
         ndays <- 365
       }
-      idx = 1
+
       for (doy in 1:ndays) {
+
+        day_idx <- idx:((idx-1) + 48)
+
+        # Grab the days data
+        tair_day = Tair[day_idx]
+        rain_day = ppt[day_idx]
+        par_day = PAR[day_idx]
+        vpd_day = VPD[day_idx]
+        wind_day = wind_speed[day_idx]
+        press_day = air_pressure[day_idx] * PA_2_KPA
+        co2_day = CO2[day_idx]
 
         ## If there is no Tsoil variabile use Tair...it doesn't look like Tsoil
         ## is a standard input
-        tsoil = mean(tair[idx:idx+48] + K_TO_DEG)
+        tsoil_out = mean(tair_day)
+
         for (hod in 1:48) {
 
-          rain = ppt[idx] * SEC_TO_HFHR
-          par = PAR[idx]
-          tair = Tair[idx] + K_TO_DEG
-          wind = wind_speed[idx]
-          press = air_pressure[idx] * PA_2_KPA
-          rh = qair2rh(SH[idx], Tair[idx])
-          vpd = get.vpd(rh[idx], Tair[idx])
-          co2 = CO2[idx]
+          rain_out = rain_day[hod] * SEC_TO_HFHR
+          par_out = par_day[hod]
+          tair_out = tair_day[hod]
+          wind_out = wind_day[hod]
+          press_out = press_day[hod]
+          vpd_out = vpd_day[hod]
+          co2_out = co2_day[hod]
 
           # This is an assumption of the Medlyn gs model
-          if (vpd < 0.05) {
-            vpd = 0.05
+          if (vpd_out < 0.05) {
+            vpd_out = 0.05
           }
 
           ## No NDEP, so N-cycle will have to be switched off by default
-          ndep = -999.9
+          ndep_out = -999.9
 
-          idx <- idx + 1
+          ## build output data matrix
+          tmp <- cbind(year,
+                       doy,
+                       hod,
+                       rain_out,
+                       par_out,
+                       tair_out,
+                       tsoil_out,
+                       vpd_out,
+                       co2_out,
+                       ndep_out,
+                       wind_out,
+                       press_out)
+
+          if (is.null(out)) {
+            out = tmp
+          } else {
+            out = rbind(out, tmp)
+          }
+
+          idx <- idx + 48
         } ## Hour of day loop
-
-        ## build data matrix
-        tmp <- cbind(year,
-                     doy,
-                     hod,
-                     rain,
-                     par,
-                     tair,
-                     tsoil,
-                     vpd,
-                     CO2,
-                     ndep,
-                     wind,
-                     press)
-
-        if (is.null(out)) {
-          out = tmp
-        } else {
-          out = rbind(out, tmp)
-        }
       } ## Day of year loop
 
     } else {
 
-      idx = 1
-      if(year %% 4 == 0) {
+      if (year %% 4 == 0) {
         ndays <= 366
       } else {
         ndays <- 365
       }
+
       for (doy in 1:ndays) {
 
         # Build day, morning and afternoon indicies
-        day_idx <- idx:idx+48
-        mor_idx <- idx:idx+23
-        eve_idx <- idx+24:idx+48
+        day_idx <- idx:((idx-1) + 48)
+        mor_idx <- 1:24
+        eve_idx <- 25:48
 
-        tam <- Tair[mor_idx][PAR[mor_idx] > 0.0]
-        tpm <- Tair[eve_idx][PAR[eve_idx] > 0.0]
+        # Grab the days data
+        tair_day = Tair[day_idx]
+        par_day = PAR[day_idx]
+        vpd_day = VPD[day_idx]
+        wind_day = wind_speed[day_idx]
 
-        ## Needs to be daylight hours...how do we access sun up/down
-        tair = Tair[day_idx][PAR[mor_idx] > 0.0]
-        rain = sum(ppt[day_idx] * SEC_TO_HFHR)
+        # Calculate the output met vars
+        tair_out = mean(tair_day)
+        rain_out = sum(ppt[day_idx] * SEC_TO_HFHR)
 
         ## If there is no Tsoil variabile use Tair...it doesn't look like Tsoil
         ## is a standard input
-        tsoil = mean(tair[day_idx] + K_TO_DEG)
-
-        ## Needs to be AM/PM
-        tam = Tair[mor_idx][PAR[mor_idx] > 0.0]
-        tpm = Tair[eve_idx][PAR[eve_idx] > 0.0]
-
-        tmin = min(tair[day_idx] + K_TO_DEG)
-        tmax = max(tair[day_idx] + K_TO_DEG)
-        tday = mean(tair[day_idx] + K_TO_DEG)
-
-        vpd_am = vpd[mor_idx][PAR[mor_idx] > 0.0]
-        # This is an assumption of the Medlyn gs model
-        if (vpd_am < 0.05) {
-          vpd_am = 0.05
-        }
-
-        vpd_am = vpd[eve_idx][PAR[eve_idx] > 0.0]
-        # This is an assumption of the Medlyn gs model
-        if (vpd_pm < 0.05) {
-          vpd_pm = 0.05
-        }
-        co2 = mean(CO2[day_idx])
+        tsoil_out = mean(tair_day)
 
         ## No NDEP, so N-cycle will have to be switched off by default
-        ndep = -999.9
+        ndep_out = -999.9
 
-        wind = mean(wind_speed[day_idx])
-        press = mean(air_pressure[day_idx] * PA_2_KPA)
+        co2_out = mean(CO2[day_idx])
+        wind_out = mean(wind_speed[day_idx])
+        press_out = mean(air_pressure[day_idx] * PA_2_KPA)
 
-        # Needs to be AM/PM
-        wind_am = wind_speed[mor_idx][PAR[mor_idx] > 0.0]
-        wind_pm = wind_speed[eve_idx][PAR[eve_idx] > 0.0]
-        par_am = PAR[mor_idx][PAR[mor_idx] > 0.0]
-        par_pm = PAR[eve_idx][PAR[eve_idx] > 0.0]
-      }
+        ## Needs to be morning (am) / afternoon (pm)
+        tair_am_out = mean(tair_day[mor_idx][par_day[mor_idx] > 0.0])
+        tair_pm_out = mean(tair_day[eve_idx][par_day[eve_idx] > 0.0])
+        tmin_out = min(tair_day)
+        tmax_out = max(tair_day)
+        tday_out = mean(tair_day)
 
-      ## build data matrix
-      tmp <- cbind(year,
-                   doy,
-                   tair,
-                   rain,
-                   tsoil,
-                   tam,
-                   tpm,
-                   tmin,
-                   tmax,
-                   tday,
-                   vpd_am,
-                   vpd_pm,
-                   CO2,
-                   ndep,
-                   wind,
-                   press,
-                   wind_am,
-                   wind_pm,
-                   par_am,
-                   par_pm)
+        vpd_am_out = mean(vpd_day[mor_idx][par_day[mor_idx] > 0.0])
+        # This is an assumption of the Medlyn gs model
+        if (vpd_am_out < 0.05) {
+          vpd_am_out = 0.05
+        }
 
-      if (is.null(out)) {
-        out = tmp
-      } else {
-        out = rbind(out,tmp)
-      }
+        vpd_pm_out = mean(vpd_day[eve_idx][par_day[eve_idx] > 0.0])
+        # This is an assumption of the Medlyn gs model
+        if (vpd_pm_out < 0.05) {
+          vpd_pm_out = 0.05
+        }
+
+        wind_am_out = mean(wind_day[mor_idx][par_day[mor_idx] > 0.0])
+        wind_pm_out = mean(wind_day[eve_idx][par_day[eve_idx] > 0.0])
+        par_am_out = sum(par_day[mor_idx][par_day[mor_idx] > 0.0])
+        par_pm_out = sum(par_day[eve_idx][par_day[eve_idx] > 0.0])
+
+        ## build output data matrix
+        tmp <- cbind(year,
+                     doy,
+                     tair_out,
+                     rain_out,
+                     tsoil_out,
+                     tair_am_out,
+                     tair_pm_out,
+                     tmin_out,
+                     tmax_out,
+                     tday_out,
+                     vpd_am_out,
+                     vpd_pm_out,
+                     co2_out,
+                     ndep_out,
+                     wind_out,
+                     press_out,
+                     wind_am_out,
+                     wind_pm_out,
+                     par_am_out,
+                     par_pm_out)
+
+        if (is.null(out)) {
+          out = tmp
+        } else {
+          out = rbind(out,tmp)
+        }
+
+        idx <- idx + 1
+      } ## end of day loop
+
     } ## end sub-daily/day if/else block
   } ## end loop over years
 
@@ -323,6 +300,5 @@ met2model.GDAY <- function(in.path, in.prefix, outfolder, start_date,
               col.names=FALSE)
 
   invisible(results)
-
 
 }

--- a/models/gday/R/met2model.GDAY.R
+++ b/models/gday/R/met2model.GDAY.R
@@ -27,6 +27,9 @@
 ##'        the year part of the date)
 ##' @param overwrite should existing files be overwritten
 ##' @param verbose should the function be very verbose
+##'
+##' @author Martin De Kauwe
+
 met2model.GDAY <- function(in.path, in.prefix, outfolder, start_date,
                            end_date, ..., overwrite=FALSE, verbose=FALSE){
 


### PR DESCRIPTION
Various bug fixes to met2model.GDAY.R 

Key change:
- no longer writing the GDAY met header information. All units are declared in the translation script and seeing as the met file is transferred internal there probably isn't much need for it.

To do:
- when we split GDAY into day & sub-daily versions, then we can split the if and else blocks into two scripts.

Still potential gotchas:
- Some of the gap-filled met files seem to be missing afternoon PAR values entirely. This would lead to GDAY crashing and most likely other models.
- This should probably be fixed at the met creation stage. We could add a check during the translation but I'd argue this is a data issue rather than a model issue.
