### PR TITLE
Add parallel functionality to PEcAnRTM::invert.auto

### DIFF
--- a/modules/rtm/DESCRIPTION
+++ b/modules/rtm/DESCRIPTION
@@ -15,7 +15,6 @@ Depends:
 Suggests:
     minpack.lm,
     mclust,
-    data.table,
     PEcAn.utils,
     PEcAn.ED2,
     testthat,

--- a/modules/rtm/DESCRIPTION
+++ b/modules/rtm/DESCRIPTION
@@ -10,14 +10,14 @@ Description: This package contains functions for performing forward runs and
     using maximum likelihood, or more complex hierarchical Bayesian methods.
     Underlying numerical analyses are optimized for speed using Fortran code.
 Depends:
-    PEcAn.utils,
-    PEcAn.ED2,
-    data.table,
-    minpack.lm,
     MASS,
-    mclust,
     coda
 Suggests:
+    minpack.lm,
+    mclust,
+    data.table,
+    PEcAn.utils,
+    PEcAn.ED2,
     testthat,
     knitr
 OS_type: unix

--- a/modules/rtm/NAMESPACE
+++ b/modules/rtm/NAMESPACE
@@ -1,3 +1,2 @@
 useDynLib(PEcAnRTM)
 exportPattern("^[[:alpha:]]+")
-import(data.table)

--- a/modules/rtm/R/check.convergence.R
+++ b/modules/rtm/R/check.convergence.R
@@ -21,7 +21,7 @@ check.convergence <- function(mcmc.samples.list,
                               verbose = TRUE,
                               autoburnin = FALSE,
                               ...){
-    require(coda)
+    library(coda)
     if(class(mcmc.samples.list) != "mcmc.list") stop("Input needs to be of class 'mcmc.list'")
     gd <- try(gelman.diag(mcmc.samples.list, autoburnin = autoburnin, ...))
     if(class(gd) == "try-error"){

--- a/modules/rtm/R/defparam.R
+++ b/modules/rtm/R/defparam.R
@@ -4,6 +4,7 @@
 #' @param modname Model name. Must match `modname` in `model.list`
 #' @return Named vector of default parameter values
 defparam <- function(modname){
+    library(data.table)
     data(model.list)
     setkey(model.list, modname)
     p.raw <- model.list[modname, par.default]

--- a/modules/rtm/R/defparam.R
+++ b/modules/rtm/R/defparam.R
@@ -4,15 +4,13 @@
 #' @param modname Model name. Must match `modname` in `model.list`
 #' @return Named vector of default parameter values
 defparam <- function(modname){
-    library(data.table)
     data(model.list)
-    setkey(model.list, modname)
-    p.raw <- model.list[modname, par.default]
+    p.raw <- model.list[model.list$modname == modname, "par.default"]
     p.split <- strsplit(p.raw, " ")
     p.names <- sapply(p.split, function(x) gsub("=.*", "", x))
     p.vals <- sapply(p.split, function(x) as.numeric(gsub(".*=", "", x)))
-    p.out <- p.vals[,1]
-    names(p.out) <- p.names[,1]
+    p.out <- drop(p.vals)
+    names(p.out) <- drop(p.names)
     return(p.out)
 }
     

--- a/modules/rtm/R/edr.wrapper.R
+++ b/modules/rtm/R/edr.wrapper.R
@@ -43,7 +43,7 @@ EDR <- function(paths,
                 change.history.time = TRUE,
                 output.path = getwd(),
                 clean = FALSE){
-    require(PEcAn.ED2)
+    library(PEcAn.ED2)
 
 # Extract paths
 # TODO: Provide option to just a results path with implied file structure

--- a/modules/rtm/R/invert.auto.R
+++ b/modules/rtm/R/invert.auto.R
@@ -1,10 +1,8 @@
-#' @name invert.auto
+#' @name invert.auto 
+#' 
 #' @title Inversion with automatic convergence checking
-#' @details Performs an inversion via the `invert.custom` function with 
-#' multiple chains and automatic convergence checking. Convergence checks are 
-#' performed using the multivariate Gelman-Rubin diagnostic.
-#' @param observed Matrix of observed values. Must line up with output of 
-#' 'model'.
+#' @details Performs an inversion via the `invert.custom` function with multiple chains and automatic convergence checking. Convergence checks are performed using the multivariate Gelman-Rubin diagnostic.
+#' @param observed Matrix of observed values. Must line up with output of 'model'.
 #' @param invert.options R list object containing the following elements:
 #' 
 #' inits Vector of initial values of model parameters to be inverted.
@@ -53,11 +51,13 @@
 #' @param return.samples Include full samples list in output. Default = TRUE.
 #' @param save.samples Filename for saving samples after each iteration. If 
 #' 'NULL', do not save samples. Default = NULL.
+#' @param parallel Logical. Whether or not to run multiple chains in parallel on multiple cores (defualt=FALSE).
+#' @param parallel.cores Number of cores to use for parallelization. If NULL (default), allocate one fewer than detected number of cores.
 #' @param ... Other arguments to `check.convergence`
 #' @return List of "results" (summary statistics and Gelman Diagnostic) and 
 #' "samples"(mcmc.list object, or "NA" if return.samples=FALSE)
 
-invert.auto <- function(observed, invert.options, return.samples=TRUE, save.samples=NULL, quiet=FALSE, ...){
+invert.auto <- function(observed, invert.options, return.samples=TRUE, save.samples=NULL, quiet=FALSE, parallel=FALSE, parallel.cores=NULL, ...){
     library(coda)
     n.tries <- invert.options$n.tries
     nchains <- invert.options$nchains
@@ -67,11 +67,30 @@ invert.auto <- function(observed, invert.options, return.samples=TRUE, save.samp
     i.try <- 1
     while(try.again & i.try <= n.tries){
         print(sprintf("Attempt %d of %d", i.try, n.tries))
-        samps.list <- list()
-        for(chain in 1:nchains){
-            print(sprintf("Chain %d of %d", chain, nchains))
-            invert.options$inits <- inits.function() 
-            samps.list[[chain]] <- invert.custom(observed=observed, invert.options=invert.options, quiet=quiet)
+        if(parallel){
+            if(!require(parallel)) stop("'parallel' package not installed")
+            invert.function <- function(x){
+                invert.options$inits <- inits.function()
+                samps <- invert.custom(observed=observed, invert.options=invert.options, quiet=quiet)
+                return(samps)
+            }
+            if(is.null(parallel.cores)){
+                cl <- makeCluster(detectCores() - 1, "FORK")
+            } else {
+                if(!is.numeric(parallel.cores) | parallel.cores %% 1 != 0){
+                    stop("Invalid argument to 'parallel.cores'. Must be integer or NULL")
+                }
+                cl <- makeCluster(parallel.cores, "FORK")
+            }
+            print(sprintf("Running %d chains in parallel. Progress bar unavailable", nchains))
+            samps.list <- parLapply(cl, as.list(1:nchains), invert.function)
+        } else {
+            samps.list <- list()
+            for(chain in 1:nchains){
+                print(sprintf("Chain %d of %d", chain, nchains))
+                invert.options$inits <- inits.function() 
+                samps.list[[chain]] <- invert.custom(observed=observed, invert.options=invert.options, quiet=quiet)
+            }
         }
         if(!is.null(save.samples)) save(samps.list, file=save.samples)
         # Check for convergence. Repeat if necessary.

--- a/modules/rtm/R/invert.auto.R
+++ b/modules/rtm/R/invert.auto.R
@@ -63,6 +63,7 @@ invert.auto <- function(observed, invert.options, return.samples=TRUE, save.samp
     nchains <- invert.options$nchains
     inits.function <- invert.options$inits.function
     invert.options$do.lsq <- invert.options$do.lsq.first
+    if(invert.options$do.lsq) library(minpack.lm)
     try.again <- TRUE
     i.try <- 1
     while(try.again & i.try <= n.tries){
@@ -74,6 +75,7 @@ invert.auto <- function(observed, invert.options, return.samples=TRUE, save.samp
         if(parallel){
             library(parallel)
             invert.function <- function(x){
+                set.seed(x)
                 invert.options$inits <- inits.function()
                 samps <- invert.custom(observed=observed, invert.options=invert.options, quiet=quiet)
                 return(samps)
@@ -91,7 +93,8 @@ invert.auto <- function(observed, invert.options, return.samples=TRUE, save.samp
                 cl <- makeCluster(parallel.cores, "FORK")
             }
             print(sprintf("Running %d chains in parallel. Progress bar unavailable", nchains))
-            samps.list <- parLapply(cl, as.list(1:nchains), invert.function)
+            seed.list <- as.list(1e8 * runif(nchains))
+            samps.list <- parLapply(cl, seed.list, invert.function)
         } else {
             samps.list <- list()
             for(chain in 1:nchains){

--- a/modules/rtm/R/invert.auto.R
+++ b/modules/rtm/R/invert.auto.R
@@ -96,6 +96,7 @@ invert.auto <- function(observed, invert.options, return.samples=TRUE, save.samp
             seed.list <- as.list(1e8 * runif(nchains))
             samps.list <- parLapply(cl, seed.list, invert.function)
         } else {
+            message("Running in serial mode. Better performance can be achieved by running multiple chains in parallel (set 'parallel=TRUE').")
             samps.list <- list()
             for(chain in 1:nchains){
                 print(sprintf("Chain %d of %d", chain, nchains))

--- a/modules/rtm/R/invert.custom.R
+++ b/modules/rtm/R/invert.custom.R
@@ -1,4 +1,5 @@
 #' @name invert.custom
+#'
 #' @title Bayesian inversion of a model
 #' @details Performs an inversion of an arbitrary model using a modified 
 #' Metropolis Hastings algorithm with block sampling. This may be slightly 
@@ -18,7 +19,7 @@
 #' output.
 #'
 #' param.mins Vector of minimum values for inversion parameters
-
+#'
 #' model The model to be inverted. This should be an R function that takes 
 #' `params` as input and returns one column of `observed` (nrows should be the 
 #' same). Constants should be implicitly included here.
@@ -36,6 +37,7 @@
 #' risks getting caught in a local minimum.  Default=FALSE
 #' @param quiet Do not show progress bar. Default=FALSE
 invert.custom <- function(observed, invert.options, quiet=FALSE){
+    library(MASS)
     observed <- as.matrix(observed)
     nspec <- ncol(observed)
     nwl <- nrow(observed)

--- a/modules/rtm/R/invert.fast.R
+++ b/modules/rtm/R/invert.fast.R
@@ -34,11 +34,9 @@
 
 invert.fast <- function(modname, observed, inits, cons, 
                    pmu, psd, plog, minp, ngibbs){
-    library(data.table)
     data(model.list)
-    setkey(model.list, modname)
-    model.set <- model.list[modname]
-    if(all(is.na(model.set[,-1,with=FALSE]))){
+    model.set <- model.list[model.list$modname == modname,]
+    if(nrow(model.set) < 1){
         stop(sprintf("Error: Model '%s' not found", modname))
     }
     modcode <- as.integer(model.set$modcode)

--- a/modules/rtm/R/invert.fast.R
+++ b/modules/rtm/R/invert.fast.R
@@ -34,6 +34,7 @@
 
 invert.fast <- function(modname, observed, inits, cons, 
                    pmu, psd, plog, minp, ngibbs){
+    library(data.table)
     data(model.list)
     setkey(model.list, modname)
     model.set <- model.list[modname]

--- a/modules/rtm/R/invert.fast.re.R
+++ b/modules/rtm/R/invert.fast.re.R
@@ -35,10 +35,8 @@
 invert.fast.re <- function(modname, observed, inits, rand, cons, 
                    pmu, psd, plog, minp, ngibbs){
 # Get model code number
-    library(data.table)
     data(model.list)
-    setkey(model.list, modname)
-    model.set <- model.list[modname]
+    model.set <- model.list[model.list$modname == modname, ]
     if(all(is.na(model.set[,-1,with=FALSE]))){
         stop(sprintf("Error: Model '%s' not found", modname))
     }

--- a/modules/rtm/R/invert.fast.re.R
+++ b/modules/rtm/R/invert.fast.re.R
@@ -35,6 +35,7 @@
 invert.fast.re <- function(modname, observed, inits, rand, cons, 
                    pmu, psd, plog, minp, ngibbs){
 # Get model code number
+    library(data.table)
     data(model.list)
     setkey(model.list, modname)
     model.set <- model.list[modname]

--- a/modules/rtm/R/invert.lsq.R
+++ b/modules/rtm/R/invert.lsq.R
@@ -14,6 +14,7 @@
 #'@param uppper Upper bounds on parameters (default=NULL, which means +Inf).
 
 invert.lsq <- function(observed, inits, model, lower=NULL, upper=NULL){
+    library(minpack.lm)
     observed <- as.matrix(observed)
     merit <- function(params){
         spec <- model(params)

--- a/modules/rtm/R/process-output.R
+++ b/modules/rtm/R/process-output.R
@@ -50,6 +50,7 @@ load.from.name <- function(filename, filepath="."){
 #' matrix as a long list (for easy construction of data.tables)
 #' @param samples Matrix of MCMC samples.
 summary.mvnorm <- function(samples){
+    library(mclust)
     stopifnot(colnames(samples) != NULL)
     parnames <- colnames(samples)
     sigmanames <- sprintf("%s.%s.sigma", rep(parnames, 1, each=6),

--- a/modules/rtm/man/generate.rsr.all.Rd
+++ b/modules/rtm/man/generate.rsr.all.Rd
@@ -4,7 +4,7 @@
 \alias{generate.rsr.all}
 \title{Generate RSR matrices for all sensors and return as list}
 \usage{
-generate.rsr.all()
+generate.rsr.all(path.to.licor = NULL)
 }
 \description{
 Only needs to be called when updating these funcitons with new 

--- a/modules/rtm/man/invert.auto.Rd
+++ b/modules/rtm/man/invert.auto.Rd
@@ -5,11 +5,11 @@
 \title{Inversion with automatic convergence checking}
 \usage{
 invert.auto(observed, invert.options, return.samples = TRUE,
-  save.samples = NULL, quiet = FALSE, ...)
+  save.samples = NULL, quiet = FALSE, parallel = FALSE,
+  parallel.cores = NULL, ...)
 }
 \arguments{
-\item{observed}{Matrix of observed values. Must line up with output of 
-'model'.}
+\item{observed}{Matrix of observed values. Must line up with output of 'model'.}
 
 \item{invert.options}{R list object containing the following elements:
 
@@ -61,6 +61,10 @@ attempt. Default = 0.8}
 \item{save.samples}{Filename for saving samples after each iteration. If 
 'NULL', do not save samples. Default = NULL.}
 
+\item{parallel}{Logical. Whether or not to run multiple chains in parallel on multiple cores (defualt=FALSE).}
+
+\item{parallel.cores}{Number of cores to use for parallelization. If NULL (default), allocate one fewer than detected number of cores.}
+
 \item{...}{Other arguments to `check.convergence`}
 }
 \value{
@@ -68,8 +72,6 @@ List of "results" (summary statistics and Gelman Diagnostic) and
 "samples"(mcmc.list object, or "NA" if return.samples=FALSE)
 }
 \details{
-Performs an inversion via the `invert.custom` function with 
-multiple chains and automatic convergence checking. Convergence checks are 
-performed using the multivariate Gelman-Rubin diagnostic.
+Performs an inversion via the `invert.custom` function with multiple chains and automatic convergence checking. Convergence checks are performed using the multivariate Gelman-Rubin diagnostic.
 }
 

--- a/modules/rtm/tests/testthat/test.invert.R
+++ b/modules/rtm/tests/testthat/test.invert.R
@@ -12,19 +12,15 @@ settings$ngibbs <- 5000
 settings$burnin <- 4000
 settings$do.lsq.first <- TRUE
 settings$n.tries <- 1
-settings$nchains <- 3
-#Rprof()
-test <- invert.auto(obs, settings, return.samples=TRUE, save.samples=NULL, quiet=FALSE)
-#Rprof(NULL)
-#print(summaryRprof())
-#par(mfrow=c(3,2))
-#for(i in 1:6) {
-    #plot(samples[,i], type='l')
-    #abline(h=params[i])
-#}
+settings$nchains <- 5
+#test <- invert.auto(obs, settings, return.samples=TRUE, save.samples=NULL, quiet=FALSE)
+#test_that("Inversion output is list of length 2", {
+              #expect_is(test, "list")
+              #expect_equal(length(test), 2)
+#})
 
-test_that("Inversion output is list of length 2", {
-              expect_is(test, "list")
-              expect_equal(length(test), 2)
+test.parallel <- invert.auto(obs, settings, return.samples=TRUE, save.samples=NULL, quiet=TRUE, parallel=TRUE)
+test_that("Parallel inversion output is list of length 2", {
+              expect_is(test.parallel, "list")
+              expect_equal(length(test.parallel), 2)
 })
-

--- a/modules/rtm/tests/testthat/test.invert.R
+++ b/modules/rtm/tests/testthat/test.invert.R
@@ -1,5 +1,6 @@
 # Test slow inversion
 library(PEcAnRTM)
+library(testthat)
 context("PROSPECT R inversion")
 data(sensor.rsr)
 params <- c(1.4, 40, 8, 0.01, 0.01)
@@ -12,7 +13,7 @@ settings$ngibbs <- 5000
 settings$burnin <- 4000
 settings$do.lsq.first <- TRUE
 settings$n.tries <- 1
-settings$nchains <- 5
+settings$nchains <- 3
 #test <- invert.auto(obs, settings, return.samples=TRUE, save.samples=NULL, quiet=FALSE)
 #test_that("Inversion output is list of length 2", {
               #expect_is(test, "list")
@@ -23,4 +24,9 @@ test.parallel <- invert.auto(obs, settings, return.samples=TRUE, save.samples=NU
 test_that("Parallel inversion output is list of length 2", {
               expect_is(test.parallel, "list")
               expect_equal(length(test.parallel), 2)
+})
+
+test_that("Parallel inversion output produces distinct chains", {
+              expect_false(identical(test.parallel$samples[[1]],
+                                     test.parallel$samples[[2]]))
 })

--- a/modules/rtm/tests/testthat/test.prospect.R
+++ b/modules/rtm/tests/testthat/test.prospect.R
@@ -1,5 +1,6 @@
 #' Tests of radiative transfer models
 library(PEcAnRTM)
+library(testthat)
 context("PROSPECT models")
 
 p4 <- c("N"=1.4, "Cab"=30, "Cw"=0.004, "Cm"=0.003)

--- a/modules/rtm/tests/testthat/test.sail.R
+++ b/modules/rtm/tests/testthat/test.sail.R
@@ -1,9 +1,8 @@
 #' Tests of radiative transfer models
 library(PEcAnRTM)
+library(testthat)
 context("SAIL models")
 
-data(model.list)
-setkey(model.list, modname)
 p <- defparam("pro4sail")
 pout <- pro4sail(p)
 test.dim <- c(2101,4)


### PR DESCRIPTION
Run multiple MCMC chains in parallel using the `parallel` package. This significantly reduces computational time.

@istfer is up for review.