### PR TITLE
changes to use SIPNET r136 outputs with corrected header

### DIFF
--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -75,6 +75,7 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
   jobsh <- gsub('@END_DATE@', settings$run$end.date, jobsh)
   
   jobsh <- gsub('@BINARY@', settings$model$binary, jobsh)
+  jobsh <- gsub('@REVISION@', settings$model$revision, jobsh)
   
   if(is.null(settings$model$delete.raw)) settings$model$delete.raw <- FALSE
   jobsh <- gsub('@DELETE.RAW@', settings$model$delete.raw, jobsh)

--- a/models/sipnet/inst/template.job
+++ b/models/sipnet/inst/template.job
@@ -29,7 +29,7 @@ if [ ! -e "@OUTDIR@/sipnet.out" ]; then
 
   # convert to MsTMIP
   echo "require (PEcAn.SIPNET)
-    model2netcdf.SIPNET('@OUTDIR@', @SITE_LAT@, @SITE_LON@, '@START_DATE@', '@END_DATE@', @DELETE.RAW@)
+    model2netcdf.SIPNET('@OUTDIR@', @SITE_LAT@, @SITE_LON@, '@START_DATE@', '@END_DATE@', @DELETE.RAW@, '@REVISION@')
     " | R --vanilla
 fi
 


### PR DESCRIPTION
I first changed the header and the variables that are being written in /fs/data5/pecan.models/SIPNET/trunk/sipnet.c so they match (header being written in L784, acsii outputs are written in L817, csv in L838)

Now the header agrees with both the ascii and csv outputs ( I don't know whether sipnet maintainers would be happy with the change).

To be able to make model2netcdf.SIPNET compatible with different SIPNET revisions I modified it, now revision info is being passed from template.job. I only changed things for evapotranspiration but r136 version of SIPNET gives outputs such as fPAR, rh ra too. Unfortunately I have to leave now to finish packing for the field!

