### PR TITLE
adding mv for emulator

### DIFF
--- a/modules/assim.batch/R/pda.load.data.R
+++ b/modules/assim.batch/R/pda.load.data.R
@@ -25,16 +25,16 @@ load.pda.data <- function(settings, con) {
     inputs[[i]]$variable.name <- input.settings[[i]]$variable.name
     data.path <- input.settings[[i]]$path
 
-    obvs.id <- input.settings[[i]]$input.id 
-    
+    inputs[[i]]$variable.id <- input.settings[[i]]$variable.id
+    inputs[[i]]$input.id <- input.settings[[i]]$input.id
     # I require that the user defines data.path in the settings as well, instead of using query.file.path
     # because 'data.path <- query.file.path(obvs.id, con)' might return an incomplete path 
     # which results in reading all the files in that particular directory in the load.x_netcdf step
-    if(is.null(obvs.id) | is.null(data.path)) {            
+    if(is.null(inputs[[i]]$input.id) | is.null(data.path)) {            
       logger.error("Must provide both ID and PATH for all data assimilation inputs.")
     }
     
-    format <- query.format.vars(obvs.id, con) 
+    format <- query.format.vars(inputs[[i]]$input.id, con) 
     
     vars.used.index <- which(format$vars$bety_name %in% c(inputs[[i]]$variable.name))
     

--- a/modules/assim.batch/man/pda.emulator.Rd
+++ b/modules/assim.batch/man/pda.emulator.Rd
@@ -24,6 +24,6 @@ Brute-force, only to be used on simple models
 \author{
 Mike Dietze
 
-Ryan Kelly
+Ryan Kelly, Istem Fer
 }
 

--- a/modules/assim.batch/vignettes/AssimBatchVignette.Rmd
+++ b/modules/assim.batch/vignettes/AssimBatchVignette.Rmd
@@ -163,6 +163,8 @@ If you are using methods other than *bruteforce* and *bruteforce.bs*, some addit
 
 * `<GPpckg>` Specifies which R package to use for fitting a Gaussian process to interpolate the likelihood surface in between the calculated values that are obtained from actual model runs. Current options are `kernlab` and `GPfit` (recommended). 
 
+* Also, `<jvar>` tag(s) under the `<jump>` block is better left empty for emulator runs if you are doing this for the first time.
+
 **bayesian.tools** would look for sampler specific settings that can be passed through the pecan.xml as a block under the `<bt.settings>` tag. Currently, the available samplers in the BayesianTools package are:
 
 * Metropolis

--- a/modules/emulator/R/update.jump.R
+++ b/modules/emulator/R/update.jump.R
@@ -54,7 +54,7 @@ function(jmp,chain){
       j <- attr(jmp,"history")[l,i]
       hnew[i] <- j*a/attr(jmp,"target")
     }
-    print(hnew)
+    #print(hnew)
     attr(jmp,"history")<- rbind(attr(jmp,"history"),hnew)
     attr(jmp,"arate")[l+1] <- a
   }


### PR DESCRIPTION
Rainy afternoon in Bartlett :)

I made changes for the emulator code to propose values with mvrnorm. It was a little quick and dirty fix (it now uses `pda.adjust.jumps.bs` of block sampling code as well) but it should do the job for the flux course.

I also made some changes to the pda.load code as I missed to pass input.id/variable.id info along with `inputs` list in the latest changes (because it was `bety$write=FALSE` in my pecan.xml while I was testing it) which is necessary to associate the likelihoods with inputs in BETY.

@jam2767 is up for review (although I may not be prompt with my replies)