### PR TITLE
Corrected units of VPD in met2CF.Ameriflux from mol/m2/s1 to Pa

### DIFF
--- a/modules/data.atmosphere/R/met2CF.Ameriflux.R
+++ b/modules/data.atmosphere/R/met2CF.Ameriflux.R
@@ -202,7 +202,7 @@ met2CF.Ameriflux <- function(in.path, in.prefix, outfolder, start_date, end_date
     # convert VPD to water_vapor_saturation_deficit
     # HACK : conversion will make all values < 0 to be NA
     copyvals(nc1=nc1, var1='VPD',
-             nc2=nc2, var2='water_vapor_saturation_deficit', units2='mol m-2 s-1', dim2=dim, 
+             nc2=nc2, var2='water_vapor_saturation_deficit', units2='Pa', dim2=dim, 
              conv=function(x) { ifelse(x<0, NA, x*1000) }, verbose=verbose)
 
     # copy Rg to surface_downwelling_shortwave_flux_in_air


### PR DESCRIPTION
Raw Ameriflux VPD is in kPa. The conversion that already was there just multiplied by 1000, effectively converting kPa to Pa. The unit was  mol/m2/s1 however, so this just needed a change to the unit name, not a conversion. This should close #692 