### PR TITLE
download.GFDL output file descriptors

### DIFF
--- a/modules/data.atmosphere/R/download.GFDL.R
+++ b/modules/data.atmosphere/R/download.GFDL.R
@@ -131,5 +131,3 @@ download.GFDL <- function(outfolder, start_date, end_date, site_id, lat.in, lon.
   invisible(results)
 }
 
-
-download.GFDL('C:/Users/James Simkins/', '2010-01-01 00:00:00', '2010-12-31 23:59:59', 2, 43, -88) 

--- a/modules/data.atmosphere/R/download.GFDL.R
+++ b/modules/data.atmosphere/R/download.GFDL.R
@@ -34,9 +34,9 @@ download.GFDL <- function(outfolder, start_date, end_date, site_id, lat.in, lon.
     lon_floor = 360 + lon_floor
   }
   lat_GFDL = lat_floor*(.5) +45
-  lat_GFDL = floor(lat_GFDL)
+  lat_GFDL = floor(lat_GFDL)+1
   lon_GFDL = lon_floor/2.5 
-  lon_GFDL = floor(lon_GFDL)
+  lon_GFDL = floor(lon_GFDL)+1
   
   
   
@@ -69,7 +69,7 @@ download.GFDL <- function(outfolder, start_date, end_date, site_id, lat.in, lon.
     year = ylist[i]    
     ntime = (2920)
     
-    loc.file = file.path(outfolder,paste("GFDL",model,year,"nc",sep="."))
+    loc.file = file.path(outfolder,paste("GFDL",model,experiment,scenario,year,"nc",sep="."))
     
     met_start = 2006
     met_block = 5
@@ -132,3 +132,4 @@ download.GFDL <- function(outfolder, start_date, end_date, site_id, lat.in, lon.
 }
 
 
+download.GFDL('C:/Users/James Simkins/', '2010-01-01 00:00:00', '2010-12-31 23:59:59', 2, 43, -88) 


### PR DESCRIPTION
Added this so different experiments/scenarios across the same GFDL model could be tagged properly. Also, discovered that lat/lons were off by 1 because OPeNDAP indexes start at 0, not 1. Same was true for CRUNCEP, told Christy about the error for her pull request.