### PR TITLE
Username passing for download fluxnet/ameriflux

### DIFF
--- a/modules/data.atmosphere/R/download.AmerifluxLBL.R
+++ b/modules/data.atmosphere/R/download.AmerifluxLBL.R
@@ -13,7 +13,7 @@
 ##' 
 ##' @author Ankur Desai, based on download.Ameriflux.R by Josh Mantooth, Rob Kooper
 
-download.AmerifluxLBL <- function(sitename, outfolder, start_date, end_date, overwrite=FALSE, verbose=FALSE, ...) {
+download.AmerifluxLBL <- function(sitename, outfolder, start_date, end_date, overwrite=FALSE, verbose=FALSE, username="pecan", ...) {
   # get start/end year code works on whole years only
   
   require(lubridate) 
@@ -36,7 +36,7 @@ download.AmerifluxLBL <- function(sitename, outfolder, start_date, end_date, ove
   
   #need to query to get full file name #this is Ameriflux version
   url <- "http://wile.lbl.gov:8080/AmeriFlux/DataDownload.svc/datafileURLs"
-  json_query <- paste0('{"username":"AnkurDesai","siteList":["',site,'"],"intendedUse":"Research - Land model/Earth system model","description":"PEcAn download"}')
+  json_query <- paste0('{"username":"',username,'","siteList":["',site,'"],"intendedUse":"Research - Land model/Earth system model","description":"PEcAn download"}')
   result <- POST(url, body = json_query, encode = "json", add_headers("Content-Type" = "application/json"))
   link <- content(result)
 

--- a/modules/data.atmosphere/R/download.Fluxnet2015.R
+++ b/modules/data.atmosphere/R/download.Fluxnet2015.R
@@ -13,7 +13,7 @@
 ##' 
 ##' @author Ankur Desai, based on download.Ameriflux.R by Josh Mantooth, Rob Kooper
 
-download.Fluxnet2015 <- function(sitename, outfolder, start_date, end_date, overwrite=FALSE, verbose=FALSE, ...) {
+download.Fluxnet2015 <- function(sitename, outfolder, start_date, end_date, overwrite=FALSE, verbose=FALSE, username="pecan", ...) {
   # get start/end year code works on whole years only
   
   require(lubridate) 
@@ -36,7 +36,7 @@ download.Fluxnet2015 <- function(sitename, outfolder, start_date, end_date, over
   
   #need to query to get full file name - this is Fluxnet2015 version, TIER1 only
   url <- "http://wile.lbl.gov:8080/AmeriFlux/DataDownload.svc/datafileURLs"
-  json_query <- paste0('{"username":"AnkurDesai","siteList":["',site,'"],"intendedUse":"Research - Land model/Earth system model","description":"PEcAn download","dataProduct":"SUBSET","policy":"TIER1"}')  
+  json_query <- paste0('{"username":"',username,'","siteList":["',site,'"],"intendedUse":"Research - Land model/Earth system model","description":"PEcAn download","dataProduct":"SUBSET","policy":"TIER1"}')  
   result <- POST(url, body = json_query, encode = "json", add_headers("Content-Type" = "application/json"))
   link <- content(result)
   ftplink <- NULL

--- a/modules/data.atmosphere/R/met.process.R
+++ b/modules/data.atmosphere/R/met.process.R
@@ -12,7 +12,7 @@
 ##' @param dir  directory to write outputs to
 ##'
 ##' @author Elizabeth Cowdery, Michael Dietze, Ankur Desai, James Simkins
-met.process <- function(site, input_met, start_date, end_date, model, host, dbparms, dir, browndog=NULL){
+met.process <- function(site, input_met, start_date, end_date, model, host, dbparms, dir, browndog=NULL, username="pecan"){
   require(RPostgreSQL)
   require(XML)
   
@@ -144,7 +144,7 @@ met.process <- function(site, input_met, start_date, end_date, model, host, dbpa
         outfolder = paste0(outfolder,"_site_",str_ns)
         args <- list(site$name, outfolder, start_date, end_date)
         
-        cmdFcn  = paste0(pkg,"::",fcn,"(",paste0("'",args,"'",collapse=","),")")
+        cmdFcn  = paste0(pkg,"::",fcn,"(",paste0("'",args,"'",collapse=","),paste0(",username='",username,"'"),")")
         new.files <- remote.execute.R(script=cmdFcn,host=host$name,user=NA,verbose=TRUE,R="R")
         
         ## insert database record


### PR DESCRIPTION
username defaults to pecan, passed to download functions as username=username from met.process. next step is to fix workflow to read username from settings and pass to met.process.