### PR TITLE
Generalize emulator code for >1 PFTs

### DIFF
--- a/modules/assim.batch/R/pda.emulator.R
+++ b/modules/assim.batch/R/pda.emulator.R
@@ -181,8 +181,8 @@ pda.emulator <- function(settings, params.id=NULL, param.names=NULL, prior.id=NU
       
       ## GPfit optimization routine assumes that inputs are in [0,1]
       ## Instead of drawing from parameters, we draw from probabilities
-      knots.probs.all <- do.call(cbind, knots.probs)
-      prior.ind.all <- do.call(c, prior.ind)
+      knots.probs.all <- do.call("cbind", knots.probs)
+      prior.ind.all <- do.call("c", prior.ind)
         
       X <- knots.probs.all[, prior.ind.all, drop=FALSE]
       
@@ -223,7 +223,7 @@ pda.emulator <- function(settings, params.id=NULL, param.names=NULL, prior.id=NU
     }
     
     ## Change the priors to unif(0,1) for mcmc.GP
-    prior.all <- do.call(rbind, prior.list)
+    prior.all <- do.call("rbind", prior.list)
     
     prior.all[prior.ind.all,]=rep(c("unif",0,1,"NA"),each=sum(n.param))
     ## Set up prior functions accordingly
@@ -323,7 +323,7 @@ pda.emulator <- function(settings, params.id=NULL, param.names=NULL, prior.id=NU
     if(settings$assim.batch$GPpckg=="GPfit"){
       ## Set the prior functions back to work with actual parameter range
 
-      prior.all <- do.call(rbind, prior.list)
+      prior.all <- do.call("rbind", prior.list)
       prior.fn.all <- pda.define.prior.fn(prior.all)
      
       ## Convert probabilities back to parameter values
@@ -388,10 +388,7 @@ pda.emulator <- function(settings, params.id=NULL, param.names=NULL, prior.id=NU
     ind <- ind + n.param[i]
   }
 
-  # # re-shuffle list to separate each parameter samples to their own list
-  # mcmc.param.list <- lapply(seq_along(prior.ind.all), function(v) sapply(mcmc.list, function(x) x[,v]))
-  # names(mcmc.param.list) <- unlist(pname)[prior.ind.all]
-  # 
+
   settings <- pda.postprocess(settings, con, mcmc.param.list, jvar.list, pname, prior.list, prior.ind)
 
   ## close database connection

--- a/modules/assim.batch/R/pda.emulator.R
+++ b/modules/assim.batch/R/pda.emulator.R
@@ -136,10 +136,9 @@ pda.emulator <- function(settings, params.id=NULL, param.names=NULL, prior.id=NU
         }
       }
 
-      # colnames(knots.list$probs) <- pname
-      knots.params <- knots.list$params
-      knots.probs <- knots.list$probs
-      
+      knots.params <- sapply(knots.list, `[[`, "params")
+      knots.probs <- sapply(knots.list, `[[`, "probs")
+
     } # end of round-if
   } # end of extension-if
   

--- a/modules/assim.batch/R/pda.emulator.R
+++ b/modules/assim.batch/R/pda.emulator.R
@@ -217,8 +217,12 @@ pda.emulator <- function(settings, params.id=NULL, param.names=NULL, prior.id=NU
       for(c in 1:settings$assim.batch$chain){
         init.x <- mcmc.list[[c]][nrow(mcmc.list[[c]]),]
         
-        init.list[[c]] <-  as.list(sapply(seq_along(prior.ind), 
-                                          function(x) eval(prior.fn$pprior[[prior.ind[x]]], list(q=init.x[x]))))
+        prior.all <- do.call("rbind", prior.list)
+        prior.ind.all <- do.call("c", prior.ind)
+        prior.fn.all <- pda.define.prior.fn(prior.all)
+        
+        init.list[[c]] <-  as.list(sapply(seq_along(prior.ind.all), 
+                                          function(x) eval(prior.fn.all$pprior[[prior.ind.all[x]]], list(q=init.x[x]))))
       }
     }
     

--- a/modules/assim.batch/R/pda.emulator.R
+++ b/modules/assim.batch/R/pda.emulator.R
@@ -374,16 +374,25 @@ pda.emulator <- function(settings, params.id=NULL, param.names=NULL, prior.id=NU
                                               paste0('mcmc.list.pda', settings$assim.batch$ensemble.id, '.Rdata'))
   save(mcmc.list, file = settings$assim.batch$mcmc.path)
   
+  settings$assim.batch$jvar.path <- file.path(settings$outdir, 
+                                              paste0('jvar.pda', settings$assim.batch$ensemble.id, '.Rdata'))
+  save(jvar.list, file = settings$assim.batch$jvar.path)
   
-  # Separate each PFT's samples to their own list
+  
+  # Separate each PFT's parametes samples to their own list
   mcmc.param.list <- list()
   ind <- 0
   for(i in seq_along(settings$pfts)){
     mcmc.param.list[[i]] <-  lapply(mcmc.list, function(x) x[, (ind+1):(ind + n.param[i]), drop=FALSE])
+    names(mcmc.param.list[[i]])
     ind <- ind + n.param[i]
   }
-  
-  settings <- pda.postprocess(settings, con, mcmc.param.list, jvar.list, pname, prior, prior.ind)
+
+  # # re-shuffle list to separate each parameter samples to their own list
+  # mcmc.param.list <- lapply(seq_along(prior.ind.all), function(v) sapply(mcmc.list, function(x) x[,v]))
+  # names(mcmc.param.list) <- unlist(pname)[prior.ind.all]
+  # 
+  settings <- pda.postprocess(settings, con, mcmc.param.list, jvar.list, pname, prior.list, prior.ind)
 
   ## close database connection
   if(!is.null(con)) db.close(con)

--- a/modules/assim.batch/R/pda.utils.R
+++ b/modules/assim.batch/R/pda.utils.R
@@ -51,7 +51,7 @@ runModule.assim.batch <- function(settings) {
 ##'
 ##' @return An updated settings list
 ##'
-##' @author Ryan Kelly
+##' @author Ryan Kelly, Istem Fer
 ##' @export
 pda.settings <- function(settings, params.id=NULL, param.names=NULL, prior.id=NULL, chain=NULL,
                          iter=NULL, adapt=NULL, adj.min=NULL, ar.target=NULL, jvar=NULL, n.knot=NULL) {
@@ -78,16 +78,16 @@ pda.settings <- function(settings, params.id=NULL, param.names=NULL, prior.id=NU
   if(is.null(settings$assim.batch$param.names)) {
     logger.error('Parameter data assimilation requested, but no parameters specified for PDA')
   } else {
-    settings$assim.batch$param.names <- as.list(as.character(settings$assim.batch$param.names))
+    settings$assim.batch$param.names <- lapply(settings$assim.batch$param.names, as.character)
   }
-  # have to add names or listToXml() won't work
-  names(settings$assim.batch$param.names) <- rep("param", length(settings$assim.batch$param.names))
+  # # have to add names or listToXml() won't work
+  # names(settings$assim.batch$param.names) <- rep("param", length(settings$assim.batch$param.names))
   # Finally, check that none of the names listed are specified as pft constants
   constant.names <- unlist(sapply(settings$pfts, function(x) names(x$constants)))
   params.in.constants <- which(unlist(settings$assim.batch$param.names) %in% constant.names)
   if(length(params.in.constants) > 0) {
     logger.severe(paste0("PDA requested for parameter(s) [",
-      paste(settings$assim.batch$param.names[params.in.constants], collapse=", "), 
+      paste(unlist(settings$assim.batch$param.names)[params.in.constants], collapse=", "), 
       "] but these parameters are specified as constants in pecan.xml!"))
   }
   
@@ -96,12 +96,13 @@ pda.settings <- function(settings, params.id=NULL, param.names=NULL, prior.id=NU
   if(!is.null(prior.id)) {
     settings$assim.batch$prior$posterior.id <- prior.id
   }
-  if(!is.null(settings$assim.batch$prior$posterior.id)) {
-    settings$assim.batch$prior$posterior.id <- as.character(settings$assim.batch$prior$posterior.id)
+  if(!is.null(settings$pfts$pft$posteriorid)) {
+    settings$assim.batch$prior <- lapply(settings$pfts, `[[`, "posteriorid")
+    names(settings$assim.batch$prior) <- sapply(settings$pfts, `[[`, "name")
   }
 
 
-  # chain: An identifier for the MCMC chain. Currently not used for anything but a label.
+  # chain: An identifier for the MCMC chain. 
   if(!is.null(chain)) {
     settings$assim.batch$chain <- chain
   }

--- a/modules/assim.batch/R/pda.utils.R
+++ b/modules/assim.batch/R/pda.utils.R
@@ -864,7 +864,7 @@ pda.postprocess <- function(settings, con, mcmc.param.list, jvar.list, pname, pr
   ## save updated parameter distributions as trait.mcmc so that they can be read by the ensemble code
   # *** TODO: Generalize for multiple PFTS
   filename <- file.path(settings$pfts[[i]]$outdir, 
-                paste0('trait.mcmc.pda',settings$pfts[[i]]$name,'_', settings$assim.batch$ensemble.id, '.Rdata'))
+                paste0('trait.mcmc.pda.',settings$pfts[[i]]$name,'_', settings$assim.batch$ensemble.id, '.Rdata'))
   save(trait.mcmc, file = filename)
   dbfile.insert(dirname(filename), basename(filename), 'Posterior', posteriorid, con)
   

--- a/modules/assim.batch/R/pda.utils.R
+++ b/modules/assim.batch/R/pda.utils.R
@@ -730,12 +730,13 @@ pda.plot.params <- function(settings, mcmc.param.list, prior.ind) {
   } # end of for-loop over PFTs
   
   # conver mcmc.list to list of matrices 
-  params.subset.list <-lapply(params.subset, as.matrix)
+  params.subset.list <- list()
+  for(i in 1:length(params.subset)) params.subset.list[[i]] <-do.call("rbind", params.subset[[i]])
   
   # reformat each sublist such that params have their own list
-  params.subset.list <- lapply(1:length(params.subset.list), function(x) as.list(data.frame(mm[[x]])))
+  return.samples <- lapply(1:length(params.subset.list), function(x) as.list(data.frame(params.subset.list[[x]])))
   
- return(params.subset.list)
+ return(return.samples)
 }
 
 


### PR DESCRIPTION
Here are the changes I've made so far. I'm still updating the chunks that are there for extension runs (see my previous PR) but still wanted to push this without waiting any longer so that I can include other suggestions asap.

There were too many little details and I changed design more than once on the way, so there can easily be  redundancies or bugs. But it runs a first round of emulator for more than one PFTs/parameters/chains without any errors, at least without me noticing.

@araiho is up for review, although @mdietze definitely needs to chime in

here is the `assim.batch` formatting I'm using to make it work
```
 <assim.batch>
  <method>emulator</method>
  <n.knot>10</n.knot>
  <iter>200</iter>
  <chain>3</chain>
  <param.names>
   <soil>
    <param>som_respiration_rate</param>
   </soil>
   <temperate.coniferous>
    <param>veg_respiration_Q10</param>
    <param>stem_respiration_rate</param>
    <param>Vm_low_temp</param>
   </temperate.coniferous>
  </param.names>
  <jump>
   <adapt>100</adapt>
   <adj.min>0.1</adj.min>
   <ar.target>0.3</ar.target>
  </jump>
  <inputs>
   <file>
    <path>
     <path>/fs/data1/pecan.data/input/Ameriflux_site_0-772/US-NR1.2004.nc</path>
     <path>/fs/data1/pecan.data/input/Ameriflux_site_0-772/US-NR1.2005.nc</path>
     <path>/fs/data1/pecan.data/input/Ameriflux_site_0-772/US-NR1.2006.nc</path>
     <path>/fs/data1/pecan.data/input/Ameriflux_site_0-772/US-NR1.2007.nc</path>
    </path>
    <format>Ameriflux.L2</format>
    <input.id>1000000173</input.id>
    <likelihood>Laplace</likelihood>
    <variable.name>
     <variable.name>NEE</variable.name>
     <variable.name>UST</variable.name>
    </variable.name>
    <variable.id>297</variable.id>
   </file>
  </inputs>
 </assim.batch>
```

p.s. extensions also work now