### PR TITLE
Style cleanup for `scripts/*.R` scripts

### DIFF
--- a/scripts/Rfcn.R
+++ b/scripts/Rfcn.R
@@ -1,36 +1,35 @@
 #!/usr/bin/env Rscript
 
-## code to run an arbitrary R function
-## intended to be used to run commands on a remote server
-## e.g.  ssh <machine> <package> <function> <args>
+## code to run an arbitrary R function intended to be used to run commands on a remote server e.g.  ssh <machine> <package>
+## <function> <args>
 
 args <- commandArgs(trailingOnly = TRUE)
 
 ## check args
-if(length(args)<2){
-  print(c("Insufficient args",args))
+if (length(args) < 2) {
+  print(c("Insufficient args", args))
   exit()
 }
 
 ## load packages
-if(args[1] != "NULL"){
-  pkgs = unlist(strsplit(args[1],",",fixed=TRUE))
-  for(i in 1:length(pkgs)){
+if (args[1] != "NULL") {
+  pkgs <- unlist(strsplit(args[1], ",", fixed = TRUE))
+  for (i in seq_along(pkgs)) {
     do.call(require, list(pkgs[i]))
   }
 }
 
 ## check that function exists
-if(exists(args[2])){
+if (exists(args[2])) {
   
   ## put function arguments into a list
-  fcn.args = list()
-  if(length(args)>2){
-    for(i in 1:(length(args)-2)){
-      fcn.args[[i]] = args[i+2]
+  fcn.args <- list()
+  if (length(args) > 2) {
+    for (i in 1:(length(args) - 2)) {
+      fcn.args[[i]] <- args[i + 2]
     }
   }
-
+  
   ## call function
-  do.call(args[2], fcn.args) 
+  do.call(args[2], fcn.args)
 }

--- a/scripts/dependencies.R
+++ b/scripts/dependencies.R
@@ -6,96 +6,98 @@
 ##' 
 ##' @name dependencygraph
 ##' @title Create a graph of all package dependencies
+##' @param packages TODO
+##' @param filename TODO
+##' @param suggests TODO
+##' @param filter TODO
 ##' @export 
 ##' @examples
-##' dependencygraph(c("igraph"), suggests=TRUE)
+##' dependencygraph(c('igraph'), suggests=TRUE)
 ##' @author Rob Kooper
 ##'
-dependencygraph <- function(packages, filename='', suggests=FALSE, filter=NA) {
-    require(graphics)
-    require(igraph)
-
-    graphData <- data.frame(from=numeric(0), to=numeric(0), relationship=numeric(0))
-    seen <- c()
-
-    scanPackageField <- function(package, field) {
-        packages <- packageDescription(package, fields=field)
-        packages <- gsub('\n', '', packages)
-        packages <- strsplit(packages, ',[ \t]*')[[1]]
-        packages <- gsub(' ?\\(.*', '', packages)
-        for(x in na.omit(packages)) {
-            if (x == 'R') {
-                next
-            }
-            if (!is.na(filter) && length(grep(filter, x)) == 0) {
-                next
-            }
-            p <- gsub(' (.*)', '', x)
-            graphData[nrow(graphData)+1,] <<- c(package, p, field)
-            scanPackage(p)
-        }
+dependencygraph <- function(packages, filename = "", suggests = FALSE, filter = NA) {
+  require(graphics)
+  require(igraph)
+  
+  graphData <- data.frame(from = numeric(0), to = numeric(0), relationship = numeric(0))
+  seen <- c()
+  
+  scanPackageField <- function(package, field) {
+    packages <- packageDescription(package, fields = field)
+    packages <- gsub("\n", "", packages)
+    packages <- strsplit(packages, ",[ \t]*")[[1]]
+    packages <- gsub(" ?\\(.*", "", packages)
+    for (x in na.omit(packages)) {
+      if (x == "R") {
+        next
+      }
+      if (!is.na(filter) && length(grep(filter, x)) == 0) {
+        next
+      }
+      p <- gsub(" (.*)", "", x)
+      graphData[nrow(graphData) + 1, ] <<- c(package, p, field)
+      scanPackage(p)
     }
-
-    scanPackage <- function(package) {
-        if (!(package %in% seen)) {
-            seen <<- c(seen, package)
-            scanPackageField(package, "Depends")
-            if (suggests) {
-                scanPackageField(package, "Suggests")
-            }
-        }
+  } # scanPackageField
+  
+  scanPackage <- function(package) {
+    if (!(package %in% seen)) {
+      seen <<- c(seen, package)
+      scanPackageField(package, "Depends")
+      if (suggests) {
+        scanPackageField(package, "Suggests")
+      }
     }
+  } # scanPackageField
+  
+  for (p in packages) {
+    scanPackage(p)
+  }
+  
+  graph <- graph.data.frame(graphData)
+  
+  V(graph)$size <- 10
+  V(graph)$color <- "white"
+  V(graph)$label.color <- "black"
+  
+  E(graph)$arrow.size <- 0.5
+  E(graph)[relationship == "Depends"]$color <- "red"
+  E(graph)[relationship == "Suggests"]$color <- "blue"
+  # colors <- heat.colors(vcount(graph)) E(graph)$color <- colors[match(graphData$to, unique(graphData$to))]
+  
+  set.seed(3952)
+  layout <- layout.fruchterman.reingold.grid(graph)
+  # layout <- layout.circle(graph)
+  
+  if (length(grep("\\.pdf$", filename)) != 0) {
+    pdf(file = filename)
+    plot(graph, layout = layout, frame = true)
+    dev.off()
+  } else if (length(grep("\\.png$", filename)) != 0) {
+    png(file = filename, width = 1280, heigh = 1024)
+    plot(graph, layout = layout)
+    dev.off()
+  } else if (length(grep("\\.jpg$", filename)) != 0) {
+    jpeg(file = filename, width = 1280, heigh = 1024)
+    plot(graph, layout = layout)
+    dev.off()
+  } else if (length(grep("\\.svg$", filename)) != 0) {
+    svg(file = filename, width = 10, heigh = 10)
+    plot(graph, layout = layout, frame = TRUE)
+    dev.off()
+  } else if (length(grep("\\.csv$", filename)) != 0) {
+    write.table(graphData, file = filename, row.names = FALSE, sep = ",")
+  } else if (length(grep("\\.txt$", filename)) != 0) {
+    write.table(graphData, file = filename, row.names = FALSE, sep = "\t")
+  } else {
+    plot(graph)
+  }
+} # dependencygraph
 
-    for(p in packages) {
-        scanPackage(p)
-    }
+packages <- c("PEcAn.BIOCRO", "PEcAn.DB", "PEcAn.ED2", "PEcAn.MA", "PEcAn.SIPNET", 
+              "PEcAn.assim.batch", "PEcAn.assim.sequential", 
+              "PEcAn.data.atmosphere", "PEcAn.data.land", "PEcAn.priors", "PEcAn.settings", 
+              "PEcAn.uncertainty", "PEcAn.utils", "PEcAn.visualization")
 
-    graph <- graph.data.frame(graphData)
-
-    V(graph)$size <- 10
-    V(graph)$color <- 'white'
-    V(graph)$label.color <- 'black'
-
-    E(graph)$arrow.size <- 0.5
-    E(graph)[relationship == 'Depends']$color <- 'red'
-    E(graph)[relationship == 'Suggests']$color <- 'blue'
-    #colors <- heat.colors(vcount(graph))
-    #E(graph)$color <- colors[match(graphData$to, unique(graphData$to))]
-
-    set.seed(3952)
-    layout <- layout.fruchterman.reingold.grid(graph)
-    #layout <- layout.circle(graph)
-
-    if (length(grep("\\.pdf$", filename)) != 0) {
-        pdf(file=filename)
-        plot(graph, layout=layout, frame=true)
-        dev.off()
-    } else if (length(grep("\\.png$", filename)) != 0) {
-        png(file=filename, width=1280, heigh=1024)
-        plot(graph, layout=layout)
-        dev.off()
-    } else if (length(grep("\\.jpg$", filename)) != 0) {
-        jpeg(file=filename, width=1280, heigh=1024)
-        plot(graph, layout=layout)
-        dev.off()
-    } else if (length(grep("\\.svg$", filename)) != 0) {
-        svg(file=filename, width=10, heigh=10)
-        plot(graph, layout=layout, frame=TRUE)
-        dev.off()
-    } else  if (length(grep("\\.csv$", filename)) != 0) {
-        write.table(graphData, file=filename, row.names=FALSE, sep=',')
-    } else  if (length(grep("\\.txt$", filename)) != 0) {
-        write.table(graphData, file=filename, row.names=FALSE, sep='\t')
-    } else {
-        plot(graph)
-    }
-}
-
-packages <- c("PEcAn.BIOCRO", "PEcAn.DB", "PEcAn.ED2", "PEcAn.MA",
-              "PEcAn.SIPNET", "PEcAn.assim.batch", "PEcAn.assim.sequential",
-              "PEcAn.data.atmosphere", "PEcAn.data.land", "PEcAn.priors",
-              "PEcAn.settings", "PEcAn.uncertainty", "PEcAn.utils",
-              "PEcAn.visualization")
-
-#dependencygraph(packages, suggests=FALSE, filename="graph.png")
-dependencygraph(packages, suggests=TRUE, filename="graph.png", filter="PEcAn")
+# dependencygraph(packages, suggests=FALSE, filename='graph.png')
+dependencygraph(packages, suggests = TRUE, filename = "graph.png", filter = "PEcAn")

--- a/scripts/install.dependencies.R
+++ b/scripts/install.dependencies.R
@@ -1,8 +1,11 @@
 #!/usr/bin/env Rscript
 #-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.  All rights reserved. This program and the accompanying materials are made
-# available under the terms of the University of Illinois/NCSA Open Source License which accompanies this distribution, and is
-# available at http://opensource.ncsa.illinois.edu/license.html
+# Copyright (c) 2012 University of Illinois, NCSA.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the 
+# University of Illinois/NCSA Open Source License
+# which accompanies this distribution, and is available at
+# http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
 
 # install graph for MCMCpack for allometry module

--- a/scripts/install.dependencies.R
+++ b/scripts/install.dependencies.R
@@ -1,61 +1,58 @@
 #!/usr/bin/env Rscript
 #-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
-# University of Illinois/NCSA Open Source License
-# which accompanies this distribution, and is available at
-# http://opensource.ncsa.illinois.edu/license.html
+# Copyright (c) 2012 University of Illinois, NCSA.  All rights reserved. This program and the accompanying materials are made
+# available under the terms of the University of Illinois/NCSA Open Source License which accompanies this distribution, and is
+# available at http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
 
 # install graph for MCMCpack for allometry module
-if(!("graph" %in% installed.packages()[,"Package"])) {
+if (!("graph" %in% installed.packages()[, "Package"])) {
   source("http://bioconductor.org/biocLite.R")
-  biocLite('graph')
+  biocLite("graph")
 }
 
-#install Rgraphviz for MCMCpack for allometry module
-if(!("Rgraphviz" %in% installed.packages()[,"Package"])) {
+# install Rgraphviz for MCMCpack for allometry module
+if (!("Rgraphviz" %in% installed.packages()[, "Package"])) {
   source("http://bioconductor.org/biocLite.R")
-  biocLite('Rgraphviz')
+  biocLite("Rgraphviz")
 }
 
 # install packages needed from CRAN
-list.of.packages <- c('abind', 'car', 'chron', 'coda', 'data.table', 'doSNOW', 'dplR', 'earth', 'emulator',
-                      'ggmap', 'ggplot2', 'gridExtra', 'Hmisc', 'httr', 'kernlab','GPfit',
-                      'knitr', 'lubridate', 'Maeswrap','MASS', 'MCMCpack', 'mvtnorm', 'ncdf4',
-                      'plotrix', 'plyr', 'raster', 'randtoolbox', 'rjags',
-                      'rgdal', 'tgp', 'DBI', 'roxygen2', 'stringr', 'testthat', 'boot',
-                      'XML', 'RNCEP', 'foreign', 'RCurl', 'udunits2', 'RPostgreSQL',
-                      'rPython','minpack.lm', 'mclust', 'geonames', 'Rcpp','devtools', 'inline', 'segmented',
-                      'msm', 'dplyr', 'shiny', 'scales', 'maps', 'sp')
-new.packages <- list.of.packages[!(list.of.packages %in% installed.packages()[,"Package"])]
-if(length(new.packages)) {
+list.of.packages <- c("abind", "car", "chron", "coda", "data.table", "doSNOW", "dplR", "earth", 
+                      "emulator", "ggmap", "ggplot2", "gridExtra", "Hmisc", "httr", "kernlab", 
+                      "GPfit", "knitr", "lubridate", "Maeswrap", "MASS", "MCMCpack", "mvtnorm", "ncdf4", 
+                      "plotrix", "plyr", "raster", "randtoolbox", "rjags", "rgdal", "tgp", "DBI", 
+                      "roxygen2", "stringr", "testthat", "boot", "XML", "RNCEP", "foreign", 
+                      "RCurl", "udunits2", "RPostgreSQL", "rPython", "minpack.lm", "mclust", 
+                      "geonames", "Rcpp", "devtools", "inline", "segmented", "msm", "dplyr", 
+                      "shiny", "scales", "maps", "sp")
+new.packages <- list.of.packages[!(list.of.packages %in% installed.packages()[, "Package"])]
+if (length(new.packages)) {
   print("installing : ")
   print(new.packages)
-  install.packages(new.packages, repos="http://cran.rstudio.com/")
-	
-warning("If Maeswrap Package download fails, please refer to PEcAn documentation for download instructions")
+  install.packages(new.packages, repos = "http://cran.rstudio.com/")
+  
+  warning("If Maeswrap Package download fails, please refer to PEcAn documentation for download instructions")
 }
 
 # install packages from forge
-if(!("REddyProc" %in% installed.packages()[,"Package"])) {
-  install.packages("REddyProc", repos="http://R-Forge.R-project.org", type="source")
+if (!("REddyProc" %in% installed.packages()[, "Package"])) {
+  install.packages("REddyProc", repos = "http://R-Forge.R-project.org", type = "source")
 }
 
 # install packages from github
-if(!("BioCro" %in% installed.packages()[,"Package"])) {
+if (!("BioCro" %in% installed.packages()[, "Package"])) {
   devtools::install_github("ebimodeling/biocro")
 }
 
 # BayesianTools package snapshot
-if(!("BayesianTools" %in% installed.packages()[,"Package"])) {
+if (!("BayesianTools" %in% installed.packages()[, "Package"])) {
   devtools::install_url("https://dl.dropboxusercontent.com/s/ccvpnvblf3vzuvs/BayesianTools_0.0.0.9000.tar.gz")
 }
 
 
 # install rhdf5 from bioconductor for met2model.ED
-if(!("rhdf5" %in% installed.packages()[,"Package"])) {
+if (!("rhdf5" %in% installed.packages()[, "Package"])) {
   source("http://bioconductor.org/biocLite.R")
-  biocLite('rhdf5')
+  biocLite("rhdf5")
 }

--- a/scripts/pft.add.spp.R
+++ b/scripts/pft.add.spp.R
@@ -1,7 +1,10 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.  All rights reserved. This program and the accompanying materials are made
-# available under the terms of the University of Illinois/NCSA Open Source License which accompanies this distribution, and is
-# available at http://opensource.ncsa.illinois.edu/license.html
+# Copyright (c) 2012 University of Illinois, NCSA.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the 
+# University of Illinois/NCSA Open Source License
+# which accompanies this distribution, and is available at
+# http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
 ## M. Dietze
 ##' adds a list of species to a pft based on USDA Plants acronyms

--- a/scripts/pft.add.spp.R
+++ b/scripts/pft.add.spp.R
@@ -1,10 +1,7 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
-# University of Illinois/NCSA Open Source License
-# which accompanies this distribution, and is available at
-# http://opensource.ncsa.illinois.edu/license.html
+# Copyright (c) 2012 University of Illinois, NCSA.  All rights reserved. This program and the accompanying materials are made
+# available under the terms of the University of Illinois/NCSA Open Source License which accompanies this distribution, and is
+# available at http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
 ## M. Dietze
 ##' adds a list of species to a pft based on USDA Plants acronyms
@@ -18,24 +15,24 @@
 ##' @param ... optional arguements for connecting to database (e.g. password, user name, database)
 ##' @return Function does not return a value but does print out diagnostic statements.
 ##' @author Michael C. Dietze
-pft.add.spp <- function(pft,acronym,test=TRUE,con=NULL,...){
-
+pft.add.spp <- function(pft, acronym, test = TRUE, con = NULL, ...) {
+  
   ## establish database connection
-  if(is.null(con)){
+  if (is.null(con)) {
     con <- query.bety.con(...)
   }
-
+  
   ## look up pfts.id based on pfts.name
-  q = dbSendQuery(con,paste('select * from pfts where name ="',pft,'"',sep=""))
-  my.pft = fetch(q,n = -1)
+  q <- dbSendQuery(con, paste0("select * from pfts where name =\"", pft, "\""))
+  my.pft <- fetch(q, n = -1)
   
   ## if pfts.name does not exist, stop and send error
-  if(nrow(my.pft) != 1 ){
+  if (nrow(my.pft) != 1) {
     print("PFT did not match uniquely.  Match=")
     print(my.pft)
     print("Similar pfts")
-    q = dbSendQuery(con,paste('select * from pfts where name like "%',pft,'%"',sep=""))
-    print(fetch(q,n=-1))
+    q <- dbSendQuery(con, paste0("select * from pfts where name like \"%", pft, "%\""))
+    print(fetch(q, n = -1))
     return()
   } else {
     print("using PFT:")
@@ -43,53 +40,51 @@ pft.add.spp <- function(pft,acronym,test=TRUE,con=NULL,...){
   }
   
   ## loop over acronyms
-  for(acro in acronym){
-  
+  for (acro in acronym) {
+    
     ## look up plant_id based on acronyms
-    q = dbSendQuery(con,paste("select id, ScientificName,Symbol from plants where Symbol = '",acro,"'",sep=""))  
-    my.plant = fetch(q,n = -1 )
-    if(nrow(my.plant) != 1){
-      print(c("ACRONYM not matched",acro))
+    q <- dbSendQuery(con, paste0("select id, ScientificName,Symbol from plants where Symbol = '", acro, "'"))
+    my.plant <- fetch(q, n = -1)
+    if (nrow(my.plant) != 1) {
+      print(c("ACRONYM not matched", acro))
       print(my.plant)
-      next()
+      next
     }
     
     ## look up species.id based on plant_id
-    q = dbSendQuery(con,paste("select * from species where plant_id = '",my.plant$id,"'",sep=""))
-    my.species = fetch(q,n=-1)
-    if(nrow(my.species) != 1){
-      print(c("PLANT_ID not matched",acro,my.plant$id))
+    q <- dbSendQuery(con, paste0("select * from species where plant_id = '", my.plant$id, "'"))
+    my.species <- fetch(q, n = -1)
+    if (nrow(my.species) != 1) {
+      print(c("PLANT_ID not matched", acro, my.plant$id))
       print(my.species)
-      next()
+      next
     }
-
+    
     ## look up pfts_species.specie_id to check for duplicates
-    q = dbSendQuery(con,paste("select * from pfts_species where pft_id = '",my.pft$id,"' and specie_id = '",my.species$id,"'",sep=""))
-    my.pft2spp = fetch(q,n = -1)
-    if(nrow(my.pft2spp) > 0){
-      print(c("Species already exists for PFT",acro))
+    q <- dbSendQuery(con, paste0("select * from pfts_species where pft_id = '", my.pft$id, "' and specie_id = '", my.species$id, 
+                                 "'"))
+    my.pft2spp <- fetch(q, n = -1)
+    if (nrow(my.pft2spp) > 0) {
+      print(c("Species already exists for PFT", acro))
       print(my.species)
-      next()
+      next
     }
-
     
     ## give list of species
-    print(c("ADDING",acro))
-    #print(my.plant)
-    #print(my.species)
-    if(test){
-    #  print("TEST ONLY")
-      next()
+    print(c("ADDING", acro))
+    # print(my.plant) print(my.species)
+    if (test) {
+      # print('TEST ONLY')
+      next
     }
-  
-    ## if a species is not already in the pft, add
-    q = dbSendQuery(con,paste("insert into pfts_species set pft_id = '",my.pft$id,"', specie_id = '",my.species$id,"'",sep=""))
     
-
-  } ## end loop over acronyms
-
-  if(test){
+    ## if a species is not already in the pft, add
+    q <- dbSendQuery(con, paste0("insert into pfts_species set pft_id = '", my.pft$id, "', specie_id = '", my.species$id, "'"))
+    
+  }  ## end loop over acronyms
+  
+  if (test) {
     print("THIS WAS A TEST, NO SPECIES WERE ADDED. SET 'test = FALSE' TO COMMIT CHANGES")
   }
-
-}
+  
+} # pft.add.spp

--- a/scripts/quickbuild.R
+++ b/scripts/quickbuild.R
@@ -3,8 +3,7 @@
 library(devtools)
 dev_mode(on = TRUE)
 
-lapply(list("utils", "db", "settings", "visualization", "modules/priors", "modules/meta.analysis",
-            "modules/uncertainty", "modules/data.land", "modules/data.atmosphere", "modules/assim.batch",
-            "modules/assim.sequential", "models/ed", "models/sipnet", "models/biocro", "all"),
+lapply(list("utils", "db", "settings", "visualization", "modules/priors", "modules/meta.analysis", 
+            "modules/uncertainty", "modules/data.land", "modules/data.atmosphere", "modules/assim.batch", 
+            "modules/assim.sequential", "models/ed", "models/sipnet", "models/biocro", "all"), 
        function(x) install(x, quick = TRUE, local = TRUE, quiet = TRUE))
-

--- a/scripts/workflow.bm.R
+++ b/scripts/workflow.bm.R
@@ -1,11 +1,15 @@
 #!/usr/bin/env Rscript
 #-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.  All rights reserved. This program and the accompanying materials are made
-# available under the terms of the University of Illinois/NCSA Open Source License which accompanies this distribution, and is
-# available at http://opensource.ncsa.illinois.edu/license.html
+# Copyright (c) 2012 University of Illinois, NCSA.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the 
+# University of Illinois/NCSA Open Source License
+# which accompanies this distribution, and is available at
+# http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
 
-# ---------------------------------------------------------------------- Load required libraries
+# ----------------------------------------------------------------------
+# Load required libraries
 # ----------------------------------------------------------------------
 library(PEcAn.all)
 library(RCurl)
@@ -74,8 +78,10 @@ options(error = quote({
 }))
 
 
-# ---------------------------------------------------------------------- PEcAn Workflow
-# ---------------------------------------------------------------------- Open and read in settings file for PEcAn run.
+# ---------------------------------------------------------------------- 
+# PEcAn Workflow
+# ---------------------------------------------------------------------- 
+# Open and read in settings file for PEcAn run.
 args <- commandArgs(trailingOnly = TRUE)
 # if (is.na(args[1])){ settings <- read.settings('pecan.xml') } else { settings.file = args[1] settings <-
 # read.settings(settings.file) }

--- a/scripts/workflow.bm.R
+++ b/scripts/workflow.bm.R
@@ -1,15 +1,11 @@
 #!/usr/bin/env Rscript
 #-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
-# University of Illinois/NCSA Open Source License
-# which accompanies this distribution, and is available at
-# http://opensource.ncsa.illinois.edu/license.html
+# Copyright (c) 2012 University of Illinois, NCSA.  All rights reserved. This program and the accompanying materials are made
+# available under the terms of the University of Illinois/NCSA Open Source License which accompanies this distribution, and is
+# available at http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
 
-# ----------------------------------------------------------------------
-# Load required libraries
+# ---------------------------------------------------------------------- Load required libraries
 # ----------------------------------------------------------------------
 library(PEcAn.all)
 library(RCurl)
@@ -19,53 +15,43 @@ library(RCurl)
 #--------------------------------------------------------------------------------#
 status.start <- function(name) {
   if (exists("settings")) {
-    cat(paste(name,
-              format(Sys.time(), "%F %T"), sep="\t"),
-        file=file.path(settings$outdir, "STATUS"), append=TRUE)
+    cat(paste(name, format(Sys.time(), "%F %T"), sep = "\t"), file = file.path(settings$outdir, "STATUS"), append = TRUE)
   }
 }
-status.end <- function(status="DONE") {
+status.end <- function(status = "DONE") {
   if (exists("settings")) {
-    cat(paste("",
-              format(Sys.time(), "%F %T"),
-              status,
-              "\n", sep="\t"),
-        file=file.path(settings$outdir, "STATUS"), append=TRUE)
+    cat(paste("", format(Sys.time(), "%F %T"), status, "\n", sep = "\t"), file = file.path(settings$outdir, "STATUS"), append = TRUE)
   }
 }
 status.skip <- function(name) {
   if (exists("settings")) {
-    cat(paste(name,
-              format(Sys.time(), "%F %T"),
-              "",
-              format(Sys.time(), "%F %T"),
-              "SKIPPED",
-              "\n", sep="\t"),
-        file=file.path(settings$outdir, "STATUS"), append=TRUE)
+    cat(paste(name, format(Sys.time(), "%F %T"), "", format(Sys.time(), "%F %T"), "SKIPPED", "\n", sep = "\t"), file = file.path(settings$outdir, 
+                                                                                                                                 "STATUS"), append = TRUE)
   }
 }
 status.check <- function(name) {
-  if (!exists("settings")) return (0)
-  status.file=file.path(settings$outdir, "STATUS")
-  if (!file.exists(status.file)){
-    return (0)
+  if (!exists("settings")) 
+    return(0)
+  status.file <- file.path(settings$outdir, "STATUS")
+  if (!file.exists(status.file)) {
+    return(0)
   }
-  status.data <- read.table(status.file, row.names=1, header=FALSE, sep="\t", quote="", fill=TRUE)
-  if (! name %in% row.names(status.data)) {
-    return (0)
+  status.data <- read.table(status.file, row.names = 1, header = FALSE, sep = "\t", quote = "", fill = TRUE)
+  if (!name %in% row.names(status.data)) {
+    return(0)
   }
-  status.data[name,]
+  status.data[name, ]
   if (is.na(status.data[name, 3])) {
     logger.warn("UNKNOWN STATUS FOR", name)
-    return (0)
+    return(0)
   }
   if (status.data[name, 3] == "DONE") {
-    return (1)
+    return(1)
   }
   if (status.data[name, 3] == "ERROR") {
-    return (-1)
+    return(-1)
   }
-  return (0)
+  return(0)
 }
 kill.tunnel <- function() {
   if (exists("settings") && !is.null(settings$run$host$tunnel)) {
@@ -78,8 +64,8 @@ kill.tunnel <- function() {
 }
 
 # make sure always to call status.end
-options(warn=1)
-options(error=quote({
+options(warn = 1)
+options(error = quote({
   status.end("ERROR")
   kill.tunnel()
   if (!interactive()) {
@@ -87,20 +73,12 @@ options(error=quote({
   }
 }))
 
-#options(warning.expression=status.end("ERROR"))
 
-
-# ----------------------------------------------------------------------
-# PEcAn Workflow
-# ----------------------------------------------------------------------
-# Open and read in settings file for PEcAn run.
+# ---------------------------------------------------------------------- PEcAn Workflow
+# ---------------------------------------------------------------------- Open and read in settings file for PEcAn run.
 args <- commandArgs(trailingOnly = TRUE)
-# if (is.na(args[1])){
-#   settings <- read.settings("pecan.xml")
-# } else {
-#   settings.file = args[1]
-#   settings <- read.settings(settings.file)
-# }
+# if (is.na(args[1])){ settings <- read.settings('pecan.xml') } else { settings.file = args[1] settings <-
+# read.settings(settings.file) }
 
 settings <- read.settings(settings.file)
 
@@ -111,14 +89,16 @@ if (length(which(commandArgs() == "--continue")) == 0) {
 
 # Do conversions
 needsave <- FALSE
-for(i in 1:length(settings$run$inputs)) {
+for (i in seq_along(settings$run$inputs)) {
   input <- settings$run$inputs[[i]]
-  if (is.null(input)) next
+  if (is.null(input)) {
+    next
+  }
   
   input.tag <- names(settings$run$input)[i]
   
   # fia database
-  if ((input['input'] == 'fia') && (status.check("FIA2ED") == 0)) {
+  if ((input["input"] == "fia") && (status.check("FIA2ED") == 0)) {
     status.start("FIA2ED")
     fia.to.psscss(settings)
     status.end()
@@ -126,66 +106,70 @@ for(i in 1:length(settings$run$inputs)) {
   }
   
   # met conversion
-  if(input.tag == 'met') {
+  if (input.tag == "met") {
     name <- ifelse(is.null(settings$browndog), "MET Process", "BrownDog")
     if (is.null(input$path) && (status.check(name) == 0)) {
       status.start(name)
-      result <- PEcAn.data.atmosphere::met.process(
-        site       = settings$run$site, 
-        input_met  = settings$run$inputs$met,
-        start_date = settings$run$start.date,
-        end_date   = settings$run$end.date,
-        model      = settings$model$type,
-        host       = settings$run$host,
-        dbparms    = settings$database$bety, 
-        dir        = settings$run$dbfiles,
-        browndog   = settings$browndog)
-      settings$run$inputs[[i]][['path']] <- result
+      result <- PEcAn.data.atmosphere::met.process(site = settings$run$site, 
+                                                   input_met = settings$run$inputs$met, 
+                                                   start_date = settings$run$start.date, 
+                                                   end_date = settings$run$end.date, 
+                                                   model = settings$model$type, 
+                                                   host = settings$run$host, 
+                                                   dbparms = settings$database$bety, 
+                                                   dir = settings$run$dbfiles, 
+                                                   browndog = settings$browndog)
+      settings$run$inputs[[i]][["path"]] <- result
       status.end()
       needsave <- TRUE
     }
   }
 }
 if (needsave) {
-  saveXML(listToXml(settings, "pecan"), file=file.path(settings$outdir, 'pecan.METProcess.xml'))  
-} else if (file.exists(file.path(settings$outdir, 'pecan.METProcess.xml'))) {
-  settings <- read.settings(file.path(settings$outdir, 'pecan.METProcess.xml'))
+  saveXML(listToXml(settings, "pecan"), file = file.path(settings$outdir, "pecan.METProcess.xml"))
+} else if (file.exists(file.path(settings$outdir, "pecan.METProcess.xml"))) {
+  settings <- read.settings(file.path(settings$outdir, "pecan.METProcess.xml"))
 }
-
 
 # Query the trait database for data and priors
-if (status.check("TRAIT") == 0){
+if (status.check("TRAIT") == 0) {
   status.start("TRAIT")
   settings$pfts <- get.trait.data(settings$pfts, settings$model$type, settings$run$dbfiles, settings$database$bety, settings$meta.analysis$update)
-  saveXML(listToXml(settings, "pecan"), file=file.path(settings$outdir, 'pecan.TRAIT.xml'))
+  saveXML(listToXml(settings, "pecan"), file = file.path(settings$outdir, "pecan.TRAIT.xml"))
   status.end()
-} else if (file.exists(file.path(settings$outdir, 'pecan.TRAIT.xml'))) {
-  settings <- read.settings(file.path(settings$outdir, 'pecan.TRAIT.xml'))
+} else if (file.exists(file.path(settings$outdir, "pecan.TRAIT.xml"))) {
+  settings <- read.settings(file.path(settings$outdir, "pecan.TRAIT.xml"))
 }
 
-
 # Run the PEcAn meta.analysis
-if('meta.analysis' %in% names(settings)) {
-  if (status.check("META") == 0){
+if ("meta.analysis" %in% names(settings)) {
+  if (status.check("META") == 0) {
     status.start("META")
-    run.meta.analysis(settings$pfts, settings$meta.analysis$iter, settings$meta.analysis$random.effects, settings$meta.analysis$threshold, settings$run$dbfiles, settings$database$bety)
+    run.meta.analysis(settings$pfts, 
+                      settings$meta.analysis$iter, 
+                      settings$meta.analysis$random.effects, 
+                      settings$meta.analysis$threshold, 
+                      settings$run$dbfiles, 
+                      settings$database$bety)
     status.end()
   }
 }
 
 # Write model specific configs
-if (status.check("CONFIG") == 0){
+if (status.check("CONFIG") == 0) {
   status.start("CONFIG")
-  settings <- run.write.configs(settings, write=settings$database$bety$write, ens.sample.method=settings$ensemble$method)
-  saveXML(listToXml(settings, "pecan"), file=file.path(settings$outdir, 'pecan.CONFIGS.xml'))
+  settings <- run.write.configs(settings, 
+                                write = settings$database$bety$write, 
+                                ens.sample.method = settings$ensemble$method)
+  saveXML(listToXml(settings, "pecan"), file = file.path(settings$outdir, "pecan.CONFIGS.xml"))
   status.end()
-} else if (file.exists(file.path(settings$outdir, 'pecan.CONFIGS.xml'))) {
-  settings <- read.settings(file.path(settings$outdir, 'pecan.CONFIGS.xml'))
+} else if (file.exists(file.path(settings$outdir, "pecan.CONFIGS.xml"))) {
+  settings <- read.settings(file.path(settings$outdir, "pecan.CONFIGS.xml"))
 }
 
 if ((length(which(commandArgs() == "--advanced")) != 0) && (status.check("ADVANCED") == 0)) {
   status.start("ADVANCED")
-  q();
+  q()
 }
 
 # Start ecosystem model runs
@@ -202,10 +186,10 @@ if (status.check("OUTPUT") == 0) {
   status.end()
 }
 
-# Run ensemble analysis on model output. 
+# Run ensemble analysis on model output.
 if (status.check("ENSEMBLE") == 0) {
   status.start("ENSEMBLE")
-  run.ensemble.analysis(TRUE)    
+  run.ensemble.analysis(TRUE)
   status.end()
 }
 
@@ -217,7 +201,7 @@ if (status.check("SENSITIVITY") == 0) {
 }
 
 # Run parameter data assimilation
-if ('assim.batch' %in% names(settings)) {
+if ("assim.batch" %in% names(settings)) {
   if (status.check("PDA") == 0) {
     status.start("PDA")
     settings <- assim.batch(settings)
@@ -229,13 +213,12 @@ if ('assim.batch' %in% names(settings)) {
 if (status.check("FINISHED") == 0) {
   status.start("FINISHED")
   kill.tunnel()
-  db.query(paste("UPDATE workflows SET finished_at=NOW() WHERE id=", settings$workflow$id, "AND finished_at IS NULL"), params=settings$database$bety)
+  db.query(paste("UPDATE workflows SET finished_at=NOW() WHERE id=", settings$workflow$id, "AND finished_at IS NULL"), params = settings$database$bety)
   
   # Send email if configured
   if (!is.null(settings$email) && !is.null(settings$email$to) && (settings$email$to != "")) {
-    sendmail(settings$email$from, settings$email$to,
-             paste0("Workflow has finished executing at ", date()),
-             paste0("You can find the results on ", settings$email$url))
+    sendmail(settings$email$from, settings$email$to, paste0("Workflow has finished executing at ", date()), paste0("You can find the results on ", 
+                                                                                                                   settings$email$url))
   }
   status.end()
 }

--- a/scripts/workflow.pda.R
+++ b/scripts/workflow.pda.R
@@ -1,12 +1,16 @@
 #!/usr/bin/env Rscript
 args <- commandArgs(trailingOnly = TRUE)
 #-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.  All rights reserved. This program and the accompanying materials are made
-# available under the terms of the University of Illinois/NCSA Open Source License which accompanies this distribution, and is
-# available at http://opensource.ncsa.illinois.edu/license.html
+# Copyright (c) 2012 University of Illinois, NCSA.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the 
+# University of Illinois/NCSA Open Source License
+# which accompanies this distribution, and is available at
+# http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
 
-# ---------------------------------------------------------------------- Load required libraries
+# ---------------------------------------------------------------------- 
+# Load required libraries
 # ----------------------------------------------------------------------
 library(PEcAn.all)
 library(RCurl)
@@ -38,8 +42,10 @@ options(error = quote({
 # options(warning.expression=status.end('ERROR'))
 
 
-# ---------------------------------------------------------------------- PEcAn Workflow
-# ---------------------------------------------------------------------- Open and read in settings file for PEcAn run.
+# ---------------------------------------------------------------------- 
+# PEcAn Workflow
+# ---------------------------------------------------------------------- 
+# Open and read in settings file for PEcAn run.
 if (is.na(args[1])) {
   settings <- read.settings("pecan.xml")
 } else {
@@ -93,7 +99,7 @@ if (length(which(commandArgs() == "--continue")) == 0) {
   
   # Check status to avoid repeating work
   check.status <- function(check.name) {
-    status.file <- file.path(settings$outdir, "STATU")
+    status.file <- file.path(settings$outdir, "STATUS")
     if (!file.exists(status.file)) {
       return(0)
     }
@@ -193,7 +199,7 @@ if (check.status("SENSITIVITY") == 0) {
 }
 
 # Run parameter data assimilation
-if (("assim.batch" %in% names(settings))) {
+if ("assim.batch" %in% names(settings)) {
   status.start("PDA")
   settings$assim.batch <- pda.mcmc(settings)
   status.end()

--- a/scripts/workflow.pda.R
+++ b/scripts/workflow.pda.R
@@ -1,16 +1,12 @@
 #!/usr/bin/env Rscript
 args <- commandArgs(trailingOnly = TRUE)
 #-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
-# University of Illinois/NCSA Open Source License
-# which accompanies this distribution, and is available at
-# http://opensource.ncsa.illinois.edu/license.html
+# Copyright (c) 2012 University of Illinois, NCSA.  All rights reserved. This program and the accompanying materials are made
+# available under the terms of the University of Illinois/NCSA Open Source License which accompanies this distribution, and is
+# available at http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
 
-# ----------------------------------------------------------------------
-# Load required libraries
+# ---------------------------------------------------------------------- Load required libraries
 # ----------------------------------------------------------------------
 library(PEcAn.all)
 library(RCurl)
@@ -19,155 +15,151 @@ library(RCurl)
 # Functions used to write STATUS used by history
 #--------------------------------------------------------------------------------#
 status.start <- function(name) {
-  cat(paste(name,
-            format(Sys.time(), "%F %T"), sep="\t"),
-      file=file.path(settings$outdir, "STATUS"), append=TRUE)
+  cat(paste(name, format(Sys.time(), "%F %T"), sep = "\t"), 
+      file = file.path(settings$outdir, "STATUS"), append = TRUE)
 }
-status.end <- function(status="DONE") {
-  cat(paste("",
-            format(Sys.time(), "%F %T"),
-            status,
-            "\n", sep="\t"),
-      file=file.path(settings$outdir, "STATUS"), append=TRUE)
+status.end <- function(status = "DONE") {
+  cat(paste("", format(Sys.time(), "%F %T"), status, "\n", sep = "\t"), 
+      file = file.path(settings$outdir, "STATUS"), append = TRUE)
 }
 status.skip <- function(name) {
-  cat(paste(name,
-            format(Sys.time(), "%F %T"),
-            "",
-            format(Sys.time(), "%F %T"),
-            "SKIPPED",
-            "\n", sep="\t"),
-      file=file.path(settings$outdir, "STATUS"), append=TRUE)
+  cat(paste(name, format(Sys.time(), "%F %T"), "", format(Sys.time(), "%F %T"), "SKIPPED", "\n", sep = "\t"), 
+      file = file.path(settings$outdir, "STATUS"), append = TRUE)
 }
 
-options(warn=1)
-options(error=quote({
+options(warn = 1)
+options(error = quote({
   status.end("ERROR")
   if (!interactive()) {
     q()
   }
 }))
 
-#options(warning.expression=status.end("ERROR"))
+# options(warning.expression=status.end('ERROR'))
 
 
-# ----------------------------------------------------------------------
-# PEcAn Workflow
-# ----------------------------------------------------------------------
-# Open and read in settings file for PEcAn run.
-if (is.na(args[1])){
+# ---------------------------------------------------------------------- PEcAn Workflow
+# ---------------------------------------------------------------------- Open and read in settings file for PEcAn run.
+if (is.na(args[1])) {
   settings <- read.settings("pecan.xml")
 } else {
-  settings.file = args[1]
+  settings.file <- args[1]
   settings <- read.settings(settings.file)
 }
 
 if (length(which(commandArgs() == "--continue")) == 0) {
   # Remove existing STATUS file
   file.remove(file.path(settings$outdir, "STATUS"))
-  #unlink(file.path(settings$outdir, "STATUS"))
   
   # Do conversions
-  for(i in 1:length(settings$run$inputs)) {
+  for (i in seq_along(settings$run$inputs)) {
     input <- settings$run$inputs[[i]]
-    if (is.null(input)) next
+    if (is.null(input)) {
+      next
+    }
     
     input.tag <- names(settings$run$input)[i]
     
     # fia database
-    if (input['input'] == 'fia') {
+    if (input["input"] == "fia") {
       status.start("FIA2ED")
       fia.to.psscss(settings)
       status.end()
     }
     
     # met conversion
-    if(input.tag == 'met') {
+    if (input.tag == "met") {
       if (is.null(input$path)) {
         if (is.null(settings$browndog)) {
           status.start("MET Process")
         } else {
           status.start("BrownDog")
         }
-        result <- PEcAn.data.atmosphere::met.process(
-          site       = settings$run$site, 
-          input_met  = settings$run$inputs$met,
-          start_date = settings$run$start.date,
-          end_date   = settings$run$end.date,
-          model      = settings$model$type,
-          host       = settings$host,
-          dbparms    = settings$database$bety, 
-          dir        = settings$database$dbfiles,
-          browndog   = settings$browndog)
-        settings$run$inputs[[i]][['path']] <- result
+        result <- PEcAn.data.atmosphere::met.process(site = settings$run$site, 
+                                                     input_met = settings$run$inputs$met, 
+                                                     start_date = settings$run$start.date, 
+                                                     end_date = settings$run$end.date, 
+                                                     model = settings$model$type, 
+                                                     host = settings$host, 
+                                                     dbparms = settings$database$bety, 
+                                                     dir = settings$database$dbfiles, 
+                                                     browndog = settings$browndog)
+        settings$run$inputs[[i]][["path"]] <- result
         status.end()
       }
     }
   }
-  saveXML(listToXml(settings, "pecan"), file=file.path(settings$outdir, 'pecan.METProcess.xml'))
-
+  saveXML(listToXml(settings, "pecan"), file = file.path(settings$outdir, "pecan.METProcess.xml"))
+  
   # Check status to avoid repeating work
-  check.status <- function(check.name){
-    status.file=file.path(settings$outdir, "STATU")
-    if (!file.exists(status.file)){
-      return (0)
+  check.status <- function(check.name) {
+    status.file <- file.path(settings$outdir, "STATU")
+    if (!file.exists(status.file)) {
+      return(0)
     }
-    table <- read.table(status.file, header=FALSE)
-    for (i in 1: nrow(table))
-    {
-      if (table[i,1] == check.name ){
-        if(table[i, 6] == "DONE"){
-          return (1)
-        } else if (table[i,6] == "ERROR"){
-          return (-1)
+    table <- read.table(status.file, header = FALSE)
+    for (i in 1:nrow(table)) {
+      if (table[i, 1] == check.name) {
+        if (table[i, 6] == "DONE") {
+          return(1)
+        } else if (table[i, 6] == "ERROR") {
+          return(-1)
         } else {
-          return (0)
+          return(0)
         }
       }
     }
-    return (0)
+    return(0)
   }
-
+  
   # Query the trait database for data and priors
-  if (check.status("TRAIT") == 0){
+  if (check.status("TRAIT") == 0) {
     status.start("TRAIT")
-    settings$pfts <- get.trait.data(settings$pfts, settings$model$type, settings$database$dbfiles, settings$database$bety, settings$meta.analysis$update)
-    saveXML(listToXml(settings, "pecan"), file=file.path(settings$outdir, 'pecan.TRAIT.xml'))
+    settings$pfts <- get.trait.data(settings$pfts, 
+                                    settings$model$type, 
+                                    settings$database$dbfiles, 
+                                    settings$database$bety, 
+                                    settings$meta.analysis$update)
+    saveXML(listToXml(settings, "pecan"), file = file.path(settings$outdir, "pecan.TRAIT.xml"))
     status.end()
   }
   
   # Run the PEcAn meta.analysis
-  if (check.status("META") == 0){
+  if (check.status("META") == 0) {
     status.start("META")
-    if('meta.analysis' %in% names(settings)) {
-      run.meta.analysis(settings$pfts, settings$meta.analysis$iter, settings$meta.analysis$random.effects, settings$meta.analysis$threshold, settings$database$dbfiles, settings$database$bety)
+    if ("meta.analysis" %in% names(settings)) {
+      run.meta.analysis(settings$pfts, settings$meta.analysis$iter, 
+                        settings$meta.analysis$random.effects, 
+                        settings$meta.analysis$threshold, 
+                        settings$database$dbfiles, 
+                        settings$database$bety)
     }
     status.end()
   }
   
   # Write model specific configs
-  if (check.status("CONFIG") == 0){
+  if (check.status("CONFIG") == 0) {
     status.start("CONFIG")
-    settings <- run.write.configs(settings, write=settings$database$bety$write, ens.sample.method="halton")
-      saveXML(listToXml(settings, "pecan"), file=file.path(settings$outdir, 'pecan.CONFIGS.xml'))
+    settings <- run.write.configs(settings, write = settings$database$bety$write, ens.sample.method = "halton")
+    saveXML(listToXml(settings, "pecan"), file = file.path(settings$outdir, "pecan.CONFIGS.xml"))
     status.end()
   }
-    
+  
   if (length(which(commandArgs() == "--advanced")) != 0) {
     status.start("ADVANCED")
-    q();
+    q()
   }
 }
 
 # Start ecosystem model runs
-if (check.status("MODEL") == 0){
+if (check.status("MODEL") == 0) {
   status.start("MODEL")
   start.model.runs(settings, settings$database$bety$write)
   status.end()
 }
 
 # Get results of model runs
-if (check.status("OUTPUT") == 0){
+if (check.status("OUTPUT") == 0) {
   status.start("OUTPUT")
   get.results(settings)
   status.end()
@@ -175,60 +167,60 @@ if (check.status("OUTPUT") == 0){
 
 # Load observations for plotting with ensemble
 status.start("OBSERVATIONS")
-window = 6
-if(!is.null(settings$assim.batch$inputs)) {
-  con <- try(db.open(settings$database$bety), silent=TRUE)
+window <- 6
+if (!is.null(settings$assim.batch$inputs)) {
+  con <- try(db.open(settings$database$bety), silent = TRUE)
   inputs <- load.pda.data(settings$assim.batch$inputs, con)
   NEEo <- inputs[[1]]$NEEo
-  NEEo <- NEEo / (1000/12*1e6/10000/86400/365) #convert umol/m2/s -> kgC/ha/yr
+  NEEo <- NEEo/(1000/12 * 1e+06/10000/86400/365)  #convert umol/m2/s -> kgC/ha/yr
   db.close(con)
 } else {
   NEEo <- NULL
 }
 status.end()
 
-if (check.status("ENSEMBLE") == 0){
+if (check.status("ENSEMBLE") == 0) {
   status.start("ENSEMBLE")
-  run.ensemble.analysis(plot.timeseries=TRUE, observations=NEEo, window=window)
+  run.ensemble.analysis(plot.timeseries = TRUE, observations = NEEo, window = window)
   status.end()
 }
 
 # Run sensitivity analysis and variance decomposition on model output
-if (check.status("SENSITIVITY") == 0){
+if (check.status("SENSITIVITY") == 0) {
   status.start("SENSITIVITY")
   run.sensitivity.analysis()
   status.end()
 }
 
 # Run parameter data assimilation
-if(('assim.batch' %in% names(settings))) {
+if (("assim.batch" %in% names(settings))) {
   status.start("PDA")
   settings$assim.batch <- pda.mcmc(settings)
   status.end()
 }
 
-if(!is.null(settings$assim.batch)) {
+if (!is.null(settings$assim.batch)) {
   # Repeat sensitivity and ensemble analysis with PDA-constrained params
-
+  
   # Calls model specific write.configs e.g. write.config.ed.R
   status.start("PDA.CONFIG")
-  settings <- run.write.configs(settings, write=settings$database$bety$write, ens.sample.method="halton")
-    saveXML(listToXml(settings, "pecan"), file=file.path(settings$outdir, 'pecan.PDA.CONFIGS.xml'))
+  settings <- run.write.configs(settings, write = settings$database$bety$write, ens.sample.method = "halton")
+  saveXML(listToXml(settings, "pecan"), file = file.path(settings$outdir, "pecan.PDA.CONFIGS.xml"))
   status.end()
-
+  
   # Start ecosystem model runs
   status.start("PDA.MODEL")
   start.model.runs(settings, settings$database$bety$write)
   status.end()
-
+  
   # Get results of model runs
   status.start("PDA.OUTPUT")
   get.results(settings)
   status.end()
-
-  # Run ensemble analysis on model output. 
+  
+  # Run ensemble analysis on model output.
   status.start("PDA.ENSEMBLE")
-  run.ensemble.analysis(plot.timeseries=TRUE, observations=NEEo, window=window)
+  run.ensemble.analysis(plot.timeseries = TRUE, observations = NEEo, window = window)
   status.end()
   
   # Run sensitivity analysis and variance decomposition on model output
@@ -238,22 +230,24 @@ if(!is.null(settings$assim.batch)) {
 }
 
 # Pecan workflow complete
-if (check.status("FINISHED") == 0){
+if (check.status("FINISHED") == 0) {
   status.start("FINISHED")
-  db.query(paste("UPDATE workflows SET finished_at=NOW() WHERE id=", settings$workflow$id, "AND finished_at IS NULL"), params=settings$database$bety)
+  db.query(paste("UPDATE workflows SET finished_at=NOW() WHERE id=", settings$workflow$id, "AND finished_at IS NULL"), 
+           params = settings$database$bety)
   status.end()
 }
 
 # Send email if configured
 if (!is.null(settings$email) && !is.null(settings$email$to) && (settings$email$to != "")) {
-  sendmail(settings$email$from, settings$email$to,
-           paste0("Workflow has finished executing at ", date()),
+  sendmail(settings$email$from, settings$email$to, 
+           paste0("Workflow has finished executing at ", date()), 
            paste0("You can find the results on ", settings$email$url))
 }
 
 # Write end time in database
-if (settings$workflow$id != 'NA') {
-  db.query(paste0("UPDATE workflows SET finished_at=NOW() WHERE id=", settings$workflow$id, " AND finished_at IS NULL"), params=settings$database$bety)
+if (settings$workflow$id != "NA") {
+  db.query(paste0("UPDATE workflows SET finished_at=NOW() WHERE id=", settings$workflow$id, " AND finished_at IS NULL"), 
+           params = settings$database$bety)
 }
 status.end()
 

--- a/scripts/workflow.treering.R
+++ b/scripts/workflow.treering.R
@@ -6,11 +6,11 @@ options(warn = 1, keep.source = TRUE, error = quote({
 }))
 
 status.start <- function(name) {
-  cat(paste(name, format(Sys.time(), "%F %T"), sep="\t"), file=file.path(settings$outdir, "STATUS"), append=TRUE)      
+  cat(paste(name, format(Sys.time(), "%F %T"), sep = "\t"), file = file.path(settings$outdir, "STATUS"), append = TRUE)
 }
 
-status.end <- function(status="DONE") {
-  cat(paste("", format(Sys.time(), "%F %T"), status, "\n", sep="\t"), file=file.path(settings$outdir, "STATUS"), append=TRUE)      
+status.end <- function(status = "DONE") {
+  cat(paste("", format(Sys.time(), "%F %T"), status, "\n", sep = "\t"), file = file.path(settings$outdir, "STATUS"), append = TRUE)
 }
 
 #---------------- Load libraries. -----------------------------------------------------------------#
@@ -22,11 +22,11 @@ library(mvtnorm)
 library(rjags)
 library(reshape2)
 #--------------------------------------------------------------------------------------------------#
-#
+# 
 
 #---------------- Load PEcAn settings file. -------------------------------------------------------#
 # Open and read in settings file for PEcAn run.
-settings <- read.settings("pecan.SDA.xml") 
+settings <- read.settings("pecan.SDA.xml")
 #--------------------------------------------------------------------------------------------------#
 
 #---------------- Load plot and tree ring data. -------------------------------------------------------#
@@ -38,83 +38,85 @@ trees <- read.csv("~/Camp2016/ForestPlots/2016/TenderfootBog_2016_Cleaned.csv")
 rings <- Read_Tucson("~/Camp2016/ForestPlots/2016/TucsonCombined/")
 
 ## Match observations & format for JAGS
-combined <- matchInventoryRings(trees,rings,extractor="Tag",nyears=39,coredOnly=FALSE) #WARNINGS
-data <- buildJAGSdata_InventoryRings(combined) #WARNINGS
+combined <- matchInventoryRings(trees, rings, extractor = "Tag", nyears = 39, coredOnly = FALSE)  #WARNINGS
+data <- buildJAGSdata_InventoryRings(combined)  #WARNINGS
 status.end()
 
 #---------------- Load plot and tree ring data. -------------------------------------------------------#
 status.start("TREE RING MODEL")
 ## Tree Ring model
-n.iter = 5000
-jags.out = InventoryGrowthFusion(data,n.iter=n.iter)
-save(trees,rings,combined,data,jags.out,
-     file=file.path(settings$outdir,"treering.Rdata"))
+n.iter <- 5000
+jags.out <- InventoryGrowthFusion(data, n.iter = n.iter)
+save(trees, rings, combined, data, jags.out, file = file.path(settings$outdir, "treering.Rdata"))
 
-pdf(file.path(settings$outdir,"treering.Diagnostics.pdf"))
-InventoryGrowthFusionDiagnostics(jags.out,combined)
+pdf(file.path(settings$outdir, "treering.Diagnostics.pdf"))
+InventoryGrowthFusionDiagnostics(jags.out, combined)
 dev.off()
 status.end()
 
 #-------------- Allometry Model -------------------------------#
 status.start("ALLOMETRY")
 con <- db.open(settings$database$bety)
-pft.data = list()
-for(ipft in 1:length(settings$pfts)){  ## loop over PFTs
-  pft_name = settings$pfts[[ipft]]$name
-  query <- paste0("SELECT s.spcd,",'s."Symbol"'," as acronym from pfts as p join pfts_species on p.id = pfts_species.pft_id join species as s on pfts_species.specie_id = s.id where p.name like '%",pft_name,"%'")  
+pft.data <- list()
+for (ipft in seq_along(settings$pfts)) {
+  ## loop over PFTs
+  pft_name <- settings$pfts[[ipft]]$name
+  query <- paste0("SELECT s.spcd,", "s.\"Symbol\"", " as acronym from pfts as p join pfts_species on p.id = pfts_species.pft_id join species as s on pfts_species.specie_id = s.id where p.name like '%", 
+                  pft_name, "%'")
   pft.data[[pft_name]] <- db.query(query, con)
 }
-allom.stats = AllomAve(pft.data,outdir = settings$outdir,ngibbs=n.iter/10)
-save(allom.stats,file=file.path(settings$outdir,"allom.stats.Rdata"))
+allom.stats <- AllomAve(pft.data, outdir = settings$outdir, ngibbs = n.iter/10)
+save(allom.stats, file = file.path(settings$outdir, "allom.stats.Rdata"))
 status.end()
 
 #-------------- Convert tree-level growth & diameter to stand-level NPP & AGB -------------------------------#
 status.start("PLOT2AGB")
-out = as.matrix(jags.out)
-sel = grep('x[',colnames(out),fixed=TRUE)
-unit.conv = pi*10^2/10000
-state = plot2AGB(combined,out[,sel],settings$outdir,list(allom.stats[[2]]),unit.conv=unit.conv)
+out <- as.matrix(jags.out)
+sel <- grep("x[", colnames(out), fixed = TRUE)
+unit.conv <- pi * 10^2/10000
+state <- plot2AGB(combined, out[, sel], settings$outdir, list(allom.stats[[2]]), unit.conv = unit.conv)
 
-NPP.conv <- .48 #Mg/ha/yr -> MgC/ha/yr
-AGB.conv <- (1/10000)*(1000/1)*.48 #Mg/ha -> kgC/m2
+NPP.conv <- 0.48  #Mg/ha/yr -> MgC/ha/yr
+AGB.conv <- (1/10000) * (1000/1) * 0.48  #Mg/ha -> kgC/m2
 
-NPP = apply(state$NPP[1,,],2,mean,na.rm=TRUE)*NPP.conv##MgC/ha/yr 
-AGB = apply(state$AGB[1,,],2,mean,na.rm=TRUE)*AGB.conv#kgC/m2
+NPP <- apply(state$NPP[1, , ], 2, mean, na.rm = TRUE) * NPP.conv  # MgC/ha/yr 
+AGB <- apply(state$AGB[1, , ], 2, mean, na.rm = TRUE) * AGB.conv  # kgC/m2
 
 obs.mean <- list()
-for(i in 1:length(NPP)) {
-  obs.mean[[i]]<-c(NPP[i],AGB[i])
-  names(obs.mean[[i]])<-c("NPP",'AbvGrndWood')
+for (i in seq_along(NPP)) {
+  obs.mean[[i]] <- c(NPP[i], AGB[i])
+  names(obs.mean[[i]]) <- c("NPP", "AbvGrndWood")
 }
 
 obs.cov <- list()
-for(i in 1:length(NPP)){
-  obs.cov[[i]]<- cov(cbind(state$NPP[,,i]*NPP.conv,state$AGB[,,i]*AGB.conv))
-  colnames(obs.cov[[i]]) <- c("NPP","AbvGrndWood")
-  rownames(obs.cov[[i]]) <- c("NPP","AbvGrndWood")
+for (i in seq_along(NPP)) {
+  obs.cov[[i]] <- cov(cbind(state$NPP[, , i] * NPP.conv, state$AGB[, , i] * AGB.conv))
+  colnames(obs.cov[[i]]) <- c("NPP", "AbvGrndWood")
+  rownames(obs.cov[[i]]) <- c("NPP", "AbvGrndWood")
 }
 status.end()
 
 #---------------- Build Initial Conditions ----------------------------------------------------------------------#
 status.start("IC")
-ne = as.numeric(settings$state.data.assimilation$n.ensemble)
-IC = sample.IC.SIPNET(ne,state)
+ne <- as.numeric(settings$state.data.assimilation$n.ensemble)
+IC <- sample.IC.SIPNET(ne, state)
 status.end()
 
 #--------------- Assimilation -------------------------------------------------------#
 status.start("EnKF")
-sda.enkf(settings=settings, obs.mean = obs.mean,
-         obs.cov = obs.cov, IC = IC, Q = NULL)
+sda.enkf(settings = settings, obs.mean = obs.mean, obs.cov = obs.cov, IC = IC, Q = NULL)
 status.end()
 #--------------------------------------------------------------------------------------------------#
 ### PEcAn workflow run complete
 status.start("FINISHED")
-if (settings$workflow$id != 'NA') {
-  query.base(paste("UPDATE workflows SET finished_at=NOW() WHERE id=", settings$workflow$id, "AND finished_at IS NULL"),con)
+if (settings$workflow$id != "NA") {
+  query.base(paste("UPDATE workflows SET finished_at=NOW() WHERE id=", settings$workflow$id, "AND finished_at IS NULL"), con)
 }
 status.end()
 db.close(con)
-##close any open database connections
-for(i in dbListConnections(PostgreSQL())) db.close(i)
+## close any open database connections
+for (i in dbListConnections(PostgreSQL())) {
+  db.close(i)
+}
 print("---------- PEcAn Workflow Complete ----------")
 #--------------------------------------------------------------------------------------------------#


### PR DESCRIPTION
Ran through `formatR::tidy_dir`; added `@param` roxygen fields;
standardized indents; made sure all `if` blocks have braces; changed to
`paste0` where applicable; cracked down on over-length lines.