### PR TITLE
Style cleanup for `db/R/*.R` scripts

### DIFF
--- a/db/R/get.trait.data.R
+++ b/db/R/get.trait.data.R
@@ -1,7 +1,7 @@
 #-------------------------------------------------------------------------------
 # Copyright (c) 2012 University of Illinois, NCSA.
 # All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
+# are made available under the terms of the
 # University of Illinois/NCSA Open Source License
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
@@ -35,7 +35,7 @@ check.lists <- function(x, y) {
     return(FALSE)
   }
   return(TRUE)
-}
+} # check.lists
 
 ##--------------------------------------------------------------------------------------------------#
 ##' Get trait data from the database for a single pft
@@ -51,58 +51,60 @@ check.lists <- function(x, y) {
 ##' @author David LeBauer, Shawn Serbin, Rob Kooper
 ##' @export
 ##'
-get.trait.data.pft <- function(pft, modeltype, dbfiles, dbcon,
-                               forceupdate = TRUE,
-                               trait.names = traitdictionary$id) {
+get.trait.data.pft <- function(pft, modeltype, dbfiles, dbcon, forceupdate = TRUE, trait.names = traitdictionary$id) {
   ## Remove old files.  Clean up.
-  old.files <- list.files(path=pft$outdir, full.names=TRUE, include.dirs=FALSE)
+  old.files <- list.files(path = pft$outdir, full.names = TRUE, include.dirs = FALSE)
   file.remove(old.files)
-
+  
   # find appropriate pft
   if (is.null(modeltype)) {
-    pftid <- db.query(paste0("SELECT id FROM pfts WHERE name='", pft$name, "'"), dbcon)[['id']]
+    pftid <- db.query(paste0("SELECT id FROM pfts WHERE name='", pft$name, "'"), dbcon)[["id"]]
   } else {
-    pftid <- db.query(paste0("SELECT pfts.id FROM pfts, modeltypes WHERE pfts.name='", pft$name, "' and pfts.modeltype_id=modeltypes.id and modeltypes.name='", modeltype, "'"), dbcon)[['id']]
+    pftid <- db.query(paste0("SELECT pfts.id FROM pfts, modeltypes WHERE pfts.name='", pft$name, 
+                             "' and pfts.modeltype_id=modeltypes.id and modeltypes.name='", modeltype, "'"), dbcon)[["id"]]
   }
   if (is.null(pftid)) {
     logger.severe("Could not find pft, could not store file", filename)
     return(NA)
   }
-
+  
   # get the species, we need to check if anything changed
   species <- query.pft_species(pft$name, modeltype, dbcon)
   spstr <- vecpaste(species$id)
-
+  
   # get the priors
   prior.distns <- query.priors(pftid, vecpaste(trait.names), out = pft$outdir, con = dbcon)
-  prior.distns <- prior.distns[which(!rownames(prior.distns) %in% names(pft$constants)),]
-  traits <- rownames(prior.distns) 
-
+  prior.distns <- prior.distns[which(!rownames(prior.distns) %in% names(pft$constants)), ]
+  traits <- rownames(prior.distns)
+  
   # get the trait data (don't bother sampling derived traits until after update check)
-  trait.data.check <- query.traits(spstr, traits, con = dbcon, update.check.only=TRUE)
+  trait.data.check <- query.traits(spstr, traits, con = dbcon, update.check.only = TRUE)
   traits <- names(trait.data.check)
-
+  
   # check to see if we need to update
   if (forceupdate || !as.logical(forceupdate)) {
     if (is.null(pft$posteriorid)) {
-      pft$posteriorid <- db.query(paste0("SELECT id FROM posteriors WHERE pft_id=", pftid, " ORDER BY created_at DESC LIMIT 1"), dbcon)[['id']]  
+      pft$posteriorid <- db.query(paste0("SELECT id FROM posteriors WHERE pft_id=", pftid, " ORDER BY created_at DESC LIMIT 1"), 
+                                  dbcon)[["id"]]
     }
-    if (!is.null(pft$posteriorid)) { 
-      files <- dbfile.check('Posterior', pft$posteriorid, dbcon)
-      ids <- match(c('trait.data.Rdata', 'prior.distns.Rdata', 'species.csv'), files$file_name)
+    if (!is.null(pft$posteriorid)) {
+      files <- dbfile.check("Posterior", pft$posteriorid, dbcon)
+      ids <- match(c("trait.data.Rdata", "prior.distns.Rdata", "species.csv"), files$file_name)
       if (!any(is.na(ids))) {
         foundallfiles <- TRUE
-        for(id in ids) {
+        for (id in ids) {
           logger.info(files$file_path[[id]], files$file_name[[id]])
           if (!file.exists(file.path(files$file_path[[id]], files$file_name[[id]]))) {
             foundallfiles <- FALSE
-            logger.error("can not find posterior file: ", file.path(files$file_path[[id]], files$file_name[[id]]))
+            logger.error("can not find posterior file: ", 
+                         file.path(files$file_path[[id]], files$file_name[[id]]))
           } else if (forceupdate && (files$file_name[[id]] == "species.csv")) {
             logger.debug("Checking if species have changed")
             testme <- read.csv(file.path(files$file_path[[id]], files$file_name[[id]]))
             if (!check.lists(species, testme)) {
               foundallfiles <- FALSE
-              logger.error("species have changed: ", file.path(files$file_path[[id]], files$file_name[[id]]))
+              logger.error("species have changed: ",
+                           file.path(files$file_path[[id]], files$file_name[[id]]))
             }
             remove(testme)
           } else if (forceupdate && (files$file_name[[id]] == "prior.distns.Rdata")) {
@@ -113,105 +115,106 @@ get.trait.data.pft <- function(pft, modeltype, dbfiles, dbcon,
             prior.distns <- prior.distns.tmp
             if (!identical(prior.distns, testme)) {
               foundallfiles <- FALSE
-              logger.error("priors have changed: ", file.path(files$file_path[[id]], files$file_name[[id]]))
+              logger.error("priors have changed: ",
+                           file.path(files$file_path[[id]], files$file_name[[id]]))
             }
             remove(testme)
           } else if (forceupdate && (files$file_name[[id]] == "trait.data.Rdata")) {
             logger.debug("Checking if trait data has changed")
             load(file.path(files$file_path[[id]], files$file_name[[id]]))
-
+            
             # For trait data including converted data, only check unconverted
             converted.stats2na <- function(x) {
-              if(all(c("mean", "stat", "mean_unconverted", "stat_unconverted") %in% names(x)))
-                x[,c("mean","stat")] <- NA
+              if (all(c("mean", "stat", "mean_unconverted", "stat_unconverted") %in% names(x))) 
+                x[, c("mean", "stat")] <- NA
               return(x)
             }
-            trait.data = lapply(trait.data, converted.stats2na)
-            trait.data.check = lapply(trait.data.check, converted.stats2na)
-
+            trait.data <- lapply(trait.data, converted.stats2na)
+            trait.data.check <- lapply(trait.data.check, converted.stats2na)
+            
             if (!identical(trait.data.check, trait.data)) {
               foundallfiles <- FALSE
-              logger.error("trait data has changed: ", file.path(files$file_path[[id]], files$file_name[[id]]))
+              logger.error("trait data has changed: ", 
+                           file.path(files$file_path[[id]], files$file_name[[id]]))
             }
             remove(trait.data, trait.data.check)
           }
         }
         if (foundallfiles) {
           logger.info("Reusing existing files from posterior", pft$posteriorid, "for", pft$name)
-          for(id in 1:nrow(files)) {
-            file.copy(file.path(files[[id, 'file_path']], files[[id, 'file_name']]), file.path(pft$outdir, files[[id, 'file_name']]))
+          for (id in 1:nrow(files)) {
+            file.copy(file.path(files[[id, "file_path"]], files[[id, "file_name"]]), 
+                      file.path(pft$outdir, files[[id, "file_name"]]))
           }
           
           # May need to symlink the generic post.distns.Rdata to a specific post.distns.*.Rdata file.
-          if(length(dir(pft$outdir, "post.distns.Rdata"))==0) {
+          if (length(dir(pft$outdir, "post.distns.Rdata")) == 0) {
             all.files <- dir(pft$outdir)
             post.distn.file <- all.files[grep("post.distns.*.Rdata", all.files)]
-            if(length(post.distn.file) > 1)
-              stop("get.trait.data.pft() doesn't know how to handle multiple post.distns.*.Rdata files")
-            else if(length(post.distn.file) == 1) {
-              # Found exactly one post.distns.*.Rdata file. Use it.
-              file.symlink(file.path(pft$outdir, post.distn.file), file.path(pft$outdir, 'post.distns.Rdata'))
-            }
+            if (length(post.distn.file) > 1) 
+              stop("get.trait.data.pft() doesn't know how to handle multiple post.distns.*.Rdata files") else if (length(post.distn.file) == 1) {
+                # Found exactly one post.distns.*.Rdata file. Use it.
+                file.symlink(file.path(pft$outdir, post.distn.file), file.path(pft$outdir, "post.distns.Rdata"))
+              }
           }
           return(pft)
         }
       }
     }
   }
-
+  
   # get the trait data (including sampling of derived traits, if any)
-  trait.data <- query.traits(spstr, traits, con = dbcon, update.check.only=FALSE)
+  trait.data <- query.traits(spstr, traits, con = dbcon, update.check.only = FALSE)
   traits <- names(trait.data)
-
+  
   # get list of existing files so they get ignored saving
-  old.files <- list.files(path=pft$outdir)
-
+  old.files <- list.files(path = pft$outdir)
+  
   # create a new posterior
   now <- format(Sys.time(), "%Y-%m-%d %H:%M:%S")
-  db.query(paste0("INSERT INTO posteriors (pft_id, created_at, updated_at) VALUES (", pftid, ", '", now, "', '", now, "')"), dbcon)
-  pft$posteriorid <- db.query(paste0("SELECT id FROM posteriors WHERE pft_id=", pftid, " AND created_at='", now, "'"), dbcon)[['id']]
-
+  db.query(paste0("INSERT INTO posteriors (pft_id, created_at, updated_at) VALUES (", pftid, ", '", 
+                  now, "', '", now, "')"), dbcon)
+  pft$posteriorid <- db.query(paste0("SELECT id FROM posteriors WHERE pft_id=", pftid, " AND created_at='", 
+                                     now, "'"), dbcon)[["id"]]
+  
   # create path where to store files
   pathname <- file.path(dbfiles, "posterior", pft$posteriorid)
   dir.create(pathname, showWarnings = FALSE, recursive = TRUE)
-
+  
   ## 1. get species list based on pft
   write.csv(species, file.path(pft$outdir, "species.csv"), row.names = FALSE)
-
+  
   ## save priors
   save(prior.distns, file = file.path(pft$outdir, "prior.distns.Rdata"))
-  write.csv(prior.distns,
-            file = file.path(pft$outdir, "prior.distns.csv"), row.names = TRUE)
-
+  write.csv(prior.distns, file = file.path(pft$outdir, "prior.distns.csv"), row.names = TRUE)
+  
   ## 3. display info to the console
-  logger.info('Summary of Prior distributions for: ', pft$name)
+  logger.info("Summary of Prior distributions for: ", pft$name)
   logger.info(colnames(prior.distns))
-  apply(cbind(rownames(prior.distns), prior.distns), MARGIN=1, logger.info)
-
-  ## traits = variables with prior distributions for this pft 
+  apply(cbind(rownames(prior.distns), prior.distns), MARGIN = 1, logger.info)
+  
+  ## traits = variables with prior distributions for this pft
   trait.data.file <- file.path(pft$outdir, "trait.data.Rdata")
   save(trait.data, file = trait.data.file)
-  write.csv(ldply(trait.data),
-            file = file.path(pft$outdir, "trait.data.csv"), row.names = FALSE)
+  write.csv(ldply(trait.data), file = file.path(pft$outdir, "trait.data.csv"), row.names = FALSE)
   
   logger.info("number of observations per trait for", pft$name)
-  for(t in names(trait.data)){
+  for (t in names(trait.data)) {
     logger.info(nrow(trait.data[[t]]), "observations of", t)
   }
-    
-
+  
   ### save and store in database all results except those that were there already
-  for(file in list.files(path=pft$outdir)) {
+  for (file in list.files(path = pft$outdir)) {
     if (file %in% old.files) {
       next
     }
     filename <- file.path(pathname, file)
     file.copy(file.path(pft$outdir, file), filename)
-    dbfile.insert(pathname,file, 'Posterior', pft$posteriorid, dbcon)
+    dbfile.insert(pathname, file, "Posterior", pft$posteriorid, dbcon)
   }
-
+  
   return(pft)
-}
+} # get.trait.data.pft
 
 ##--------------------------------------------------------------------------------------------------#
 ##' Get trait data from the database.
@@ -234,31 +237,33 @@ get.trait.data.pft <- function(pft, modeltype, dbfiles, dbcon,
 ##' @author David LeBauer, Shawn Serbin
 ##' @export
 ##'
-get.trait.data <- function(pfts, modeltype, dbfiles, database, forceupdate,trait.names=NULL) {
+get.trait.data <- function(pfts, modeltype, dbfiles, database, forceupdate, trait.names = NULL) {
   ##---------------- Load trait dictionary --------------#
-  if(is.logical(trait.names)){
-    if(trait.names){
+  if (is.logical(trait.names)) {
+    if (trait.names) {
       data(trait.dictionary, package = "PEcAn.utils")
       trait.names <- trait.dictionary$id
     }
   }
-
+  
   # process all pfts
   dbcon <- db.open(database)
   result <- lapply(pfts, get.trait.data.pft, modeltype, dbfiles, dbcon, forceupdate, trait.names)
   db.close(dbcon)
-
+  
   invisible(result)
-}
-##==================================================================================================#
+} # get.trait.data
+
+## ==================================================================================================#
 
 ##' @export
 runModule.get.trait.data <- function(settings) {
-  if(is.null(settings$meta.analysis)) return(settings) ## if there's no MA, there's no need for traits
-  if(is.MultiSettings(settings)) {
+  if (is.null(settings$meta.analysis)) 
+    return(settings)  ## if there's no MA, there's no need for traits
+  if (is.MultiSettings(settings)) {
     pfts <- list()
     pft.names <- character(0)
-    for(i in seq_along(settings)) {
+    for (i in seq_along(settings)) {
       pfts.i <- settings[[i]]$pfts
       pft.names.i <- sapply(pfts.i, function(x) x$name)
       ind <- which(pft.names.i %in% setdiff(pft.names.i, pft.names))
@@ -266,30 +271,26 @@ runModule.get.trait.data <- function(settings) {
       pft.names <- sapply(pfts, function(x) x$name)
     }
     
-    logger.info(paste0("Getting trait data for all PFTs listed by any Settings object in the list: ",
-                paste(pft.names, collapse=", ")))
-                
+    logger.info(paste0("Getting trait data for all PFTs listed by any Settings object in the list: ", 
+                       paste(pft.names, collapse = ", ")))
+    
     modeltype <- settings$model$type
     dbfiles <- settings$database$dbfiles
     database <- settings$database$bety
-    forceupdate <- !is.null(settings$meta.analysis) && (as.logical(settings$meta.analysis$update) || (settings$meta.analysis$update == 'AUTO'))
+    forceupdate <- !is.null(settings$meta.analysis) && (as.logical(settings$meta.analysis$update) || 
+                                                          (settings$meta.analysis$update == "AUTO"))
     settings$pfts <- get.trait.data(pfts, modeltype, dbfiles, database, forceupdate)
     return(settings)
-  } else if(is.Settings(settings)) {
+  } else if (is.Settings(settings)) {
     pfts <- settings$pfts
     modeltype <- settings$model$type
     dbfiles <- settings$database$dbfiles
     database <- settings$database$bety
-    forceupdate <- !is.null(settings$meta.analysis) && (as.logical(settings$meta.analysis$update) || (settings$meta.analysis$update == 'AUTO'))
+    forceupdate <- !is.null(settings$meta.analysis) && 
+      (as.logical(settings$meta.analysis$update) || (settings$meta.analysis$update == "AUTO"))
     settings$pfts <- get.trait.data(pfts, modeltype, dbfiles, database, forceupdate)
     return(settings)
   } else {
     stop("runModule.get.trait.data only works with Settings or MultiSettings")
   }
-}
-
-
-
-####################################################################################################
-### EOF.  End of R script file.    					
-####################################################################################################
+} # runModule.get.trait.data

--- a/db/R/input.name.check.R
+++ b/db/R/input.name.check.R
@@ -1,3 +1,3 @@
-input.name.check <- function(inputname, con){
-  inputid <- db.query(paste0("SELECT id FROM inputs WHERE name = '", inputname, "'"), con)[['id']]
+input.name.check <- function(inputname, con) {
+  inputid <- db.query(paste0("SELECT id FROM inputs WHERE name = '", inputname, "'"), con)[["id"]]
 }

--- a/db/R/priordupe.R
+++ b/db/R/priordupe.R
@@ -9,43 +9,37 @@
 ##' @return nothing, creates new pft in database as a side-effect
 ##' @author David LeBauer
 ##' @examples \dontrun{
-##' priordupe(parent.pft.name    = "tempdecid",
-##'           new.pft.name       = "mytempdecid",
-##'           new.pft.definition = "mytempdecid is a new pft")
+##' priordupe(parent.pft.name    = 'tempdecid',
+##'           new.pft.name       = 'mytempdecid',
+##'           new.pft.definition = 'mytempdecid is a new pft')
 ##' }
-priordupe <- function(parent.pft.name = NULL,
-                      new.pft.name   = NULL,
-                      new.pft.definition =  NULL,
-                      settings = NULL){
-                      
-  require(PEcAn.DB)
+priordupe <- function(parent.pft.name = NULL, new.pft.name = NULL, new.pft.definition = NULL, settings = NULL) {
+  
+  library(PEcAn.DB)
   con <- db.open(settings$database$bety)
-  parent.pft.id <- db.query(paste("select id from pfts where name = ",
-                                    parent.pft.name, ";"), con=con)
-
+  parent.pft.id <- db.query(paste("select id from pfts where name = ", parent.pft.name, ";"),
+                            con = con)
+  
   ## create new pft
-  db.query(paste("insert into pfts set definition = ",
-                   newpftdefn, " name = ",
-                   new.pft.name, ";"), con=con)
-  new.pft.id <- db.query(paste("select id from pfts where name =",
-                                 new.pft.name,";"), con=con)
-
-  old.species.id <- db.query(paste("select specie_id from pfts_species where pft_id =",
-                                     parent.pft.id, ";"), con=con)
+  db.query(paste("insert into pfts set definition = ", newpftdefn, 
+                 " name = ", new.pft.name, ";"), 
+           con = con)
+  new.pft.id <- db.query(paste("select id from pfts where name =", new.pft.name, ";"), 
+                         con = con)
+  
+  old.species.id <- db.query(paste("select specie_id from pfts_species where pft_id =", parent.pft.id, 
+                                   ";"), con = con)
   new.pfts_species <- c(pft_id = new.pft.id, specie_id = unique(old.species.id))
   
-  db.query(paste("insert into pfts_species set pft_id = ",
-                   new.pfts_species$pft_id,
-                   "specie_id = ",
-                   new.pfts_species$specie_id, ";"), con=con)
-
-  old.priors <-  db.query(paste("select prior_id from pfts_priors where pft_id =",
-                                  parent.pft.id, ";"), con=con)
-  new.pfts_priors <- c(pft_id = new.pft.id,
-                       prior_id = unique(old.priors))
-  db.query(paste("insert into pfts_priors set pft_id = ",
-                   new.pfts_priors$pft_id,
-                   "specie_id = ",
-                   new.pfts_priors$priors_id, ";"), con=con)
+  db.query(paste("insert into pfts_species set pft_id = ", new.pfts_species$pft_id,
+                 "specie_id = ", new.pfts_species$specie_id, ";"), 
+           con = con)
+  
+  old.priors <- db.query(paste("select prior_id from pfts_priors where pft_id =", parent.pft.id, 
+                               ";"), con = con)
+  new.pfts_priors <- c(pft_id = new.pft.id, prior_id = unique(old.priors))
+  db.query(paste("insert into pfts_priors set pft_id = ", new.pfts_priors$pft_id, 
+                 "specie_id = ", new.pfts_priors$priors_id, ";"), 
+           con = con)
   db.close(con)
-}
+} # priordupe

--- a/db/R/query.base.R
+++ b/db/R/query.base.R
@@ -1,7 +1,7 @@
 #-------------------------------------------------------------------------------
 # Copyright (c) 2012 University of Illinois, NCSA.
 # All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
+# are made available under the terms of the
 # University of Illinois/NCSA Open Source License
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
@@ -25,16 +25,16 @@
 ##' \dontrun{
 ##' query.base('select count(id) from traits;')
 ##' }
-query.base <- function(query, con=NULL, ...){
+query.base <- function(query, con = NULL, ...) {
   .Deprecated("db.query")
-  .db.utils$deprecated <- .db.utils$deprecated+1
-  if(is.null(con)){
-    invisible(db.query(query, params=settings$database$bety))
+  .db.utils$deprecated <- .db.utils$deprecated + 1
+  if (is.null(con)) {
+    invisible(db.query(query, params = settings$database$bety))
   } else {
     invisible(db.query(query, con))
   }
-}
-#==================================================================================================#
+} # query.base
+# ==================================================================================================#
 
 #---------------- Base database connection function. ----------------------------------------------#
 ##' Creates database connection object.
@@ -52,12 +52,12 @@ query.base <- function(query, con=NULL, ...){
 ##' \dontrun{
 ##' con <- query.base.con(settings)
 ##' }
-query.base.con <- function(settings,...){
+query.base.con <- function(settings, ...) {
   .Deprecated("db.open")
-  .db.utils$deprecated <- .db.utils$deprecated+1
+  .db.utils$deprecated <- .db.utils$deprecated + 1
   invisible(db.open(settings$database$bety))
-}
-#==================================================================================================#
+} # query.base.con
+# ==================================================================================================#
 
 #---------------- Close open database connections. --------------------------------------------#
 ##' Close database connection
@@ -73,10 +73,10 @@ query.base.con <- function(settings,...){
 ##' @export
 query.close <- function(con) {
   .Deprecated("db.close")
-  .db.utils$deprecated <- .db.utils$deprecated+1
+  .db.utils$deprecated <- .db.utils$deprecated + 1
   invisible(db.close(con))
-}
-#==================================================================================================#
+} # query.close
+# ==================================================================================================#
 
 #---------------- Close all open database connections. --------------------------------------------#
 ##' Kill existing database connections
@@ -88,14 +88,9 @@ query.close <- function(con) {
 ##' @title Kill existing database connections 
 ##' @return nothing, as a side effect closes all open connections
 ##' @author David LeBauer
-killdbcons <- function(){
+killdbcons <- function() {
   .Deprecated("NeverCallThisFunction")
-  .db.utils$deprecated <- .db.utils$deprecated+1
+  .db.utils$deprecated <- .db.utils$deprecated + 1
   for (i in dbListConnections(MySQL())) db.close(i)
-}
-#==================================================================================================#
-
-
-####################################################################################################
-### EOF.  End of R script file.      				
-####################################################################################################
+} # killdbcons
+# ==================================================================================================#

--- a/db/R/query.file.path.R
+++ b/db/R/query.file.path.R
@@ -6,19 +6,15 @@
 ##' @export 
 ##' 
 ##' @author Betsy Cowdery 
-query.file.path <- function(input.id, host_name, con){
-  machine.host <- ifelse(host_name == "localhost",fqdn(),host_name)
-  machine = db.query(paste0("SELECT * from machines where hostname = '",machine.host,"'"),con)
-  dbfile = db.query(paste("SELECT file_name,file_path from dbfiles where container_id =",input.id," and container_type = 'Input' and machine_id =",machine$id),con)
-  path <- file.path(dbfile$file_path,dbfile$file_name)
-  cmd <- paste0("file.exists( '",path,"')")
-  remote.execute.R(cmd,machine.host,verbose=TRUE)
-  #   Check - to be determined later   
-  #   if(file.exists(path)){
-  #     return(path)
-  #   }else{
-  #     logger.error("Invalid file path")
-  #   }
+query.file.path <- function(input.id, host_name, con) {
+  machine.host <- ifelse(host_name == "localhost", fqdn(), host_name)
+  machine <- db.query(paste0("SELECT * from machines where hostname = '", machine.host, "'"), con)
+  dbfile <- db.query(paste("SELECT file_name,file_path from dbfiles where container_id =", input.id, 
+    " and container_type = 'Input' and machine_id =", machine$id), con)
+  path <- file.path(dbfile$file_path, dbfile$file_name)
+  cmd <- paste0("file.exists( '", path, "')")
+  remote.execute.R(cmd, machine.host, verbose = TRUE)
+  # Check - to be determined later if(file.exists(path)){ return(path) }else{ logger.error('Invalid
+  # file path') }
   return(path)
-}
-
+} # query.file.path

--- a/db/R/query.format.vars.R
+++ b/db/R/query.format.vars.R
@@ -4,10 +4,10 @@
 ##' @param con : database connection
 ##' @export 
 ##' 
-##' @author Betsy Cowdery , Ankur Desai
+##' @author Betsy Cowdery, Ankur Desai
 ##' 
-query.format.vars <- function(input.id,con,format.id){
-
+query.format.vars <- function(input.id, con, format.id) {
+  
   # get input info either form input.id or format.id, depending which is provided
   # defaults to format.id if both provided
   # also query site information (id/lat/lon) if an input.id
@@ -19,94 +19,92 @@ query.format.vars <- function(input.id,con,format.id){
   if (missing(format.id)) {
     f <- db.query(paste("SELECT * from formats as f join inputs as i on f.id = i.format_id where i.id = ", input.id),con)
     site.id <- db.query(paste("SELECT site_id from inputs where id =",input.id),con)
-    if (is.data.frame(site.id) && nrow(site.id)>0) {
+    if (is.data.frame(site.id) && nrow(site.id) > 0) {
       site.id <- site.id$site_id
-      site.info <- db.query(paste("SELECT id, ST_X(ST_CENTROID(geometry)) AS lon, ST_Y(ST_CENTROID(geometry)) AS lat FROM sites WHERE id =",site.id),con)
+      site.info <- db.query(paste("SELECT id, ST_X(ST_CENTROID(geometry)) AS lon, ST_Y(ST_CENTROID(geometry)) AS lat FROM sites WHERE id =", 
+                                  site.id), con)
       site.lat <- site.info$lat
       site.lon <- site.info$lon
     } 
   } else {
-    f <- db.query(paste("SELECT * from formats where id = ", format.id),con)
+    f <- db.query(paste("SELECT * from formats where id = ", format.id), con)
   }
   
-  mimetype <- db.query(paste("SELECT * from  mimetypes where id = ",
-                             f$mimetype_id),con)[["type_string"]]
-  f$mimetype <- tail(unlist(strsplit(mimetype, "/")),1)
+  mimetype <- db.query(paste("SELECT * from  mimetypes where id = ", f$mimetype_id), con)[["type_string"]]
+  f$mimetype <- tail(unlist(strsplit(mimetype, "/")), 1)
   
   # get variable names and units of input data
-  fv <- db.query(paste("SELECT variable_id,name,unit,storage_type,column_number from formats_variables where format_id = ", f$id),con)
+  fv <- db.query(paste("SELECT variable_id,name,unit,storage_type,column_number from formats_variables where format_id = ", f$id), con)
   
-  if (nrow(fv)>0) {
+  if (nrow(fv) > 0) {
     colnames(fv) <- c("variable_id", "input_name", "input_units", "storage_type", "column_number")
     fv$variable_id <- as.numeric(fv$variable_id)
     n <- dim(fv)[1]
-  
+    
     # get bety names and units 
     vars <- as.data.frame(matrix(NA, ncol=3, nrow=n))
-    for(i in 1:n){
+    for(i in seq_len(n)) {
       vars[i,] <- as.matrix(db.query(paste("SELECT id, name, units from variables where id = ",
-                                 fv$variable_id[i]),con))
+                                           fv$variable_id[i]), con))
     }
     colnames(vars) <- c("variable_id", "bety_name", "bety_units")
     vars$variable_id <- as.numeric(fv$variable_id)
     
     # Fill in input names and units with bety names and units if they are missing
-    
     ind1 <- fv$input_name == ""
     fv$input_name[ind1] <- vars$bety_name[ind1]
     ind2 <- fv$input_units == ""
     fv$input_units[ind2] <- vars$bety_units[ind2]
-      
+    
     # Fill in CF vars
     # This will ultimately be useful when looking at met variables where CF != Bety
     # met <- read.csv(system.file("/data/met.lookup.csv", package= "PEcAn.data.atmosphere"), header = T, stringsAsFactors=FALSE)
-  
+    
     #Fill in MstMIP vars 
     #All pecan output is in MstMIP variables 
-  
-    bety_mstmip <- read.csv(system.file("bety_mstmip_lookup.csv", package= "PEcAn.DB"), header = T, stringsAsFactors=FALSE)
-  
-    vars_full <- merge(fv, merge(vars, bety_mstmip, by = "bety_name", all.x = TRUE), by="variable_id", all=TRUE) # not sure if all=TRUE is appropriate here or not.
-  
+    
+    bety_mstmip <- read.csv(system.file("bety_mstmip_lookup.csv", package = "PEcAn.DB"), header = TRUE, stringsAsFactors = FALSE)
+    
+    vars_full <- merge(fv, merge(vars, bety_mstmip, by = "bety_name", all.x = TRUE), by = "variable_id", all = TRUE) # not sure if all=TRUE is appropriate here or not.
+    
     vars_full$pecan_name <- vars_full$mstmip_name
     vars_full$pecan_units <- vars_full$mstmip_units
     ind <- is.na(vars_full$pecan_name)
     vars_full$pecan_name[ind] <- vars_full$bety_name[ind]
     vars_full$pecan_units[ind] <- vars_full$bety_units[ind]
-  
-    header <- as.numeric(f$header)
-    skip <- ifelse(is.na(as.numeric(f$skip)),0,as.numeric(f$skip))
     
+    header <- as.numeric(f$header)
+    skip <- ifelse(is.na(as.numeric(f$skip)), 0, as.numeric(f$skip))
     
     # Right now I'm making the inappropriate assumption that storage type will be 
     # empty unless it's a time variable. 
     # This is because I haven't come up for a good way to test that a character string is a date format
-    
     st <- fv$storage_type
-    time.row <- which(nchar(st)>1 & substr(st, 1,1) == "%")
-    if(length(time.row) == 0) time.row <- NULL
+    time.row <- which(nchar(st) > 1 & substr(st, 1, 1) == "%")
+    if (length(time.row) == 0) {
+      time.row <- NULL
+    }
     
     # Final format list
-    format <- list(file_name = f$name,
-                   mimetype = f$mimetype,
-                   vars = vars_full,
-                   skip = skip, 
-                   header = header,
-                   na.strings=c("-9999","-6999","9999"), # This shouldn't be hardcoded in, but not specified in format table ?
-                   time.row = time.row,
-                   site = site.id,
-                   lat = site.lat,
-                   lon = site.lon
-                   )
+    list(file_name = f$name,
+         mimetype = f$mimetype,
+         vars = vars_full,
+         skip = skip, 
+         header = header,
+         na.strings=c("-9999","-6999","9999"), # This shouldn't be hardcoded in, but not specified in format table ?
+         time.row = time.row,
+         site = site.id,
+         lat = site.lat,
+         lon = site.lon
+    )
   } else {
-    format <- list(file_name = f$name,
-                   mimetype = f$mimetype,
-                   na.strings=c("-9999","-6999","9999"), # This shouldn't be hardcoded in, but not specified in format table ?
-                   time.row = NULL,
-                   site = site.id,
-                   lat = site.lat,
-                   lon = site.lon
+    list(file_name = f$name,
+         mimetype = f$mimetype,
+         na.strings=c("-9999","-6999","9999"), # This shouldn't be hardcoded in, but not specified in format table ?
+         time.row = NULL,
+         site = site.id,
+         lat = site.lat,
+         lon = site.lon
     )
   }
-  return(format)
-}
+} # query.format.vars

--- a/db/R/query.pft.R
+++ b/db/R/query.pft.R
@@ -1,11 +1,12 @@
 #-------------------------------------------------------------------------------
 # Copyright (c) 2012 University of Illinois, NCSA.
 # All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
+# are made available under the terms of the
 # University of Illinois/NCSA Open Source License
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
+
 #--------------------------------------------------------------------------------------------------#
 ##'  select plant id's associated with pft
 ##'
@@ -20,32 +21,21 @@
 ##' @examples
 ##' \dontrun{
 ##' query.pft_species('ebifarm.pavi')
-##' query.pft_species(settings = read.settings("pecan.xml"))
+##' query.pft_species(settings = read.settings('pecan.xml'))
 ##' }
-query.pft_species <- function(pft, modeltype, con){
+query.pft_species <- function(pft, modeltype, con) {
   # create pft subquery
   if (is.null(modeltype)) {
-    query <- paste0("select species.id, species.genus, species.species, species.scientificname",
-                    " from species, pfts, pfts_species",
-                    " where species.id=pfts_species.specie_id",
-                    " and pfts.id=pfts_species.pft_id",
-                    " and pfts.name='", pft, "'")
+    query <- paste0("select species.id, species.genus, species.species, species.scientificname", 
+      " from species, pfts, pfts_species", " where species.id=pfts_species.specie_id", " and pfts.id=pfts_species.pft_id", 
+      " and pfts.name='", pft, "'")
   } else {
-    query <- paste0("select species.id, species.genus, species.species, species.scientificname",
-                    " from species, pfts, pfts_species, modeltypes",
-                    " where species.id=pfts_species.specie_id",
-                    " and pfts.id=pfts_species.pft_id",
-                    " and pfts.name='", pft, "'",
-                    " and pfts.modeltype_id=modeltypes.id",
-                    " and modeltypes.name='", modeltype, "'")
+    query <- paste0("select species.id, species.genus, species.species, species.scientificname", 
+      " from species, pfts, pfts_species, modeltypes", " where species.id=pfts_species.specie_id", 
+      " and pfts.id=pfts_species.pft_id", " and pfts.name='", pft, "'", " and pfts.modeltype_id=modeltypes.id", 
+      " and modeltypes.name='", modeltype, "'")
   }
-
-  species <- db.query(query, con)
-  invisible(species)
-}
-#==================================================================================================#
-
-
-####################################################################################################
-### EOF.  End of R script file.      				
-####################################################################################################
+  
+  invisible(db.query(query, con))
+} # query.pft_species
+# ==================================================================================================#

--- a/db/R/query.prior.R
+++ b/db/R/query.prior.R
@@ -1,11 +1,12 @@
 #-------------------------------------------------------------------------------
 # Copyright (c) 2012 University of Illinois, NCSA.
 # All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
+# are made available under the terms of the
 # University of Illinois/NCSA Open Source License
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
+
 #--------------------------------------------------------------------------------------------------#
 ##' Query priors associated with a string of traits and plant functional type
 ##'
@@ -23,44 +24,33 @@
 ##' \dontrun{
 ##' query.priors('ebifarm.pavi', vecpaste('SLA', 'Vcmax', 'leaf_width'))
 ##' }
-query.priors <- function(pft, trstr=NULL, out=NULL, con=NULL,...){
-  if(is.null(con)){
+query.priors <- function(pft, trstr = NULL, out = NULL, con = NULL, ...) {
+  if (is.null(con)) {
     con <- db.open(settings$database$bety)
   }
-  if(is.list(con)){
+  if (is.list(con)) {
     print("query.priors")
     print("WEB QUERY OF DATABASE NOT IMPLEMENTED")
     return(NULL)
   }
   
-  query.text <- paste("select variables.name, distn, parama, paramb, n",
-      "from priors",
-      "join variables on priors.variable_id = variables.id",
-      "join pfts_priors on pfts_priors.prior_id = priors.id",
-      "join pfts on pfts.id = pfts_priors.pft_id",
-      "where pfts.id = ", pft)
-  if(is.null(trstr) || trstr == "''"){
-    query.text = paste(query.text,";",sep="")
+  query.text <- paste("select variables.name, distn, parama, paramb, n", "from priors", "join variables on priors.variable_id = variables.id", 
+    "join pfts_priors on pfts_priors.prior_id = priors.id", "join pfts on pfts.id = pfts_priors.pft_id", 
+    "where pfts.id = ", pft)
+  if (is.null(trstr) || trstr == "''") {
+    query.text <- paste(query.text, ";", sep = "")
   } else {
-    query.text = paste(query.text,"and variables.name in (", trstr, ");")
+    query.text <- paste(query.text, "and variables.name in (", trstr, ");")
   }
   
   priors <- db.query(query.text, con)
   
-  if(nrow(priors) <= 0){
+  if (nrow(priors) <= 0) {
     warning(paste("No priors found for pft(s): ", pft))
-    priors <- priors[, which(colnames(priors)!='name')]
-    return(priors)
-  }
-  else {    
+    priors[, which(colnames(priors) != "name")]
+  } else {
     rownames(priors) <- priors$name
-    priors <- priors[, which(colnames(priors)!='name')]
-    return(priors)
+    priors[, which(colnames(priors) != "name")]
   }
-}
-#==================================================================================================#
-
-
-####################################################################################################
-### EOF.  End of R script file.        			
-####################################################################################################
+} # query.priors
+# ==================================================================================================#

--- a/db/R/query.site.R
+++ b/db/R/query.site.R
@@ -6,11 +6,15 @@
 ##' 
 ##' @author Betsy Cowdery 
 ##' 
-query.site <- function(site.id,con){
+query.site <- function(site.id, con) {
   site <- db.query(paste("SELECT *, ST_X(ST_CENTROID(geometry)) AS lon, ST_Y(ST_CENTROID(geometry))
-                         AS lat FROM sites WHERE id =",site.id),con)
-  if(nrow(site)==0){logger.error("Site not found"); return(NULL)}
-  if(!(is.na(site$lat)) && !(is.na(site$lat))){
+             AS lat FROM sites WHERE id =", 
+    site.id), con)
+  if (nrow(site) == 0) {
+    logger.error("Site not found")
+    return(NULL)
+  }
+  if (!(is.na(site$lat)) && !(is.na(site$lat))) {
     return(site)
   }
-}
+} # query.site

--- a/db/R/query.trait.data.R
+++ b/db/R/query.trait.data.R
@@ -6,6 +6,7 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
+
 ##--------------------------------------------------------------------------------------------------#
 ##' Queries data from the trait database and transforms statistics to SE
 ##'
@@ -18,11 +19,10 @@
 ##' @return dataframe with trait data
 ##' @seealso used in \code{\link{query.trait.data}}; \code{\link{transformstats}} performs transformation calculations
 ##' @author <unknown>
-fetch.stats2se <- function(connection, query){
-  transformed <- transformstats(db.query(query, connection))
-  return(transformed)
+fetch.stats2se <- function(connection, query) {
+  transformstats(db.query(query, connection))
 }
-##==================================================================================================#
+## ==================================================================================================#
 
 
 ##--------------------------------------------------------------------------------------------------#
@@ -38,36 +38,36 @@ fetch.stats2se <- function(connection, query){
 ##' @param ... extra arguments
 ##' @seealso used in \code{\link{query.trait.data}}; \code{\link{fetch.stats2se}}; \code{\link{transformstats}} performs transformation calculations
 ##' @author David LeBauer, Carl Davidson
-query.data <- function(trait, spstr, extra.columns='ST_X(ST_CENTROID(sites.geometry)) AS lon, ST_Y(ST_CENTROID(sites.geometry)) AS lat, ', con=NULL, store.unconverted=FALSE, ...) {
+query.data <- function(trait, spstr, extra.columns = "ST_X(ST_CENTROID(sites.geometry)) AS lon, ST_Y(ST_CENTROID(sites.geometry)) AS lat, ", 
+                       con = NULL, store.unconverted = FALSE, ...) {
   if (is.null(con)) {
     logger.error("No open database connection passed in.")
     con <- db.open(settings$database$bety)
   }
   query <- paste("select
-              traits.id, traits.citation_id, traits.site_id, traits.treatment_id,
-              treatments.name, traits.date, traits.time, traits.cultivar_id, traits.specie_id,
-              traits.mean, traits.statname, traits.stat, traits.n, variables.name as vname,
-              extract(month from traits.date) as month,",
-            extra.columns,
-            "treatments.control, sites.greenhouse
-              from traits
-              left join treatments on  (traits.treatment_id = treatments.id)
-              left join sites on (traits.site_id = sites.id)
-              left join variables on (traits.variable_id = variables.id)
-            where specie_id in (", spstr,")
-            and variables.name in ('", trait,"');", sep = "")
+        traits.id, traits.citation_id, traits.site_id, traits.treatment_id,
+        treatments.name, traits.date, traits.time, traits.cultivar_id, traits.specie_id,
+        traits.mean, traits.statname, traits.stat, traits.n, variables.name as vname,
+        extract(month from traits.date) as month,", 
+                 extra.columns, "treatments.control, sites.greenhouse
+        from traits
+        left join treatments on  (traits.treatment_id = treatments.id)
+        left join sites on (traits.site_id = sites.id)
+        left join variables on (traits.variable_id = variables.id)
+      where specie_id in (", 
+                 spstr, ")
+      and variables.name in ('", trait, "');", sep = "")
   result <- fetch.stats2se(con, query)
   
-  if(store.unconverted) {
+  if (store.unconverted) {
     result$mean_unconverted <- result$mean
     result$stat_unconverted <- result$stat
   }
   
-  return(result)
   db.close(con)
-}
-##==================================================================================================#
-
+  return(result)
+} # query.data
+## ==================================================================================================#
 
 ##--------------------------------------------------------------------------------------------------#
 ##'
@@ -82,27 +82,27 @@ query.data <- function(trait, spstr, extra.columns='ST_X(ST_CENTROID(sites.geome
 ##' @param ... extra arguments
 ##' @seealso used in \code{\link{query.trait.data}}; \code{\link{fetch.stats2se}}; \code{\link{transformstats}} performs transformation calculations
 ##' @author <unknown>
-query.yields <- function(trait = 'yield', spstr, extra.columns='', con=NULL, ...){
+query.yields <- function(trait = "yield", spstr, extra.columns = "", con = NULL, ...) {
   query <- paste("select
-            yields.id, yields.citation_id, yields.site_id, treatments.name,
-            yields.date, yields.time, yields.cultivar_id, yields.specie_id,
-            yields.mean, yields.statname, yields.stat, yields.n,
-            variables.name as vname,
-            month(yields.date) as month,",
-                 extra.columns,
-                 "treatments.control, sites.greenhouse
-          from yields
-            left join treatments on  (yields.treatment_id = treatments.id)
-            left join sites on (yields.site_id = sites.id)
-            left join variables on (yields.variable_id = variables.id)
-          where specie_id in (", spstr,");", sep = "")
-  if(!trait == 'yield'){
-    query <- gsub(");", paste(" and variables.name in ('", trait,"');", sep = ""), query)
+      yields.id, yields.citation_id, yields.site_id, treatments.name,
+      yields.date, yields.time, yields.cultivar_id, yields.specie_id,
+      yields.mean, yields.statname, yields.stat, yields.n,
+      variables.name as vname,
+      month(yields.date) as month,", 
+                 extra.columns, "treatments.control, sites.greenhouse
+      from yields
+      left join treatments on  (yields.treatment_id = treatments.id)
+      left join sites on (yields.site_id = sites.id)
+      left join variables on (yields.variable_id = variables.id)
+      where specie_id in (", 
+                 spstr, ");", sep = "")
+  if (!trait == "yield") {
+    query <- gsub(");", paste(" and variables.name in ('", trait, "');", sep = ""), query)
   }
-
+  
   return(fetch.stats2se(con, query))
-}
-##==================================================================================================#
+} # query.yields
+## ==================================================================================================#
 
 
 ######################## COVARIATE FUNCTIONS #################################
@@ -125,19 +125,18 @@ query.yields <- function(trait = 'yield', spstr, extra.columns='', con=NULL, ...
 ##' @author Carl Davidson, Ryan Kelly
 ##' @export
 ##--------------------------------------------------------------------------------------------------#
-append.covariate<-function(data, column.name, covariates.data){
+append.covariate <- function(data, column.name, covariates.data) {
   # Keep only the highest-priority covariate for each trait
   covariates.data <- covariates.data[!duplicated(covariates.data$trait_id), ]
-
+  
   # Select columns to keep, and rename the covariate column
-  covariates.data <- covariates.data[, c('trait_id', 'level')]
-  names(covariates.data) <- c('id', column.name)
-
+  covariates.data <- covariates.data[, c("trait_id", "level")]
+  names(covariates.data) <- c("id", column.name)
+  
   # Merge on trait ID
-  merged <- merge(covariates.data, data, all = TRUE, by = "id")
-  return(merged)
-}
-##==================================================================================================#
+  merge(covariates.data, data, all = TRUE, by = "id")
+} # append.covariate
+## ==================================================================================================#
 
 
 ##--------------------------------------------------------------------------------------------------#
@@ -150,14 +149,12 @@ append.covariate<-function(data, column.name, covariates.data){
 ##' @param ... extra arguments
 ##'
 ##' @author <unknown>
-query.covariates<-function(trait.ids, con = NULL, ...){
-  covariate.query <- paste("select covariates.trait_id, covariates.level,variables.name",
-                           "from covariates left join variables on variables.id = covariates.variable_id",
-                           "where trait_id in (",vecpaste(trait.ids),")")
-  covariates <- db.query(covariate.query, con)
-  return(covariates)
-}
-##==================================================================================================#
+query.covariates <- function(trait.ids, con = NULL, ...) {
+  covariate.query <- paste("select covariates.trait_id, covariates.level,variables.name", "from covariates left join variables on variables.id = covariates.variable_id", 
+                           "where trait_id in (", vecpaste(trait.ids), ")")
+  db.query(covariate.query, con)
+} # query.covariates
+## ==================================================================================================#
 
 
 ##--------------------------------------------------------------------------------------------------#
@@ -172,31 +169,30 @@ query.covariates<-function(trait.ids, con = NULL, ...){
 ##' @param new.temp the reference temperature for the scaled traits. Curerntly 25 degC
 ##' @param missing.temp the temperature assumed for traits with no covariate found. Curerntly 25 degC
 ##' @author Carl Davidson, David LeBauer, Ryan Kelly
-arrhenius.scaling.traits <- function(data, covariates, temp.covariates, new.temp=25, missing.temp=25){
+arrhenius.scaling.traits <- function(data, covariates, temp.covariates, new.temp = 25, missing.temp = 25) {
   # Select covariates that match temp.covariates
-  covariates <- covariates[covariates$name %in% temp.covariates,]
-    
-  if(nrow(covariates)>0) {
-    # Sort covariates in order of priority
-    covariates <- do.call(rbind, 
-      lapply(temp.covariates, function(temp.covariate) covariates[covariates$name == temp.covariate, ])
-      )
+  covariates <- covariates[covariates$name %in% temp.covariates, ]
   
-    data <- append.covariate(data, 'temp', covariates)
-
+  if (nrow(covariates) > 0) {
+    # Sort covariates in order of priority
+    covariates <- do.call(rbind, lapply(temp.covariates, function(temp.covariate) covariates[covariates$name == 
+                                                                                               temp.covariate, ]))
+    
+    data <- append.covariate(data, "temp", covariates)
+    
     # Assign default value for traits with no covariates
     data$temp[is.na(data$temp)] <- missing.temp
     
     # Scale traits
-    data$mean <- arrhenius.scaling(data$mean, old.temp = data$temp, new.temp=new.temp)
-    data$stat <- arrhenius.scaling(data$stat, old.temp = data$temp, new.temp=new.temp)
-
-    #remove temporary covariate column.
-    data<-data[,colnames(data)!='temp']
+    data$mean <- arrhenius.scaling(data$mean, old.temp = data$temp, new.temp = new.temp)
+    data$stat <- arrhenius.scaling(data$stat, old.temp = data$temp, new.temp = new.temp)
+    
+    # remove temporary covariate column.
+    data <- data[, colnames(data) != "temp"]
   }
   return(data)
-}
-##==================================================================================================#
+} # arrhenius.scaling.traits
+## ==================================================================================================#
 
 
 ##--------------------------------------------------------------------------------------------------#
@@ -207,18 +203,18 @@ arrhenius.scaling.traits <- function(data, covariates, temp.covariates, new.temp
 ##' @param covariates covariate data
 ##'
 ##' @author <unknown>
-filter.sunleaf.traits <- function(data, covariates){
-  if(length(covariates)>0) {
-    data <- append.covariate(data, 'canopy_layer',
-                             covariates[covariates$name == 'canopy_layer',])
-    data <-  data[data$canopy_layer >= 0.66 | is.na(data$canopy_layer),]
+filter.sunleaf.traits <- function(data, covariates) {
+  if (length(covariates) > 0) {
+    data <- append.covariate(data, "canopy_layer", covariates[covariates$name == "canopy_layer", 
+                                                              ])
+    data <- data[data$canopy_layer >= 0.66 | is.na(data$canopy_layer), ]
     
     # remove temporary covariate column
-    data<-data[,colnames(data)!='canopy_layer']
+    data <- data[, colnames(data) != "canopy_layer"]
   }
   return(data)
-}
-##==================================================================================================#
+} # filter.sunleaf.traits
+## ==================================================================================================#
 
 
 ##--------------------------------------------------------------------------------------------------#
@@ -232,24 +228,23 @@ filter.sunleaf.traits <- function(data, covariates){
 ##' @seealso used with \code{\link{jagify}};
 ##' @export
 rename.jags.columns <- function(data) {
-
-                                        # Change variable names and calculate obs.prec within data frame
-  transformed <-  transform(data,
-                            Y        = mean,
-                            se       = stat,
-                            obs.prec = 1 / (sqrt(n) * stat) ^2,
-                            trt      = trt_id,
-                            site     = site_id,
-                            cite     = citation_id,
-                            ghs      = greenhouse)
-
-                                        # Subset data frame
-  selected <- subset(transformed, select = c('Y', 'n', 'site', 'trt', 'ghs', 'obs.prec',
-                                    'se', 'cite'))
-                                        # Return subset data frame
+  
+  # Change variable names and calculate obs.prec within data frame
+  transformed <- transform(data, 
+                           Y = mean, 
+                           se = stat, 
+                           obs.prec = 1 / (sqrt(n) * stat) ^ 2, 
+                           trt = trt_id, 
+                           site = site_id, 
+                           cite = citation_id, 
+                           ghs = greenhouse)
+  
+  # Subset data frame
+  selected <- subset(transformed, select = c("Y", "n", "site", "trt", "ghs", "obs.prec", "se", "cite"))
+  # Return subset data frame
   return(selected)
-}
-##==================================================================================================#
+} # rename.jags.columns
+## ==================================================================================================#
 
 
 
@@ -266,27 +261,27 @@ rename.jags.columns <- function(data) {
 ##' @return dataframe with sequential treatments
 ##' @export
 ##' @author David LeBauer, Carl Davidson
-assign.treatments <- function(data){
-  data$trt_id[which(data$control == 1)] <- 'control'
+assign.treatments <- function(data) {
+  data$trt_id[which(data$control == 1)] <- "control"
   sites <- unique(data$site_id)
-  for(ss in sites){
+  for (ss in sites) {
     site.i <- data$site_id == ss
-    #if only one treatment, it's control
-    if(length(unique(data$trt_id[site.i])) == 1) data$trt_id[site.i] <- 'control'
-    if(!'control' %in% data$trt_id[site.i]){
-      logger.severe('No control treatment set for site_id:',
-                   unique(data$site_id[site.i]),
-                   'and citation id',
-                   unique(data$citation_id[site.i]),
-                   '\nplease set control treatment for this site / citation in database\n')
+    # if only one treatment, it's control
+    if (length(unique(data$trt_id[site.i])) == 1) 
+      data$trt_id[site.i] <- "control"
+    if (!"control" %in% data$trt_id[site.i]) {
+      logger.severe("No control treatment set for site_id:", unique(data$site_id[site.i]), 
+                    "and citation id", unique(data$citation_id[site.i]), 
+                    "\nplease set control treatment for this site / citation in database\n")
     }
   }
   return(data)
-}
-drop.columns <- function(data, columns){
-  return(data[,which(!colnames(data) %in% columns)])
-}
-##==================================================================================================#
+} # assign.treatments
+
+drop.columns <- function(data, columns) {
+  return(data[, which(!colnames(data) %in% columns)])
+} # drop.columns
+## ==================================================================================================#
 
 
 ##--------------------------------------------------------------------------------------------------#
@@ -305,16 +300,16 @@ drop.columns <- function(data, columns){
 ##' ## return vector of length \code{sample.size} from N(mean,stat)
 ##' take.samples(summary = data.frame(mean = 10, stat = 10), sample.size = 10)
 ##'
-take.samples <- function(summary, sample.size = 10^6){
-  if(is.na(summary$stat)){
+take.samples <- function(summary, sample.size = 10^6) {
+  if (is.na(summary$stat)) {
     ans <- summary$mean
   } else {
     set.seed(0)
     ans <- rnorm(sample.size, summary$mean, summary$stat)
   }
   return(ans)
-}
-##==================================================================================================#
+} # take.samples
+## ==================================================================================================#
 
 
 ##--------------------------------------------------------------------------------------------------#
@@ -338,20 +333,22 @@ take.samples <- function(summary, sample.size = 10^6){
 ##' @examples
 ##' input <- list(x = data.frame(mean = 1, stat = 1, n = 1))
 ##' derive.trait(FUN = identity, input = input, var.name = 'x')
-derive.trait <- function(FUN, ..., input=list(...), var.name=NA, sample.size=10^6){
-  if(any(lapply(input, nrow) > 1)){
+derive.trait <- function(FUN, ..., input = list(...), var.name = NA, sample.size = 10^6) {
+  if (any(lapply(input, nrow) > 1)) {
     return(NULL)
   }
-  input.samples <- lapply(input, take.samples, sample.size=sample.size)
+  input.samples <- lapply(input, take.samples, sample.size = sample.size)
   output.samples <- do.call(FUN, input.samples)
-  output<-input[[1]]
-  output$mean<-mean(output.samples)
-  output$stat<-ifelse(length(output.samples) > 1, sd(output.samples), NA)
-  output$n <- min(sapply(input, function(trait){trait$n}))
+  output <- input[[1]]
+  output$mean <- mean(output.samples)
+  output$stat <- ifelse(length(output.samples) > 1, sd(output.samples), NA)
+  output$n <- min(sapply(input, function(trait) {
+    trait$n
+  }))
   output$vname <- ifelse(is.na(var.name), output$vname, var.name)
   return(output)
-}
-##==================================================================================================#
+} # derive.trait
+## ==================================================================================================#
 
 
 ##--------------------------------------------------------------------------------------------------#
@@ -367,44 +364,40 @@ derive.trait <- function(FUN, ..., input=list(...), var.name=NA, sample.size=10^
 ##' @param match.columns in the event more than one trait dataset is supplied,
 ##'        this specifies the columns that identify a unique data point
 ##' @return a copy of the first input trait with modified mean, stat, and n
-derive.traits <- function(FUN, ..., input=list(...),
-                          match.columns=c('citation_id', 'site_id', 'specie_id'),
-                          var.name=NA, sample.size=10^6){
-  if(length(input) == 1){
-    input<-input[[1]]
-                                        #KLUDGE: modified to handle empty datasets
-    for(i in (0:nrow(input))[-1]){
-      input[i,]<-derive.trait(FUN, input[i,], sample.size=sample.size)
+derive.traits <- function(FUN, ..., input = list(...), match.columns = c("citation_id", "site_id", 
+                                                                         "specie_id"), var.name = NA, sample.size = 10^6) {
+  if (length(input) == 1) {
+    input <- input[[1]]
+    # KLUDGE: modified to handle empty datasets
+    for (i in (0:nrow(input))[-1]) {
+      input[i, ] <- derive.trait(FUN, input[i, ], sample.size = sample.size)
     }
     return(input)
-  }
-  else if(length(match.columns) > 0){
-                                        #function works recursively to reduce the number of match columns
+  } else if (length(match.columns) > 0) {
+    # function works recursively to reduce the number of match columns
     match.column <- match.columns[[1]]
-                                        #find unique values within the column that intersect among all input datasets
-    columns <- lapply(input, function(data){data[[match.column]]})
+    # find unique values within the column that intersect among all input datasets
+    columns <- lapply(input, function(data) {
+      data[[match.column]]
+    })
     intersection <- Reduce(intersect, columns)
-
-                                        #run derive.traits() on subsets of input that contain those unique values
-    derived.traits<-lapply(intersection,
-                           function(id){
-                             filtered.input <- lapply(input,
-                                                      function(data){data[data[[match.column]] == id,]})
-                             derive.traits(FUN, input=filtered.input,
-                                           match.columns=match.columns[-1],
-                                           var.name=var.name,
-                                           sample.size=sample.size)
-                           })
+    
+    # run derive.traits() on subsets of input that contain those unique values
+    derived.traits <- lapply(intersection, function(id) {
+      filtered.input <- lapply(input, function(data) {
+        data[data[[match.column]] == id, ]
+      })
+      derive.traits(FUN, input = filtered.input, match.columns = match.columns[-1], var.name = var.name, 
+                    sample.size = sample.size)
+    })
     derived.traits <- derived.traits[!is.null(derived.traits)]
     derived.traits <- do.call(rbind, derived.traits)
     return(derived.traits)
+  } else {
+    return(derive.trait(FUN, input = input, var.name = var.name, sample.size = sample.size))
   }
-  else{
-    return(derive.trait(FUN, input=input,
-                        var.name=var.name, sample.size=sample.size))
-  }
-}
-##==================================================================================================#
+} # derive.traits
+## ==================================================================================================#
 
 
 ##--------------------------------------------------------------------------------------------------#
@@ -425,130 +418,117 @@ derive.traits <- function(FUN, ..., input=list(...),
 ##' @examples
 ##' \dontrun{
 ##' settings <- read.settings()
-##' query.trait.data("Vcmax", "938", con = con)
+##' query.trait.data('Vcmax', '938', con = con)
 ##' }
 ##' @author David LeBauer, Carl Davidson, Shawn Serbin
-query.trait.data <- function(trait, spstr, con = NULL, update.check.only=FALSE, ...){
-
-  if(is.list(con)){
+query.trait.data <- function(trait, spstr, con = NULL, update.check.only = FALSE, ...) {
+  
+  if (is.list(con)) {
     print("query.trait.data")
     print("WEB QUERY OF DATABASE NOT IMPLEMENTED")
     return(NULL)
   }
-
+  
   # print trait info
-  if(!update.check.only) {
+  if (!update.check.only) {
     print("---------------------------------------------------------")
     print(trait)
   }
-
-### Query the data from the database for trait X.
-  data <- query.data(trait, spstr, con=con, store.unconverted=TRUE)
-
-### Query associated covariates from database for trait X.
-  covariates <- query.covariates(data$id, con=con)
-  canopy.layer.covs <- covariates[covariates$name == 'canopy_layer', ]
-
-### Set small sample size for derived traits if update-checking only. Otherwise use default.
-  if(update.check.only) {
-    sample.size <- 10 
+  
+  ### Query the data from the database for trait X.
+  data <- query.data(trait, spstr, con = con, store.unconverted = TRUE)
+  
+  ### Query associated covariates from database for trait X.
+  covariates <- query.covariates(data$id, con = con)
+  canopy.layer.covs <- covariates[covariates$name == "canopy_layer", ]
+  
+  ### Set small sample size for derived traits if update-checking only. Otherwise use default.
+  if (update.check.only) {
+    sample.size <- 10
   } else {
     sample.size <- 10^6  ## Same default as derive.trait(), derive.traits(), and take.samples()
   }
-
-  if(trait == 'Vcmax') {
-#########################   VCMAX   ############################
-### Apply Arrhenius scaling to convert Vcmax at measurement temp to that at 25 degC (ref temp).
-    data <- arrhenius.scaling.traits(data, covariates, c('leafT', 'airT','T'))
-
-### Keep only top of canopy/sunlit leaf samples based on covariate.
-    if(nrow(canopy.layer.covs) > 0) data <- filter.sunleaf.traits(data, canopy.layer.covs)
-
-    ## select only summer data for Panicum virgatum
-    ##TODO fix following hack to select only summer data
-    if (spstr == "'938'"){
-      data <- subset(data, subset = data$month %in% c(0,5,6,7))
-    }
-
-  } else if (trait == 'SLA') {
-#########################    SLA    ############################
-    ## convert LMA to SLA
-    data <- rbind(data,
-                  derive.traits(function(lma){1/lma},
-                                query.data('LMA', spstr, con=con, store.unconverted=TRUE),
-                                sample.size=sample.size))
-
+  
+  if (trait == "Vcmax") {
+    ######################### VCMAX ############################ Apply Arrhenius scaling to convert Vcmax at measurement temp
+    ######################### to that at 25 degC (ref temp).
+    data <- arrhenius.scaling.traits(data, covariates, c("leafT", "airT", "T"))
+    
     ### Keep only top of canopy/sunlit leaf samples based on covariate.
-    if(nrow(canopy.layer.covs) > 0) data <- filter.sunleaf.traits(data, canopy.layer.covs)
-
-    ## select only summer data for Panicum virgatum
-    ##TODO fix following hack to select only summer data
-    if (spstr == "'938'"){
-      data <- subset(data, subset = data$month %in% c(0,5,6,7,8,NA))
+    if (nrow(canopy.layer.covs) > 0) 
+      data <- filter.sunleaf.traits(data, canopy.layer.covs)
+    
+    ## select only summer data for Panicum virgatum TODO fix following hack to select only summer data
+    if (spstr == "'938'") {
+      data <- subset(data, subset = data$month %in% c(0, 5, 6, 7))
     }
-
-  } else if (trait == 'leaf_turnover_rate'){
-#########################    LEAF TURNOVER    ############################
-    ## convert LMA to SLA
-    data <- rbind(data,
-                  derive.traits(function(leaf.longevity){1/leaf.longevity},
-                                query.data('Leaf Longevity', spstr, con=con, store.unconverted=TRUE),
-                                sample.size=sample.size))
-
-  } else if (trait == 'root_respiration_rate') {
-#########################  ROOT RESPIRATION   ############################
-    ## Apply Arrhenius scaling to convert root respiration at measurement temp
-    ## to that at 25 degC (ref temp).
-    data <- arrhenius.scaling.traits(data, covariates, c('rootT', 'airT','soilT'))
-
-  } else if (trait == 'leaf_respiration_rate_m2') {
-#########################  LEAF RESPIRATION   ############################
-    ## Apply Arrhenius scaling to convert leaf respiration at measurement temp
-    ## to that at 25 degC (ref temp).
-  data <- arrhenius.scaling.traits(data, covariates, c('leafT', 'airT','T'))
-
-  } else if (trait == 'stem_respiration_rate') {
-#########################  STEM RESPIRATION   ############################
-    ## Apply Arrhenius scaling to convert stem respiration at measurement temp
-    ## to that at 25 degC (ref temp).
-    data <- arrhenius.scaling.traits(data, covariates, c('leafT', 'airT'))
-
-  } else if (trait == 'c2n_leaf') {
-#########################  LEAF C:N   ############################
-
-    data <- rbind(data,
-                  derive.traits(function(leafN){48/leafN},
-                                query.data('leafN', spstr, con=con, store.unconverted=TRUE),
-                                sample.size=sample.size))
-
-  } else if (trait == 'fineroot2leaf') {
-#########################  FINE ROOT ALLOCATION  ############################
-    ## FRC_LC is the ratio of fine root carbon to leaf carbon
-    data<-rbind(data, query.data('FRC_LC', spstr, con=con, store.unconverted=TRUE))
+    
+  } else if (trait == "SLA") {
+    ######################### SLA ############################ convert LMA to SLA
+    data <- rbind(data, derive.traits(function(lma) {
+      1/lma
+    }, query.data("LMA", spstr, con = con, store.unconverted = TRUE), sample.size = sample.size))
+    
+    ### Keep only top of canopy/sunlit leaf samples based on covariate.
+    if (nrow(canopy.layer.covs) > 0) 
+      data <- filter.sunleaf.traits(data, canopy.layer.covs)
+    
+    ## select only summer data for Panicum virgatum TODO fix following hack to select only summer data
+    if (spstr == "'938'") {
+      data <- subset(data, subset = data$month %in% c(0, 5, 6, 7, 8, NA))
+    }
+    
+  } else if (trait == "leaf_turnover_rate") {
+    ######################### LEAF TURNOVER ############################ convert LMA to SLA
+    data <- rbind(data, derive.traits(function(leaf.longevity) {
+      1/leaf.longevity
+    }, query.data("Leaf Longevity", spstr, con = con, store.unconverted = TRUE), sample.size = sample.size))
+    
+  } else if (trait == "root_respiration_rate") {
+    ######################### ROOT RESPIRATION ############################ Apply Arrhenius scaling to convert root
+    ######################### respiration at measurement temp to that at 25 degC (ref temp).
+    data <- arrhenius.scaling.traits(data, covariates, c("rootT", "airT", "soilT"))
+    
+  } else if (trait == "leaf_respiration_rate_m2") {
+    ######################### LEAF RESPIRATION ############################ Apply Arrhenius scaling to convert leaf
+    ######################### respiration at measurement temp to that at 25 degC (ref temp).
+    data <- arrhenius.scaling.traits(data, covariates, c("leafT", "airT", "T"))
+    
+  } else if (trait == "stem_respiration_rate") {
+    ######################### STEM RESPIRATION ############################ Apply Arrhenius scaling to convert stem
+    ######################### respiration at measurement temp to that at 25 degC (ref temp).
+    data <- arrhenius.scaling.traits(data, covariates, c("leafT", "airT"))
+    
+  } else if (trait == "c2n_leaf") {
+    ######################### LEAF C:N ############################
+    
+    data <- rbind(data, derive.traits(function(leafN) {
+      48/leafN
+    }, query.data("leafN", spstr, con = con, store.unconverted = TRUE), sample.size = sample.size))
+    
+  } else if (trait == "fineroot2leaf") {
+    ######################### FINE ROOT ALLOCATION ############################ FRC_LC is the ratio of fine root carbon to
+    ######################### leaf carbon
+    data <- rbind(data, query.data("FRC_LC", spstr, con = con, store.unconverted = TRUE))
   }
   result <- data
-
+  
   ## if result is empty, stop run
-
-  if(nrow(result)==0) {
+  
+  if (nrow(result) == 0) {
     return(NA)
     warning(paste("there is no data for", trait))
   } else {
-
-    ## Do we really want to print each trait table?? Seems like a lot of
-    ## info to send to console.  Maybe just print summary stats?
-    ## print(result)
-    if(!update.check.only) {
-      print(paste("Median ",trait," : ",round(median(result$mean,na.rm=TRUE),digits=3),sep=""))
+    
+    ## Do we really want to print each trait table?? Seems like a lot of info to send to console.
+    ## Maybe just print summary stats?  print(result)
+    if (!update.check.only) {
+      print(paste("Median ", trait, " : ", round(median(result$mean, na.rm = TRUE), digits = 3), 
+                  sep = ""))
       print("---------------------------------------------------------")
     }
     # print list of traits queried and number by outdoor/glasshouse
     return(result)
   }
-}
-##==================================================================================================#
-
-
-####################################################################################################
-### EOF.  End of R script file.
-####################################################################################################
+} # query.trait.data
+## ==================================================================================================#

--- a/db/R/query.traits.R
+++ b/db/R/query.traits.R
@@ -1,11 +1,12 @@
 #-------------------------------------------------------------------------------
 # Copyright (c) 2012 University of Illinois, NCSA.
 # All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
+# are made available under the terms of the
 # University of Illinois/NCSA Open Source License
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
+
 #--------------------------------------------------------------------------------------------------#
 ##' Query available trait data associated with a given pft and a list of traits
 ##' 
@@ -25,35 +26,31 @@
 ##' trait.data <- query.traits(spstr, trvec)
 ##' }
 ##' @author David LeBauer, Carl Davidson, Shawn Serbin
-query.traits <- function(spstr, priors, con = NULL, update.check.only=FALSE){
-
-  if(is.null(con)){
+query.traits <- function(spstr, priors, con = NULL, update.check.only = FALSE) {
+  
+  if (is.null(con)) {
     con <- db.open(settings$database$bety)
   }
-  if(is.list(con)){
+  if (is.list(con)) {
     print("query.traits")
     print("WEB QUERY OF DATABASE NOT IMPLEMENTED")
     return(NULL)
   }
   
-  if(!spstr == "''"){
+  if (!spstr == "''") {
     query <- paste("select distinct variables.name from traits join variables 
-                 on (traits.variable_id = variables.id) where specie_id in (", spstr,");", sep = "")
+         on (traits.variable_id = variables.id) where specie_id in (", 
+      spstr, ");", sep = "")
     traits <- db.query(query, con)$name
     traits <- unique(traits[traits %in% priors])
-  
+    
     ### Grab trait data
-    trait.data <- lapply(traits, function(trait) query.trait.data(trait, spstr, con=con, update.check.only=update.check.only))
+    trait.data <- lapply(traits, function(trait) query.trait.data(trait, spstr, con = con, update.check.only = update.check.only))
     names(trait.data) <- traits
   } else {
     trait.data <- list()
   }
   
   return(trait.data)
-}
-#==================================================================================================#
-
-
-####################################################################################################
-### EOF.  End of R script file.          		
-####################################################################################################
+} # query.traits
+# ==================================================================================================#

--- a/db/R/utils.R
+++ b/db/R/utils.R
@@ -1,13 +1,13 @@
 #-------------------------------------------------------------------------------
 # Copyright (c) 2012 University of Illinois, NCSA.
 # All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
+# are made available under the terms of the
 # University of Illinois/NCSA Open Source License
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
 
-.db.utils <- new.env() 
+.db.utils <- new.env()
 .db.utils$created <- 0
 .db.utils$queries <- 0
 .db.utils$deprecated <- 0
@@ -31,9 +31,9 @@
 ##' \dontrun{
 ##' db.query('select count(id) from traits;', params=settings$database$bety)
 ##' }
-db.query <- function(query, con=NULL, params=NULL) {
+db.query <- function(query, con = NULL, params = NULL) {
   iopened <- 0
-  if(is.null(con)){
+  if (is.null(con)) {
     if (is.null(params)) {
       logger.error("No parameters or connection specified")
       stop()
@@ -46,15 +46,16 @@ db.query <- function(query, con=NULL, params=NULL) {
   }
   data <- dbGetQuery(con, query)
   res <- dbGetException(con)
-  if (res$errorNum != 0 || (res$errorMsg != 'OK' && res$errorMsg != '')) {
-    logger.severe(paste("Error executing db query '", query, "' errorcode=", res$errorNum, " message='", res$errorMsg, "'", sep=''))
+  if (res$errorNum != 0 || (res$errorMsg != "OK" && res$errorMsg != "")) {
+    logger.severe(paste("Error executing db query '", query, "' errorcode=", res$errorNum, " message='", 
+                        res$errorMsg, "'", sep = ""))
   }
-  .db.utils$queries <- .db.utils$queries+1
-  if(iopened==1) {
+  .db.utils$queries <- .db.utils$queries + 1
+  if (iopened == 1) {
     db.close(con)
   }
   invisible(data)
-}
+} # db.query
 
 ##' Generic function to open a database connection
 ##'
@@ -74,25 +75,25 @@ db.open <- function(params) {
   params$dbfiles <- NULL
   params$write <- NULL
   if (is.null(params$driver)) {
-    args <- c(drv=dbDriver("PostgreSQL"), params, recursive=TRUE)
+    args <- c(drv = dbDriver("PostgreSQL"), params, recursive = TRUE)
   } else {
-    args <- c(drv=dbDriver(params$driver), params, recursive=TRUE)
-    args[['driver']] <- NULL
+    args <- c(drv = dbDriver(params$driver), params, recursive = TRUE)
+    args[["driver"]] <- NULL
   }
   c <- do.call(dbConnect, as.list(args))
-  id <- sample(1000, size=1)
-  while(length(which(.db.utils$connections$id==id)) != 0) {
-    id <- sample(1000, size=1)
+  id <- sample(1000, size = 1)
+  while (length(which(.db.utils$connections$id == id)) != 0) {
+    id <- sample(1000, size = 1)
   }
   attr(c, "pecanid") <- id
   dump.log <- NULL
-  dump.frames(dumpto="dump.log")
-  .db.utils$created <- .db.utils$created+1
+  dump.frames(dumpto = "dump.log")
+  .db.utils$created <- .db.utils$created + 1
   .db.utils$connections$id <- append(.db.utils$connections$id, id)
   .db.utils$connections$con <- append(.db.utils$connections$con, c)
   .db.utils$connections$log <- append(.db.utils$connections$log, list(dump.log))
   invisible(c)
-}
+} # db.open
 
 ##' Generic function to close a database connection
 ##'
@@ -107,7 +108,7 @@ db.open <- function(params) {
 ##' \dontrun{
 ##' db.close(con)
 ##' }
-db.close <- function(con, showWarnings=TRUE) {
+db.close <- function(con, showWarnings = TRUE) {
   if (is.null(con)) {
     return()
   }
@@ -116,9 +117,9 @@ db.close <- function(con, showWarnings=TRUE) {
   if (showWarnings && is.null(id)) {
     logger.warn("Connection created outside of PEcAn.db package")
   } else {
-    deleteme <- which(.db.utils$connections$id==id)
+    deleteme <- which(.db.utils$connections$id == id)
     if (showWarnings && length(deleteme) == 0) {
-      logger.warn("Connection might have been closed already.");
+      logger.warn("Connection might have been closed already.")
     } else {
       .db.utils$connections$id <- .db.utils$connections$id[-deleteme]
       .db.utils$connections$con <- .db.utils$connections$con[-deleteme]
@@ -126,7 +127,7 @@ db.close <- function(con, showWarnings=TRUE) {
     }
   }
   dbDisconnect(con)
-}
+} # db.close
 
 ##' Debug method for db.open and db.close
 ##'
@@ -149,14 +150,13 @@ db.print.connections <- function() {
   if (length(.db.utils$connections$id) == 0) {
     logger.debug("No open database connections.\n")
   } else {
-    for(x in 1:length(.db.utils$connections$id)) {
+    for (x in seq_along(.db.utils$connections$id)) {
       logger.info(paste("Connection", x, "with id", .db.utils$connections$id[[x]], "was created at:\n"))
       logger.info(paste("\t", names(.db.utils$connections$log[[x]]), "\n"))
-      #      cat("\t database object : ")
-      #      print(.db.utils$connections$con[[x]])
+      # cat('\t database object : ') print(.db.utils$connections$con[[x]])
     }
   }
-}
+} # db.print.connections
 
 ##' Test connection to database
 ##' 
@@ -166,7 +166,7 @@ db.print.connections <- function() {
 ##' @return TRUE if database connection works; else FALSE
 ##' @export
 ##' @author David LeBauer, Rob Kooper
-db.exists <- function(params, write=TRUE, table=NA) {
+db.exists <- function(params, write = TRUE, table = NA) {
   # open connection
   con <- tryCatch({
     invisible(db.open(params))
@@ -178,30 +178,32 @@ db.exists <- function(params, write=TRUE, table=NA) {
     return(invisible(FALSE))
   }
   
-  #check table's privilege about read and write permission
+  # check table's privilege about read and write permission
   user.permission <<- tryCatch({
-    invisible(db.query(paste0("select privilege_type from information_schema.role_table_grants where grantee='",params$user,"' and table_catalog = '",params$dbname,"' and table_name='",table,"'"), con))
+    invisible(db.query(paste0("select privilege_type from information_schema.role_table_grants where grantee='", 
+                              params$user, "' and table_catalog = '", params$dbname, "' and table_name='", table, "'"), 
+                       con))
   }, error = function(e) {
     logger.error("Could not query database.\n\t", e)
     db.close(con)
     invisible(NULL)
   })
-
-  if (!is.na(table)){
-    read.perm = FALSE
-    write.perm = FALSE
+  
+  if (!is.na(table)) {
+    read.perm <- FALSE
+    write.perm <- FALSE
     
     # check read permission
-    if ('SELECT' %in% user.permission[['privilege_type']]) {
-      read.perm = TRUE
+    if ("SELECT" %in% user.permission[["privilege_type"]]) {
+      read.perm <- TRUE
     }
     
-    #check write permission
-    if ('INSERT' %in% user.permission[['privilege_type']] &&'UPDATE' %in% user.permission[['privilege_type']] ) {
-      write.perm = TRUE
+    # check write permission
+    if ("INSERT" %in% user.permission[["privilege_type"]] && "UPDATE" %in% user.permission[["privilege_type"]]) {
+      write.perm <- TRUE
     }
     
-    if (read.perm == FALSE){
+    if (read.perm == FALSE) {
       return(invisible(FALSE))
     }
     
@@ -212,7 +214,7 @@ db.exists <- function(params, write=TRUE, table=NA) {
       logger.error("Could not query database.\n\t", e)
       db.close(con)
       invisible(NULL)
-    })  
+    })
     if (is.null(read.result)) {
       return(invisible(FALSE))
     }
@@ -220,13 +222,15 @@ db.exists <- function(params, write=TRUE, table=NA) {
     # get the table's primary key column
     get.key <- tryCatch({
       db.query(paste("SELECT pg_attribute.attname,format_type(pg_attribute.atttypid, pg_attribute.atttypmod) 
-                     FROM pg_index, pg_class, pg_attribute 
-                     WHERE 
-                     pg_class.oid = '",table,"'::regclass AND
-                     indrelid = pg_class.oid AND
-                     pg_attribute.attrelid = pg_class.oid AND 
-                     pg_attribute.attnum = any(pg_index.indkey)
-                     AND indisprimary"), con)     
+           FROM pg_index, pg_class, pg_attribute 
+           WHERE 
+           pg_class.oid = '", 
+                     table, "'::regclass AND
+           indrelid = pg_class.oid AND
+           pg_attribute.attrelid = pg_class.oid AND 
+           pg_attribute.attnum = any(pg_index.indkey)
+           AND indisprimary"), 
+               con)
     }, error = function(e) {
       logger.error("Could not query database.\n\t", e)
       db.close(con)
@@ -239,27 +243,25 @@ db.exists <- function(params, write=TRUE, table=NA) {
     # if requested write a row to the database
     if (write) {
       # in the case when has read permission but no write
-      if (write.perm == FALSE)
-      {
+      if (write.perm == FALSE) {
         return(invisible(FALSE))
       }
       
       # when the permission correct to check whether write works
-      key <- get.key$attname 
-      key.value<- read.result[key]
+      key <- get.key$attname
+      key.value <- read.result[key]
       coln.name <- names(read.result)
       write.coln <- ""
-      for (name in coln.name)
-      {
-        if (name != key)
-        {
-          write.coln <- name 
-          break 
+      for (name in coln.name) {
+        if (name != key) {
+          write.coln <- name
+          break
         }
       }
       write.value <- read.result[write.coln]
       result <- tryCatch({
-        db.query(paste("UPDATE ", table, " SET ", write.coln,"='", write.value, "' WHERE ",  key, "=", key.value, sep=""), con)
+        db.query(paste("UPDATE ", table, " SET ", write.coln, "='", write.value, "' WHERE ", 
+                       key, "=", key.value, sep = ""), con)
         invisible(TRUE)
       }, error = function(e) {
         logger.error("Could not write to database.\n\t", e)
@@ -268,12 +270,9 @@ db.exists <- function(params, write=TRUE, table=NA) {
     } else {
       result <- TRUE
     }
-  }
-  
-  else{
+  } else {
     result <- TRUE
   }
-  
   
   # close database, all done
   tryCatch({
@@ -283,7 +282,7 @@ db.exists <- function(params, write=TRUE, table=NA) {
   })
   
   invisible(result)
-}
+} # db.exists
 
 ##' Sets if the queries should be shown that are being executed
 ##' 
@@ -294,7 +293,7 @@ db.exists <- function(params, write=TRUE, table=NA) {
 ##' @author Rob Kooper
 db.showQueries <- function(show) {
   .db.utils$showquery <- show
-}
+} # db.showQueries
 
 ##' Returns if the queries should be shown that are being executed
 ##' 
@@ -304,7 +303,7 @@ db.showQueries <- function(show) {
 ##' @author Rob Kooper
 db.getShowQueries <- function() {
   invisible(.db.utils$showquery)
-}
+} # db.getShowQueries
 
 ##' Retrieve id from a table matching query
 ##' 
@@ -317,22 +316,26 @@ db.getShowQueries <- function() {
 ##' @author David LeBauer
 ##' @examples
 ##' \dontrun{
-##' pftid <- get.id("pfts", "name", "salix", con)
-##' pftid <- get.id("pfts", c("name", "modeltype_id"), c("ebifarm.salix", 1), con)
+##' pftid <- get.id('pfts', 'name', 'salix', con)
+##' pftid <- get.id('pfts', c('name', 'modeltype_id'), c('ebifarm.salix', 1), con)
 ##' }
-get.id <- function(table, colnames, values, con, create=FALSE, dates=FALSE){
+get.id <- function(table, colnames, values, con, create = FALSE, dates = FALSE) {
   values <- lapply(values, function(x) ifelse(is.character(x), shQuote(x), x))
-  where_clause <- paste(colnames, values , sep = " = ", collapse = " and ")
+  where_clause <- paste(colnames, values, sep = " = ", collapse = " and ")
   query <- paste("select id from", table, "where", where_clause, ";")
   id <- db.query(query, con)[["id"]]
   if (is.null(id) && create) {
-    colinsert <- paste0(colnames, collapse=", ")
-    if (dates) colinsert <- paste0(colinsert, ", created_at, updated_at")
-    valinsert <- paste0(values, collapse=", ")
-    if (dates) valinsert <- paste0(valinsert, ", NOW(), NOW()")
+    colinsert <- paste0(colnames, collapse = ", ")
+    if (dates) {
+      colinsert <- paste0(colinsert, ", created_at, updated_at")
+    }
+    valinsert <- paste0(values, collapse = ", ")
+    if (dates) {
+      valinsert <- paste0(valinsert, ", NOW(), NOW()")
+    }
     logger.info("INSERT INTO ", table, " (", colinsert, ") VALUES (", valinsert, ")")
     db.query(paste0("INSERT INTO ", table, " (", colinsert, ") VALUES (", valinsert, ")"), con)
     id <- db.query(query, con)[["id"]]
   }
   return(id)
-}
+} # get.id


### PR DESCRIPTION
Ran through formatR::tidy_dir with arrow=TRUE and indent=2; made sure all if blocks have braces; cracked down on over-length lines; changed `require` calls to `library`.

Note significant (non-style) changes made:
* in `query.data.R`, execution would never reach final `db.close` call. Moved it to before `return`