### PR TITLE
Fix end-of-function problems (#1040 and #1041)

### DIFF
--- a/db/R/query.site.R
+++ b/db/R/query.site.R
@@ -10,7 +10,9 @@ query.site <- function(site.id,con){
   site <- db.query(paste("SELECT *, ST_X(ST_CENTROID(geometry)) AS lon, ST_Y(ST_CENTROID(geometry))
                          AS lat FROM sites WHERE id =",site.id),con)
   if(nrow(site)==0){logger.error("Site not found"); return(NULL)}
-  if(!(is.na(site$lat)) && !(is.na(site$lat))){
+  if(!(is.na(site$lon)) && !(is.na(site$lat))){
     return(site)
+  } else {
+    return(NULL)
   }
 }

--- a/db/R/query.trait.data.R
+++ b/db/R/query.trait.data.R
@@ -193,6 +193,8 @@ arrhenius.scaling.traits <- function(data, covariates, temp.covariates, new.temp
 
     #remove temporary covariate column.
     data<-data[,colnames(data)!='temp']
+  } else {
+    data <- NULL
   }
   return(data)
 }
@@ -215,6 +217,8 @@ filter.sunleaf.traits <- function(data, covariates){
     
     # remove temporary covariate column
     data<-data[,colnames(data)!='canopy_layer']
+  } else {
+    data <- NULL
   }
   return(data)
 }


### PR DESCRIPTION
Proposed fixes for issues #1040 and #1041. Re 1041, I’m assuming that`arrhenius.scaling.traits` and `filter.sunleaf.traits` should return NULL if there are no covariates.