### PR TITLE
Style cleanup for `models/dalec/R/*.R` scripts

### DIFF
--- a/models/dalec/R/met2model.DALEC.R
+++ b/models/dalec/R/met2model.DALEC.R
@@ -6,12 +6,12 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-#
-## R Code to convert NetCDF CF met files into DALEC met files
 
-##If files already exist in "Outfolder", the default function is NOT to overwrite them and 
-##only gives user the notice that file already exists. If user wants to overwrite the existing files, just change 
-##overwrite statement below to TRUE.
+# R Code to convert NetCDF CF met files into DALEC met files
+
+## If files already exist in 'Outfolder', the default function is NOT to overwrite them and only
+## gives user the notice that file already exists. If user wants to overwrite the existing files,
+## just change overwrite statement below to TRUE.
 
 ##' met2model for DALEC
 ##'
@@ -24,32 +24,37 @@
 ##' @param end_date the end date of the data to be downloaded (will only use the year part of the date)
 ##' @param overwrite should existing files be overwritten
 ##' @param verbose should the function be very verbose
-met2model.DALEC <- function(in.path, in.prefix, outfolder, start_date, end_date, ..., overwrite=FALSE,verbose=FALSE){
+met2model.DALEC <- function(in.path, in.prefix, outfolder, start_date, end_date,
+                            overwrite = FALSE, verbose = FALSE) {
   
-  ## DALEC 1 driver format (.csv):
-  ## Runday,  Min temp (°C), Max temp (°C), Radiation (MJ d-1), Atmospheric CO2 (μmol mol-1), Day of year
+  ## DALEC 1 driver format (.csv): Runday, Min temp (°C), Max temp (°C), Radiation (MJ d-1),
+  ## Atmospheric CO2 (μmol mol-1), Day of year
   
-  ## DALEC EnKF (Quaife) format (.dat, space delimited):
-  ## The nine columns of driving data are: day of year; mean air temperature (deg C); max daily temperature (deg C); min daily temperature (deg C); incident radiation (MJ/m2/day); maximum soil-leaf water potential difference (MPa); atmospheric carbon dioxide concentration (ppm); total plant-soil hydraulic resistance (MPa.m2.s/mmol-1); average foliar nitorgen (gC/m2 leaf area).
-  ## Calculate these from air_temperature (K), surface_downwelling_shortwave_flux_in_air (W/m2), CO2 (ppm)
+  ## DALEC EnKF (Quaife) format (.dat, space delimited): The nine columns of driving data are: day
+  ## of year; mean air temperature (deg C); max daily temperature (deg C); min daily temperature
+  ## (deg C); incident radiation (MJ/m2/day); maximum soil-leaf water potential difference (MPa);
+  ## atmospheric carbon dioxide concentration (ppm); total plant-soil hydraulic resistance
+  ## (MPa.m2.s/mmol-1); average foliar nitorgen (gC/m2 leaf area).  Calculate these from
+  ## air_temperature (K), surface_downwelling_shortwave_flux_in_air (W/m2), CO2 (ppm)
   
-  if(!require(PEcAn.utils)) print("install PEcAn.utils")
+  if (!require(PEcAn.utils)) {
+    print("install PEcAn.utils")
+  }
   
   start_date <- as.POSIXlt(start_date, tz = "GMT")
-  end_date<- as.POSIXlt(end_date, tz = "GMT")
-  out.file <- paste(in.prefix,
-                    strptime(start_date, "%Y-%m-%d"),
-                    strptime(end_date, "%Y-%m-%d"),
-                    "dat", sep=".")
+  end_date <- as.POSIXlt(end_date, tz = "GMT")
+  out.file <- paste(in.prefix, strptime(start_date, "%Y-%m-%d"), 
+                    strptime(end_date, "%Y-%m-%d"), 
+                    "dat", sep = ".")
   out.file.full <- file.path(outfolder, out.file)
   
-  results <- data.frame(file=c(out.file.full),
-                        host=c(fqdn()),
-                        mimetype=c('text/plain'),
-                        formatname=c('DALEC meteorology'),
-                        startdate=c(start_date),
-                        enddate=c(end_date),
-                        dbfile.name = out.file,
+  results <- data.frame(file = c(out.file.full), 
+                        host = c(fqdn()),
+                        mimetype = c("text/plain"), 
+                        formatname = c("DALEC meteorology"), 
+                        startdate = c(start_date), 
+                        enddate = c(end_date), 
+                        dbfile.name = out.file, 
                         stringsAsFactors = FALSE)
   print("internal results")
   print(results)
@@ -59,13 +64,13 @@ met2model.DALEC <- function(in.path, in.prefix, outfolder, start_date, end_date,
     return(invisible(results))
   }
   
-  require(ncdf4)
-  require(lubridate)
-  require(PEcAn.data.atmosphere)
-  #  require(ncdf)
+  library(ncdf4)
+  library(lubridate)
+  library(PEcAn.data.atmosphere)
+  # require(ncdf)
   
   ## check to see if the outfolder is defined, if not create directory for output
-  if(!file.exists(outfolder)){
+  if (!file.exists(outfolder)) {
     dir.create(outfolder)
   }
   
@@ -75,103 +80,99 @@ met2model.DALEC <- function(in.path, in.prefix, outfolder, start_date, end_date,
   start_year <- year(start_date)
   end_year <- year(end_date)
   
-  ## loop over files
-  # TODO need to filter out the data that is not inside start_date, end_date
-  for(year in start_year:end_year) {
+  ## loop over files TODO need to filter out the data that is not inside start_date, end_date
+  for (year in start_year:end_year) {
     print(year)
     ## Assuming default values for leaf water potential, hydraulic resistance, foliar N
-    leafN = 2.5
-    HydResist = 1
-    LeafWaterPot = -0.8
+    leafN <- 2.5
+    HydResist <- 1
+    LeafWaterPot <- -0.8
     
-    old.file <- file.path(in.path, paste(in.prefix, year, "nc", sep="."))
+    old.file <- file.path(in.path, paste(in.prefix, year, "nc", sep = "."))
     
     ## open netcdf
     nc <- nc_open(old.file)
     
     ## convert time to seconds
-    sec   <- nc$dim$time$vals  
-    sec = udunits2::ud.convert(sec,unlist(strsplit(nc$dim$time$units," "))[1],"seconds")
-    timestep.s=86400 #seconds in a day
-    ifelse(leap_year(year)==TRUE,
-           dt <- (366*24*60*60)/length(sec), #leap year
-           dt <- (365*24*60*60)/length(sec)) #non-leap year
-    tstep = round(timestep.s/dt)
-    dt = timestep.s/tstep #dt is now an integer
+    sec <- nc$dim$time$vals
+    sec <- udunits2::ud.convert(sec, unlist(strsplit(nc$dim$time$units, " "))[1], "seconds")
+    timestep.s <- 86400  # seconds in a day
+    ifelse(leap_year(year) == TRUE, 
+           dt <- (366 * 24 * 60 * 60) / length(sec), # leap year 
+           dt <- (365 * 24 * 60 * 60) / length(sec)) # non-leap year
+    tstep <- round(timestep.s / dt)
+    dt <- timestep.s / tstep  #dt is now an integer
     
     ## extract variables
-    lat  <- ncvar_get(nc,"latitude")
-    lon  <- ncvar_get(nc,"longitude")
-    Tair <- ncvar_get(nc,"air_temperature")  ## in Kelvin
-    SW   <- ncvar_get(nc,"surface_downwelling_shortwave_flux_in_air") ## in W/m2
-    CO2  <- try(ncvar_get(nc,"mole_fraction_of_carbon_dioxide_in_air"))
+    lat <- ncvar_get(nc, "latitude")
+    lon <- ncvar_get(nc, "longitude")
+    Tair <- ncvar_get(nc, "air_temperature")  ## in Kelvin
+    SW <- ncvar_get(nc, "surface_downwelling_shortwave_flux_in_air")  ## in W/m2
+    CO2 <- try(ncvar_get(nc, "mole_fraction_of_carbon_dioxide_in_air"))
     nc_close(nc)
     
-    useCO2 = is.numeric(CO2)  
-    if(useCO2)  CO2 <- CO2 * 1e6  ## convert from mole fraction (kg/kg) to ppm
-    
+    useCO2 <- is.numeric(CO2)
+    if (useCO2) 
+      CO2 <- CO2 * 1e+06  ## convert from mole fraction (kg/kg) to ppm
     
     ## is CO2 present?
-    if(!is.numeric(CO2)){
-      logger.warn("CO2 not found in",old.file,"setting to default: 400 ppm")
-      CO2 = rep(400,length(Tair))
+    if (!is.numeric(CO2)) {
+      logger.warn("CO2 not found in", old.file, "setting to default: 400 ppm")
+      CO2 <- rep(400, length(Tair))
     }
     
-    if(length(leafN) == 1){
-      logger.warn("Leaf N not specified, setting to default: ",leafN)
-      leafN = rep(leafN,length(Tair))
-    }  
-    if(length(HydResist)==1){
-      logger.warn("total plant-soil hydraulic resistance (MPa.m2.s/mmol-1) not specified, setting to default: ",HydResist)
-      HydResist = rep(HydResist,length(Tair))
+    if (length(leafN) == 1) {
+      logger.warn("Leaf N not specified, setting to default: ", leafN)
+      leafN <- rep(leafN, length(Tair))
     }
-    if(length(LeafWaterPot)==1){
-      logger.warn("maximum soil-leaf water potential difference (MPa) not specified, setting to default: ",LeafWaterPot)
-      LeafWaterPot = rep(LeafWaterPot,length(Tair))
+    if (length(HydResist) == 1) {
+      logger.warn("total plant-soil hydraulic resistance (MPa.m2.s/mmol-1) not specified, setting to default: ", 
+                  HydResist)
+      HydResist <- rep(HydResist, length(Tair))
+    }
+    if (length(LeafWaterPot) == 1) {
+      logger.warn("maximum soil-leaf water potential difference (MPa) not specified, setting to default: ", 
+                  LeafWaterPot)
+      LeafWaterPot <- rep(LeafWaterPot, length(Tair))
     }
     
-    ##build day of year
-    doy <- rep(1:365,each=timestep.s/dt)[1:length(sec)]
-    if(year %% 4 == 0){  ## is leap
-      doy <- rep(1:366,each=timestep.s/dt)[1:length(sec)]
+    ## build day of year
+    doy <- rep(1:365, each = timestep.s / dt)[1:length(sec)]
+    if (year %% 4 == 0) {
+      ## is leap
+      doy <- rep(1:366, each = timestep.s / dt)[1:length(sec)]
     }
     
     ## Aggregate variables up to daily
-    Tmean = udunits2::ud.convert(tapply(Tair,doy,mean,na.rm=TRUE),"Kelvin","Celsius")
-    Tmin  = udunits2::ud.convert(tapply(Tair,doy,min,na.rm=TRUE),"Kelvin","Celsius")
-    Tmax  = udunits2::ud.convert(tapply(Tair,doy,max,na.rm=TRUE),"Kelvin","Celsius")
-    Rin   = tapply(SW,doy,sum)*dt*1e-6 # J/m2/s * s * MJ/J
-    LeafWaterPot = tapply(LeafWaterPot,doy,mean)
-    CO2   = tapply(CO2,doy,mean)
-    HydResist = tapply(HydResist,doy,mean)
-    leafN = tapply(leafN,doy,mean)
-    doy   = tapply(doy,doy,mean)
+    Tmean <- udunits2::ud.convert(tapply(Tair, doy, mean, na.rm = TRUE), "Kelvin", "Celsius")
+    Tmin <- udunits2::ud.convert(tapply(Tair, doy, min, na.rm = TRUE), "Kelvin", "Celsius")
+    Tmax <- udunits2::ud.convert(tapply(Tair, doy, max, na.rm = TRUE), "Kelvin", "Celsius")
+    Rin <- tapply(SW, doy, sum) * dt * 1e-06  # J/m2/s * s * MJ/J
+    LeafWaterPot <- tapply(LeafWaterPot, doy, mean)
+    CO2 <- tapply(CO2, doy, mean)
+    HydResist <- tapply(HydResist, doy, mean)
+    leafN <- tapply(leafN, doy, mean)
+    doy <- tapply(doy, doy, mean)
     
-    ## The nine columns of driving data are: day of year; mean air temperature (deg C); max daily temperature (deg C); min daily temperature (deg C); incident radiation (MJ/m2/day); maximum soil-leaf water potential difference (MPa); atmospheric carbon dioxide concentration (ppm); total plant-soil hydraulic resistance (MPa.m2.s/mmol-1); average foliar nitorgen (gC/m2 leaf area).
+    ## The nine columns of driving data are: day of year; mean air temperature (deg C); max daily
+    ## temperature (deg C); min daily temperature (deg C); incident radiation (MJ/m2/day); maximum
+    ## soil-leaf water potential difference (MPa); atmospheric carbon dioxide concentration (ppm);
+    ## total plant-soil hydraulic resistance (MPa.m2.s/mmol-1); average foliar nitorgen (gC/m2 leaf
+    ## area).
     
     ## build data matrix
-    tmp <- cbind(doy,
-                 Tmean,
-                 Tmax,
-                 Tmin,
-                 Rin,
-                 LeafWaterPot,
-                 CO2,
-                 HydResist,
-                 leafN)
+    tmp <- cbind(doy, Tmean, Tmax, Tmin, Rin, LeafWaterPot, CO2, HydResist, leafN)
     
-    if(is.null(out)){
-      out = tmp
+    if (is.null(out)) {
+      out <- tmp
     } else {
-      out = rbind(out,tmp)
+      out <- rbind(out, tmp)
     }
-    
-  } ## end loop over years
+  }  ## end loop over years
   
   ## write output
-  write.table(out,out.file.full,quote = FALSE,sep=" ",row.names=FALSE,col.names=FALSE)
+  write.table(out, out.file.full, quote = FALSE, sep = " ", row.names = FALSE, col.names = FALSE)
   
   invisible(results)
   
-  
-}
+} # met2model.DALEC

--- a/models/dalec/R/met2model.DALEC.R
+++ b/models/dalec/R/met2model.DALEC.R
@@ -25,7 +25,7 @@
 ##' @param overwrite should existing files be overwritten
 ##' @param verbose should the function be very verbose
 met2model.DALEC <- function(in.path, in.prefix, outfolder, start_date, end_date,
-                            overwrite = FALSE, verbose = FALSE) {
+                            overwrite = FALSE, verbose = FALSE, ...) {
   
   ## DALEC 1 driver format (.csv): Runday, Min temp (°C), Max temp (°C), Radiation (MJ d-1),
   ## Atmospheric CO2 (μmol mol-1), Day of year
@@ -101,14 +101,14 @@ met2model.DALEC <- function(in.path, in.prefix, outfolder, start_date, end_date,
            dt <- (366 * 24 * 60 * 60) / length(sec), # leap year 
            dt <- (365 * 24 * 60 * 60) / length(sec)) # non-leap year
     tstep <- round(timestep.s / dt)
-    dt <- timestep.s / tstep  #dt is now an integer
+    dt    <- timestep.s / tstep  #dt is now an integer
     
     ## extract variables
-    lat <- ncvar_get(nc, "latitude")
-    lon <- ncvar_get(nc, "longitude")
+    lat  <- ncvar_get(nc, "latitude")
+    lon  <- ncvar_get(nc, "longitude")
     Tair <- ncvar_get(nc, "air_temperature")  ## in Kelvin
-    SW <- ncvar_get(nc, "surface_downwelling_shortwave_flux_in_air")  ## in W/m2
-    CO2 <- try(ncvar_get(nc, "mole_fraction_of_carbon_dioxide_in_air"))
+    SW   <- ncvar_get(nc, "surface_downwelling_shortwave_flux_in_air")  ## in W/m2
+    CO2  <- try(ncvar_get(nc, "mole_fraction_of_carbon_dioxide_in_air"))
     nc_close(nc)
     
     useCO2 <- is.numeric(CO2)
@@ -144,15 +144,15 @@ met2model.DALEC <- function(in.path, in.prefix, outfolder, start_date, end_date,
     }
     
     ## Aggregate variables up to daily
-    Tmean <- udunits2::ud.convert(tapply(Tair, doy, mean, na.rm = TRUE), "Kelvin", "Celsius")
-    Tmin <- udunits2::ud.convert(tapply(Tair, doy, min, na.rm = TRUE), "Kelvin", "Celsius")
-    Tmax <- udunits2::ud.convert(tapply(Tair, doy, max, na.rm = TRUE), "Kelvin", "Celsius")
-    Rin <- tapply(SW, doy, sum) * dt * 1e-06  # J/m2/s * s * MJ/J
+    Tmean        <- udunits2::ud.convert(tapply(Tair, doy, mean, na.rm = TRUE), "Kelvin", "Celsius")
+    Tmin         <- udunits2::ud.convert(tapply(Tair, doy, min, na.rm = TRUE), "Kelvin", "Celsius")
+    Tmax         <- udunits2::ud.convert(tapply(Tair, doy, max, na.rm = TRUE), "Kelvin", "Celsius")
+    Rin          <- tapply(SW, doy, sum) * dt * 1e-06  # J/m2/s * s * MJ/J
     LeafWaterPot <- tapply(LeafWaterPot, doy, mean)
-    CO2 <- tapply(CO2, doy, mean)
-    HydResist <- tapply(HydResist, doy, mean)
-    leafN <- tapply(leafN, doy, mean)
-    doy <- tapply(doy, doy, mean)
+    CO2          <- tapply(CO2, doy, mean)
+    HydResist    <- tapply(HydResist, doy, mean)
+    leafN        <- tapply(leafN, doy, mean)
+    doy          <- tapply(doy, doy, mean)
     
     ## The nine columns of driving data are: day of year; mean air temperature (deg C); max daily
     ## temperature (deg C); min daily temperature (deg C); incident radiation (MJ/m2/day); maximum

--- a/models/dalec/R/model2netcdf.DALEC.R
+++ b/models/dalec/R/model2netcdf.DALEC.R
@@ -1,11 +1,12 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2012 NCSA.
+# Copyright (c) 2015 Boston University, NCSA.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the 
-# University of Illinois/NCSA Open Source License
+# NCSA Open Source License
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
+
 #--------------------------------------------------------------------------------------------------#
 ##' Convert DALEC output to netCDF
 ##'
@@ -21,23 +22,23 @@
 ##' @author Shawn Serbin, Michael Dietze
 model2netcdf.DALEC <- function(outdir, sitelat, sitelon, start_date, end_date) {
   
-require(PEcAn.utils)
-require(ncdf4)
-
+  library(PEcAn.utils)
+  library(ncdf4)
+  
   ### Read in model output in DALEC format
-  DALEC.output <- read.table(file.path(outdir, "out.txt"), header=FALSE,sep='')
+  DALEC.output <- read.table(file.path(outdir, "out.txt"), header = FALSE, sep = "")
   DALEC.output.dims <- dim(DALEC.output)
-
+  
   ### Determine number of years and output timestep
-  days = as.Date(start_date):as.Date(end_date)
-  year = strftime(as.Date(days,origin="1970-01-01"), "%Y")
+  days <- as.Date(start_date):as.Date(end_date)
+  year <- strftime(as.Date(days, origin = "1970-01-01"), "%Y")
   num.years <- length(unique(year))
   years <- unique(year)
   timestep.s <- 86400
   
   ### Loop over years in DALEC output to create separate netCDF outputs
-  for (y in years){
-    if (file.exists(file.path(outdir, paste(y,"nc", sep=".")))) {
+  for (y in years) {
+    if (file.exists(file.path(outdir, paste(y, "nc", sep = ".")))) {
       next
     }
     print(paste("---- Processing year: ", y))  # turn on for debugging
@@ -45,92 +46,81 @@ require(ncdf4)
     ## Subset data for processing
     sub.DALEC.output <- subset(DALEC.output, year == y)
     sub.DALEC.output.dims <- dim(sub.DALEC.output)
-
+    
     ## Setup outputs for netCDF file in appropriate units
     output <- list()
     ## standard variables: Fluxes
-    output[[1]] <- (sub.DALEC.output[,1] * 0.001) / timestep.s # Autotrophic Respiration in kgC/m2/s
-    output[[2]] <- (sub.DALEC.output[,21] + sub.DALEC.output[,23])*0.001/timestep.s # Heterotrophic Resp kgC/m2/s
-    output[[3]] <- (sub.DALEC.output[,31]*0.001)/timestep.s     # GPP in kgC/m2/s    
-    output[[4]] <- (sub.DALEC.output[,33]* 0.001) / timestep.s  # NEE in kgC/m2/s
-    output[[5]] <- (sub.DALEC.output[,3] + sub.DALEC.output[,5] 
-                    + sub.DALEC.output[,7])*0.001/timestep.s # NPP kgC/m2/s
+    output[[1]] <- (sub.DALEC.output[, 1] * 0.001)/timestep.s  # Autotrophic Respiration in kgC/m2/s
+    output[[2]] <- (sub.DALEC.output[, 21] + sub.DALEC.output[, 23]) * 0.001 / timestep.s  # Heterotrophic Resp kgC/m2/s
+    output[[3]] <- (sub.DALEC.output[, 31] * 0.001)/timestep.s  # GPP in kgC/m2/s    
+    output[[4]] <- (sub.DALEC.output[, 33] * 0.001)/timestep.s  # NEE in kgC/m2/s
+    output[[5]] <- (sub.DALEC.output[, 3] + sub.DALEC.output[, 5] + sub.DALEC.output[, 7]) * 
+      0.001/timestep.s  # NPP kgC/m2/s
     
     ## non-standard variables: Fluxes
-    output[[6]] <- (sub.DALEC.output[,9]* 0.001) / timestep.s   # Leaf Litter, kgC/m2/s
-    output[[7]] <- (sub.DALEC.output[,11]* 0.001) / timestep.s  # Woody Litter, kgC/m2/s
-    output[[8]] <- (sub.DALEC.output[,13]* 0.001) / timestep.s  # Root Litter, kgC/m2/s
+    output[[6]] <- (sub.DALEC.output[, 9] * 0.001) / timestep.s  # Leaf Litter, kgC/m2/s
+    output[[7]] <- (sub.DALEC.output[, 11] * 0.001) / timestep.s  # Woody Litter, kgC/m2/s
+    output[[8]] <- (sub.DALEC.output[, 13] * 0.001) / timestep.s  # Root Litter, kgC/m2/s
     
     ## non-standard variables: Pools
-    output[[9]]  <- (sub.DALEC.output[,15]* 0.001)    # Leaf Biomass, kgC/m2
-    output[[10]] <- (sub.DALEC.output[,17]* 0.001)    # Wood Biomass, kgC/m2
-    output[[11]] <- (sub.DALEC.output[,19]* 0.001)    # Root Biomass, kgC/m2
-    output[[12]] <- (sub.DALEC.output[,27]* 0.001)    # Litter Biomass, kgC/m2
-    output[[13]] <- (sub.DALEC.output[,29]* 0.001)    # Soil C, kgC/m2
+    output[[9]] <- (sub.DALEC.output[, 15] * 0.001)  # Leaf Biomass, kgC/m2
+    output[[10]] <- (sub.DALEC.output[, 17] * 0.001)  # Wood Biomass, kgC/m2
+    output[[11]] <- (sub.DALEC.output[, 19] * 0.001)  # Root Biomass, kgC/m2
+    output[[12]] <- (sub.DALEC.output[, 27] * 0.001)  # Litter Biomass, kgC/m2
+    output[[13]] <- (sub.DALEC.output[, 29] * 0.001)  # Soil C, kgC/m2
     
     ## standard composites
-    output[[14]] = output[[1]] + output[[2]] # Total Respiration
-    output[[15]] = output[[9]] + output[[10]] + output[[11]] ## TotLivBiom
-    output[[16]] = output[[12]] + output[[13]] ## TotSoilCarb
-          
-    #******************** Declare netCDF variables ********************#
-    t <- ncdim_def(name = "time",
-                   units = paste0("days since ", y, "-01-01 00:00:00"),
-                   vals = 1:nrow(sub.DALEC.output),
-                   calendar = "standard", unlim = TRUE)
-    lat <- ncdim_def("lat", "degrees_east",
-                     vals =  as.numeric(sitelat),
-                     longname = "station_latitude") 
-    lon <- ncdim_def("lon", "degrees_north",
-                     vals = as.numeric(sitelon),
-                     longname = "station_longitude")
-
-   ## ***** Need to dynamically update the UTC offset here *****
+    output[[14]] <- output[[1]] + output[[2]]  # Total Respiration
+    output[[15]] <- output[[9]] + output[[10]] + output[[11]]  ## TotLivBiom
+    output[[16]] <- output[[12]] + output[[13]]  ## TotSoilCarb
     
-    for(i in 1:length(output)){
-      if(length(output[[i]])==0) output[[i]] <- rep(-999,length(t$vals))
+    # ******************** Declare netCDF variables ********************#
+    t <- ncdim_def(name = "time", units = paste0("days since ", y, "-01-01 00:00:00"), vals = 1:nrow(sub.DALEC.output), 
+      calendar = "standard", unlim = TRUE)
+    lat <- ncdim_def("lat", "degrees_east", vals = as.numeric(sitelat), longname = "station_latitude")
+    lon <- ncdim_def("lon", "degrees_north", vals = as.numeric(sitelon), longname = "station_longitude")
+    
+    ## ***** Need to dynamically update the UTC offset here *****
+    
+    for (i in seq_along(output)) {
+      if (length(output[[i]]) == 0) 
+        output[[i]] <- rep(-999, length(t$vals))
     }
     
     var <- list()
-   var[[1]]  <- mstmipvar("AutoResp", lat, lon, t, NA)
-   var[[2]]  <- mstmipvar("HeteroResp", lat, lon, t, NA)
-   var[[3]]  <- mstmipvar("GPP", lat, lon, t, NA)
-   var[[4]]  <- mstmipvar("NEE", lat, lon, t, NA) 
-   var[[5]]  <- mstmipvar("NPP", lat, lon, t, NA)
-   
-   var[[6]]  <- ncvar_def("LeafLitter", "kgC/m2/s", list(lon,lat,t), -999)
-   var[[7]]  <- ncvar_def("WoodyLitter", "kgC/m2/s", list(lon,lat,t), -999)
-   var[[8]]  <- ncvar_def("RootLitter", "kgC/m2/s", list(lon,lat,t), -999)
-   var[[9]]  <- ncvar_def("LeafBiomass", "kgC/m2", list(lon,lat,t), -999)
-   var[[10]]  <- ncvar_def("WoodBiomass", "kgC/m2", list(lon,lat,t), -999)
-   var[[11]]  <- ncvar_def("RootBiomass", "kgC/m2", list(lon,lat,t), -999)
-   var[[12]]  <- ncvar_def("LitterBiomass", "kgC/m2", list(lon,lat,t), -999)
-   var[[13]]  <- ncvar_def("SoilC", "kgC/m2", list(lon,lat,t), -999)
-   
-    var[[14]]  <- mstmipvar("TotalResp", lat, lon, t, NA)
-    var[[15]]  <- mstmipvar("TotLivBiom", lat, lon, t, NA)
-    var[[16]]  <- mstmipvar("TotSoilCarb", lat, lon, t, NA)
+    var[[1]] <- mstmipvar("AutoResp", lat, lon, t, NA)
+    var[[2]] <- mstmipvar("HeteroResp", lat, lon, t, NA)
+    var[[3]] <- mstmipvar("GPP", lat, lon, t, NA)
+    var[[4]] <- mstmipvar("NEE", lat, lon, t, NA)
+    var[[5]] <- mstmipvar("NPP", lat, lon, t, NA)
     
-    #******************** Declar netCDF variables ********************#
+    var[[6]] <- ncvar_def("LeafLitter", "kgC/m2/s", list(lon, lat, t), -999)
+    var[[7]] <- ncvar_def("WoodyLitter", "kgC/m2/s", list(lon, lat, t), -999)
+    var[[8]] <- ncvar_def("RootLitter", "kgC/m2/s", list(lon, lat, t), -999)
+    var[[9]] <- ncvar_def("LeafBiomass", "kgC/m2", list(lon, lat, t), -999)
+    var[[10]] <- ncvar_def("WoodBiomass", "kgC/m2", list(lon, lat, t), -999)
+    var[[11]] <- ncvar_def("RootBiomass", "kgC/m2", list(lon, lat, t), -999)
+    var[[12]] <- ncvar_def("LitterBiomass", "kgC/m2", list(lon, lat, t), -999)
+    var[[13]] <- ncvar_def("SoilC", "kgC/m2", list(lon, lat, t), -999)
     
+    var[[14]] <- mstmipvar("TotalResp", lat, lon, t, NA)
+    var[[15]] <- mstmipvar("TotLivBiom", lat, lon, t, NA)
+    var[[16]] <- mstmipvar("TotSoilCarb", lat, lon, t, NA)
+    
+    # ******************** Declar netCDF variables ********************#
     
     ### Output netCDF data
-    nc <- nc_create(file.path(outdir, paste(y,"nc", sep=".")), var)
-    varfile <- file(file.path(outdir, paste(y, "nc", "var", sep=".")), "w")
-    for(i in 1:length(var)){
-      #print(i)
-      ncvar_put(nc,var[[i]],output[[i]])  
-      cat(paste(var[[i]]$name, var[[i]]$longname), file=varfile, sep="\n")
+    nc <- nc_create(file.path(outdir, paste(y, "nc", sep = ".")), var)
+    varfile <- file(file.path(outdir, paste(y, "nc", "var", sep = ".")), "w")
+    for (i in seq_along(var)) {
+      # print(i)
+      ncvar_put(nc, var[[i]], output[[i]])
+      cat(paste(var[[i]]$name, var[[i]]$longname), file = varfile, sep = "\n")
     }
     close(varfile)
     nc_close(nc)
     
-  } ### End of year loop
-
-} ### End of function
-#==================================================================================================#
-
-
-####################################################################################################
-### EOF.  End of R script file.              
-####################################################################################################
+  }  ### End of year loop
+  
+} # model2netcdf.DALEC
+# ==================================================================================================#

--- a/models/dalec/R/model2netcdf.DALEC.R
+++ b/models/dalec/R/model2netcdf.DALEC.R
@@ -26,14 +26,14 @@ model2netcdf.DALEC <- function(outdir, sitelat, sitelon, start_date, end_date) {
   library(ncdf4)
   
   ### Read in model output in DALEC format
-  DALEC.output <- read.table(file.path(outdir, "out.txt"), header = FALSE, sep = "")
+  DALEC.output      <- read.table(file.path(outdir, "out.txt"), header = FALSE, sep = "")
   DALEC.output.dims <- dim(DALEC.output)
   
   ### Determine number of years and output timestep
-  days <- as.Date(start_date):as.Date(end_date)
-  year <- strftime(as.Date(days, origin = "1970-01-01"), "%Y")
-  num.years <- length(unique(year))
-  years <- unique(year)
+  days       <- as.Date(start_date):as.Date(end_date)
+  year       <- strftime(as.Date(days, origin = "1970-01-01"), "%Y")
+  num.years  <- length(unique(year))
+  years      <- unique(year)
   timestep.s <- 86400
   
   ### Loop over years in DALEC output to create separate netCDF outputs
@@ -63,7 +63,7 @@ model2netcdf.DALEC <- function(outdir, sitelat, sitelon, start_date, end_date) {
     output[[8]] <- (sub.DALEC.output[, 13] * 0.001) / timestep.s  # Root Litter, kgC/m2/s
     
     ## non-standard variables: Pools
-    output[[9]] <- (sub.DALEC.output[, 15] * 0.001)  # Leaf Biomass, kgC/m2
+    output[[9]]  <- (sub.DALEC.output[, 15] * 0.001)  # Leaf Biomass, kgC/m2
     output[[10]] <- (sub.DALEC.output[, 17] * 0.001)  # Wood Biomass, kgC/m2
     output[[11]] <- (sub.DALEC.output[, 19] * 0.001)  # Root Biomass, kgC/m2
     output[[12]] <- (sub.DALEC.output[, 27] * 0.001)  # Litter Biomass, kgC/m2
@@ -75,8 +75,9 @@ model2netcdf.DALEC <- function(outdir, sitelat, sitelon, start_date, end_date) {
     output[[16]] <- output[[12]] + output[[13]]  ## TotSoilCarb
     
     # ******************** Declare netCDF variables ********************#
-    t <- ncdim_def(name = "time", units = paste0("days since ", y, "-01-01 00:00:00"), vals = 1:nrow(sub.DALEC.output), 
-      calendar = "standard", unlim = TRUE)
+    t   <- ncdim_def(name = "time", units = paste0("days since ", y, "-01-01 00:00:00"), 
+                     vals = 1:nrow(sub.DALEC.output), 
+                     calendar = "standard", unlim = TRUE)
     lat <- ncdim_def("lat", "degrees_east", vals = as.numeric(sitelat), longname = "station_latitude")
     lon <- ncdim_def("lon", "degrees_north", vals = as.numeric(sitelon), longname = "station_longitude")
     
@@ -88,16 +89,16 @@ model2netcdf.DALEC <- function(outdir, sitelat, sitelon, start_date, end_date) {
     }
     
     var <- list()
-    var[[1]] <- mstmipvar("AutoResp", lat, lon, t, NA)
-    var[[2]] <- mstmipvar("HeteroResp", lat, lon, t, NA)
-    var[[3]] <- mstmipvar("GPP", lat, lon, t, NA)
-    var[[4]] <- mstmipvar("NEE", lat, lon, t, NA)
-    var[[5]] <- mstmipvar("NPP", lat, lon, t, NA)
+    var[[1]]  <- mstmipvar("AutoResp", lat, lon, t, NA)
+    var[[2]]  <- mstmipvar("HeteroResp", lat, lon, t, NA)
+    var[[3]]  <- mstmipvar("GPP", lat, lon, t, NA)
+    var[[4]]  <- mstmipvar("NEE", lat, lon, t, NA)
+    var[[5]]  <- mstmipvar("NPP", lat, lon, t, NA)
     
-    var[[6]] <- ncvar_def("LeafLitter", "kgC/m2/s", list(lon, lat, t), -999)
-    var[[7]] <- ncvar_def("WoodyLitter", "kgC/m2/s", list(lon, lat, t), -999)
-    var[[8]] <- ncvar_def("RootLitter", "kgC/m2/s", list(lon, lat, t), -999)
-    var[[9]] <- ncvar_def("LeafBiomass", "kgC/m2", list(lon, lat, t), -999)
+    var[[6]]  <- ncvar_def("LeafLitter", "kgC/m2/s", list(lon, lat, t), -999)
+    var[[7]]  <- ncvar_def("WoodyLitter", "kgC/m2/s", list(lon, lat, t), -999)
+    var[[8]]  <- ncvar_def("RootLitter", "kgC/m2/s", list(lon, lat, t), -999)
+    var[[9]]  <- ncvar_def("LeafBiomass", "kgC/m2", list(lon, lat, t), -999)
     var[[10]] <- ncvar_def("WoodBiomass", "kgC/m2", list(lon, lat, t), -999)
     var[[11]] <- ncvar_def("RootBiomass", "kgC/m2", list(lon, lat, t), -999)
     var[[12]] <- ncvar_def("LitterBiomass", "kgC/m2", list(lon, lat, t), -999)

--- a/models/dalec/R/write.configs.dalec.R
+++ b/models/dalec/R/write.configs.dalec.R
@@ -1,89 +1,86 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.
+# Copyright (c) 2015 Boston University, NCSA.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the 
-# University of Illinois/NCSA Open Source License
+# NCSA Open Source License
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
+
 #--------------------------------------------------------------------------------------------------#
 # Template for functions to prepare and write out files model-specific configuration files for MA
 #--------------------------------------------------------------------------------------------------#
-PREFIX_XML <- '<?xml version="1.0"?>\n'
+PREFIX_XML <- "<?xml version=\"1.0\"?>\n"
 
-convert.samples.DALEC <- function(trait.samples){
-    
+convert.samples.DALEC <- function(trait.samples) {
+  
   DEFAULT.LEAF.C <- 0.48
-  ## convert SLA from m2 / kg leaf to m2 / kg C 
+  ## convert SLA from m2 / kg leaf to m2 / kg C
   
-  if('SLA' %in% names(trait.samples)){
-    trait.samples[['SLA']] <- trait.samples[['SLA']] / DEFAULT.LEAF.C / 1000
+  if ("SLA" %in% names(trait.samples)) {
+    trait.samples[["SLA"]] <- trait.samples[["SLA"]]/DEFAULT.LEAF.C/1000
   }
   
-  #t1 rate variable controling decomposition from litter to soil organinc matter [day-1, ref T 10C]
-  if("litter_decomposition_to_SOM" %in% names(trait.samples)){
-    names(trait.samples)[which(names(trait.samples)=="litter_decomposition_to_SOM")] <- "t1"
+  # t1 rate variable controling decomposition from litter to soil organinc matter [day-1, ref T
+  # 10C]
+  if ("litter_decomposition_to_SOM" %in% names(trait.samples)) {
+    names(trait.samples)[which(names(trait.samples) == "litter_decomposition_to_SOM")] <- "t1"
   }
   
-  #t2 proportion of GPP lost to autotrophic respiration
-  if("autotrophic_respiration_fraction" %in% names(trait.samples)){
-    names(trait.samples)[which(names(trait.samples)=="autotrophic_respiration_fraction")] <- "t2"
+  # t2 proportion of GPP lost to autotrophic respiration
+  if ("autotrophic_respiration_fraction" %in% names(trait.samples)) {
+    names(trait.samples)[which(names(trait.samples) == "autotrophic_respiration_fraction")] <- "t2"
   }
   
-  #t3 proportion of NPP allocated to foliage
-  if("leaf_allocation_fraction" %in% names(trait.samples)){
-    names(trait.samples)[which(names(trait.samples)=="leaf_allocation_fraction")] <- "t3"
+  # t3 proportion of NPP allocated to foliage
+  if ("leaf_allocation_fraction" %in% names(trait.samples)) {
+    names(trait.samples)[which(names(trait.samples) == "leaf_allocation_fraction")] <- "t3"
   }
   
-  #t4 proportion of NPP allocated to roots
-  if("root_allocation_fraction" %in% names(trait.samples)){
-    names(trait.samples)[which(names(trait.samples)=="root_allocation_fraction")] <- "t4"
+  # t4 proportion of NPP allocated to roots
+  if ("root_allocation_fraction" %in% names(trait.samples)) {
+    names(trait.samples)[which(names(trait.samples) == "root_allocation_fraction")] <- "t4"
   }
   
-  #t5 proportion of foliage becoming litter every time step
-  if('leaf_turnover_rate' %in% names(trait.samples)){
-    trait.samples[['leaf_turnover_rate']] <- trait.samples[['leaf_turnover_rate']]/365
-    names(trait.samples)[which(names(trait.samples)=="leaf_turnover_rate")] <- "t5"
+  # t5 proportion of foliage becoming litter every time step
+  if ("leaf_turnover_rate" %in% names(trait.samples)) {
+    trait.samples[["leaf_turnover_rate"]] <- trait.samples[["leaf_turnover_rate"]]/365
+    names(trait.samples)[which(names(trait.samples) == "leaf_turnover_rate")] <- "t5"
   }
   
-  #t6 proportion of woody material becoming woody debris every time step
-  if('wood_turnover_rate' %in% names(trait.samples)){
-    trait.samples[['wood_turnover_rate']] <- trait.samples[['wood_turnover_rate']]/365
-    names(trait.samples)[which(names(trait.samples)=="wood_turnover_rate")] <- "t6"
+  # t6 proportion of woody material becoming woody debris every time step
+  if ("wood_turnover_rate" %in% names(trait.samples)) {
+    trait.samples[["wood_turnover_rate"]] <- trait.samples[["wood_turnover_rate"]]/365
+    names(trait.samples)[which(names(trait.samples) == "wood_turnover_rate")] <- "t6"
   }
   
-  #t7 proportion of fine roots becoming soil/woody debris every time step
-  if('root_turnover_rate' %in% names(trait.samples)){
-    trait.samples[['root_turnover_rate']] <- trait.samples[['root_turnover_rate']]/365
-    names(trait.samples)[which(names(trait.samples)=="root_turnover_rate")] <- "t7"
+  # t7 proportion of fine roots becoming soil/woody debris every time step
+  if ("root_turnover_rate" %in% names(trait.samples)) {
+    trait.samples[["root_turnover_rate"]] <- trait.samples[["root_turnover_rate"]]/365
+    names(trait.samples)[which(names(trait.samples) == "root_turnover_rate")] <- "t7"
   }
   
-  #t8 rate variable controlling respiration from litter [day-1, ref T 10C]
-  if("litter_respiration_rate" %in% names(trait.samples)){
-    names(trait.samples)[which(names(trait.samples)=="litter_respiration_rate")] <- "t8"
+  # t8 rate variable controlling respiration from litter [day-1, ref T 10C]
+  if ("litter_respiration_rate" %in% names(trait.samples)) {
+    names(trait.samples)[which(names(trait.samples) == "litter_respiration_rate")] <- "t8"
   }
   
-  #t9 rate variable controlling respiration from soil organic matter and woody debris [day-1, ref T 10C]
-  if("som_respiration_rate" %in% names(trait.samples)){
-    names(trait.samples)[which(names(trait.samples)=="som_respiration_rate")] <- "t9"
+  # t9 rate variable controlling respiration from soil organic matter and woody debris [day-1, ref
+  # T 10C]
+  if ("som_respiration_rate" %in% names(trait.samples)) {
+    names(trait.samples)[which(names(trait.samples) == "som_respiration_rate")] <- "t9"
   }
   
   ### INITIAL CONDITIONS
   
-  #cf0 initial canopy foliar carbon (g/m2)
-
-  #cw0 initial pool of woody carbon (g/m2)
-  
-  #cr0 initial pool of fine root carbon (g/m2)
-  
-  #cl0 initial pool of litter carbon (g/m2)
-  
-  #cs0 initial pool of soil organic matter and woody debris carbon (g/m2)
-  
-  
+  # cf0 initial canopy foliar carbon (g/m2)
+  # cw0 initial pool of woody carbon (g/m2)
+  # cr0 initial pool of fine root carbon (g/m2)
+  # cl0 initial pool of litter carbon (g/m2)
+  # cs0 initial pool of soil organic matter and woody debris carbon (g/m2)
   
   return(trait.samples)
-}
+} # convert.samples.DALEC
 
 #--------------------------------------------------------------------------------------------------#
 ##' Writes a configuration files for your model
@@ -97,25 +94,23 @@ convert.samples.DALEC <- function(trait.samples){
 ##' @param run.id 
 ##' @return configuration files
 ##' @export write.config.DALEC
-write.config.DALEC <- function(defaults, trait.values, settings, run.id){
+write.config.DALEC <- function(defaults, trait.values, settings, run.id) {
   
   ### CONVERT PARAMETERS
-  cmdFlags = ""
-  for(group in names(trait.values)){
-    if(group == "env"){
+  cmdFlags <- ""
+  for (group in names(trait.values)) {
+    if (group == "env") {
       
       ## set defaults from config.header
       
-      ##
-      
     } else {
-      if(!is.null(trait.values[[group]])){
+      if (!is.null(trait.values[[group]])) {
         params <- convert.samples.DALEC(trait.values[[group]])
         logger.info(names(params))
-        for(i in 1:length(params)){
-          cmdFlags <- paste(cmdFlags," -",names(params)[i]," ",params[[i]],sep="")
+        for (i in seq_along(params)) {
+          cmdFlags <- paste0(cmdFlags, " -", names(params)[i], " ", params[[i]])
         }
-      }    
+      }
     }
   }
   
@@ -127,38 +122,36 @@ write.config.DALEC <- function(defaults, trait.values, settings, run.id){
     outdir <- file.path(settings$modeloutdir, as.character(run.id))
   }
   
-  
   ### WRITE PARAMETERS
-  config.file.name <- paste('CONFIG.',run.id, sep='')
-  writeLines(cmdFlags, con = paste(rundir,"/", config.file.name, sep=''))
-        
+  config.file.name <- paste0("CONFIG.", run.id)
+  writeLines(cmdFlags, con = file.path(rundir, config.file.name))
+  
   ### WRITE JOB.SH
-  jobsh = paste0("#!/bin/bash\n",settings$model$binary,
-                 " $(cat ",rundir,"/",config.file.name,
-                 ") < ",as.character(settings$run$inputs$met$path),
-                 " > ",outdir,"/out.txt\n",
-#                 'echo ".libPaths(',"'~/R/library');",
-                 'echo "',
-                 ' require(PEcAn.DALEC); model2netcdf.DALEC(',
-                 "'",outdir,"',",
-                 settings$run$site$lat,",",
-                 settings$run$site$lon,", '",
-                 settings$run$start.date,"', '",
-                 settings$run$end.date,"') ",
-                 '" | R --vanilla'
-                 )
-  writeLines(jobsh, con=file.path(settings$rundir, run.id, "job.sh"))
+  jobsh <- paste0("#!/bin/bash\n", 
+                  settings$model$binary, 
+                  " $(cat ", rundir, "/", config.file.name, 
+                  ") < ", as.character(settings$run$inputs$met$path), " > ", 
+                  outdir, "/out.txt\n", 
+                  # 'echo ".libPaths(',"'~/R/library');",
+                  "echo \"", 
+                  " require(PEcAn.DALEC); model2netcdf.DALEC(", "'", 
+                  outdir, "',", 
+                  settings$run$site$lat, ",", 
+                  settings$run$site$lon, ", '", 
+                  settings$run$start.date, "', '", 
+                  settings$run$end.date, "') ", 
+                  "\" | R --vanilla")
+  writeLines(jobsh, con = file.path(settings$rundir, run.id, "job.sh"))
   Sys.chmod(file.path(settings$rundir, run.id, "job.sh"))
   
-  
-    ### Display info to the console.
-    print(run.id)
-}
-#==================================================================================================#
+  ### Display info to the console.
+  print(run.id)
+} # write.config.DALEC
+# ==================================================================================================#
 
-remove.config.DALEC <- function(outdir,settings){
+remove.config.DALEC <- function(outdir, settings) {
   
-}
+} # remove.config.DALEC
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -167,27 +160,21 @@ remove.config.DALEC <- function(outdir,settings){
 ##' @title Function to generate generic model run script files
 ##' @author <unknown>
 #--------------------------------------------------------------------------------------------------#
-write.run.DALEC <- function(settings){
-  if(!require(PEcAn.utils)) print("install PEcAn.utils")
-  run.script.template = system.file("data", "run.template.DALEC", package="PEcAn.DALEC")
-  run.text <- scan(file = run.script.template, 
-                   what="character",sep='@', quote=NULL, quiet=TRUE)
-  run.text  <- gsub('TMP', paste("/scratch/",Sys.getenv("USER"),sep=""), run.text)
-  run.text  <- gsub('BINARY', settings$host$MODEL$binary, run.text)
-  run.text <- gsub('OUTDIR', settings$host$outdir, run.text)
-  runfile <- paste(settings$outdir, 'run', sep='')
-  writeLines(run.text, con = runfile)
-  if(settings$host$name == 'localhost') {
-    system(paste('cp ', runfile, settings$host$rundir))
-  }else{
-    system(paste("rsync -outi ", runfile , ' ', settings$host$name, ":",
-                 settings$host$rundir, sep = ''))
+write.run.DALEC <- function(settings) {
+  if (!require(PEcAn.utils)) {
+    print("install PEcAn.utils")
   }
-}
-#==================================================================================================#
-
-
-
-####################################################################################################
-### EOF.  End of R script file.            	
-####################################################################################################
+  run.script.template <- system.file("data", "run.template.DALEC", package = "PEcAn.DALEC")
+  run.text <- scan(file = run.script.template, what = "character", sep = "@", quote = NULL, quiet = TRUE)
+  run.text <- gsub("TMP", paste0("/scratch/", Sys.getenv("USER")), run.text)
+  run.text <- gsub("BINARY", settings$host$MODEL$binary, run.text)
+  run.text <- gsub("OUTDIR", settings$host$outdir, run.text)
+  runfile <- paste0(settings$outdir, "run")
+  writeLines(run.text, con = runfile)
+  if (settings$host$name == "localhost") {
+    system(paste("cp ", runfile, settings$host$rundir))
+  } else {
+    system(paste0("rsync -outi ", runfile, " ", settings$host$name, ":", settings$host$rundir))
+  }
+} # write.run.DALEC
+# ==================================================================================================#


### PR DESCRIPTION
Ran through formatR::tidy_dir with arrow=TRUE and indent=2; made sure all if blocks have braces; took advantage of paste0 and file.path; changed require calls to library.

Note - got rid of extra params (…) in `met2model.DALEC`. They weren’t last, which was odd, and weren’t used.