### PR TITLE
Style cleanup for `models/ed/R/*.R` scripts

### DIFF
--- a/models/ed/R/get.model.output.ed.R
+++ b/models/ed/R/get.model.output.ed.R
@@ -1,11 +1,12 @@
 #-------------------------------------------------------------------------------
 # Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
+# All rights reserved. This program and the accompanying materials 
+# are made available under the terms of the
 # University of Illinois/NCSA Open Source License
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
+
 #--------------------------------------------------------------------------------------------------#
 ##' Extract ED output for specific variables from an hdf5 file
 ##' @name read.output.file.ed
@@ -15,22 +16,24 @@
 ##' @return single value of output variable from filename. In the case of AGB, it is summed across all plants
 ##' @export
 ##' @author David LeBauer, Carl Davidson
-read.output.file.ed <- function(filename, variables = c("AGB_CO", "NPLANT")){
-  if(filename %in% dir(pattern = 'h5')){
-    Carbon2Yield = 20
+read.output.file.ed <- function(filename, variables = c("AGB_CO", "NPLANT")) {
+  if (filename %in% dir(pattern = "h5")) {
+    Carbon2Yield <- 20
     nc <- nc_open(filename)
-    if(all(c("AGB_CO", "NPLANT") %in% variables)) {
-      result <- (sum(ncvar_get(nc,'AGB_CO') * ncvar_get(nc,'NPLANT'), na.rm =TRUE) * Carbon2Yield)
+    if (all(c("AGB_CO", "NPLANT") %in% variables)) {
+      result <- (sum(ncvar_get(nc, "AGB_CO") * ncvar_get(nc, "NPLANT"), na.rm = TRUE) * Carbon2Yield)
     } else {
-      result <- sum(sapply(variables, function(x){sum(ncvar_get(nc, x))}))
+      result <- sum(sapply(variables, function(x) {
+        sum(ncvar_get(nc, x))
+      }))
     }
     nc_close(nc)
     return(result)
   } else {
     return(NA)
   }
-}
-#==================================================================================================#
+} # read.output.file.ed
+# ==================================================================================================#
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -43,41 +46,39 @@ read.output.file.ed <- function(filename, variables = c("AGB_CO", "NPLANT")){
 ##' @param outdir the directory that the model's output was sent to
 ##' @param start.year 
 ##' @param end.year
-##' @param output.type type of output file to read, can be "-Y-" for annual output, "-M-" for monthly means, "-D-" for daily means, "-T-" for instantaneous fluxes. Output types are set in the ED2IN namelist as NL%I[DMYT]OUTPUT  
+##' @param output.type type of output file to read, can be '-Y-' for annual output, '-M-' for monthly means, '-D-' for daily means, '-T-' for instantaneous fluxes. Output types are set in the ED2IN namelist as NL%I[DMYT]OUTPUT  
 ##' @return vector of output variable for all runs within ensemble
 ##' @export
 ##' @author David LeBauer, Carl Davidson
-read.output.ED2 <- function(run.id, outdir, start.year=NA, end.year=NA, variables=c("AGB_CO", "NPLANT"), output.type = 'Y'){
+read.output.ED2 <- function(run.id, outdir, start.year = NA, end.year = NA, 
+                            variables = c("AGB_CO", "NPLANT"), output.type = "Y") {
   print(run.id)
-  #if(any(grep(run.id, dir(outdir, pattern = 'finished')))){
-  file.names <- dir(outdir, pattern=run.id, full.names=FALSE)
-  file.names <- grep(paste('-', output.type, '-', sep = ''), file.names, value = TRUE)
-  file.names <- grep('([0-9]{4}).*', file.names, value=TRUE)
-  if(length(file.names) > 0) {
-    years <- sub('((?!-Y-).)*-Y-([0-9]{4}).*', '\\2', file.names, perl=TRUE)
-    if(!is.na(start.year) && nchar(start.year) ==  4){
-      file.names <- file.names[years>=as.numeric(start.year)]
+  # if(any(grep(run.id, dir(outdir, pattern = 'finished')))){
+  file.names <- dir(outdir, pattern = run.id, full.names = FALSE)
+  file.names <- grep(paste("-", output.type, "-", sep = ""), file.names, value = TRUE)
+  file.names <- grep("([0-9]{4}).*", file.names, value = TRUE)
+  if (length(file.names) > 0) {
+    years <- sub("((?!-Y-).)*-Y-([0-9]{4}).*", "\\2", file.names, perl = TRUE)
+    if (!is.na(start.year) && nchar(start.year) == 4) {
+      file.names <- file.names[years >= as.numeric(start.year)]
     }
-    if(!is.na(end.year) && nchar(end.year) == 4){
-      file.names <- file.names[years<=as.numeric(end.year)]
+    if (!is.na(end.year) && nchar(end.year) == 4) {
+      file.names <- file.names[years <= as.numeric(end.year)]
     }
     file.names <- file.names[!is.na(file.names)]
     print(file.names)
     
-    result <- mean(sapply(file.names, read.output.file.ed,variables)) ## if any are NA, NA is returned
-
+    result <- mean(sapply(file.names, read.output.file.ed, variables))  ## if any are NA, NA is returned
+    
   } else {
-    warning(cat(paste('no output files in', outdir, '\nfor', run.id, '\n')))
+    warning(cat(paste("no output files in", outdir, "\nfor", run.id, "\n")))
     result <- NA
   }
-  #} else {
-  #  warning(cat(paste(run.id, 'not finished \n')))
-  #  result <- NA
-  #}
-
+  # } else { warning(cat(paste(run.id, 'not finished \n'))) result <- NA }
+  
   return(result)
-}
-#==================================================================================================#
+} # read.output.ED2
+# ==================================================================================================#
 
 
 
@@ -92,64 +93,48 @@ read.output.ED2 <- function(run.id, outdir, start.year=NA, end.year=NA, variable
 ##'
 ##' @author Shawn Serbin
 ##' @author David LeBauer
-get.model.output.ED2 <- function(settings){
+get.model.output.ED2 <- function(settings) {
   model <- settings$model$type
   
   ### Get ED2 model output on the localhost
-  if(settings$host$name == 'localhost'){
-    #setwd(settings$host$outdir)  # Host model output directory
+  if (settings$host$name == "localhost") {
+    # setwd(settings$host$outdir) # Host model output directory
     get.results(settings)
-    ### Move required functions to host
-    ## TODO: take out functions read.output.file.ed & read.output.ed from write.configs.ed &
-    ## put into a new file specific for reading ED output
+    ### Move required functions to host TODO: take out functions read.output.file.ed & read.output.ed
+    ### from write.configs.ed & put into a new file specific for reading ED output
     
-    ### Is the previous necessary for localhost?  These functions should be availible within R
-    ### & should not need to be copied and run but could instead be called within the running R
-    ### shell.  SPS
+    ### Is the previous necessary for localhost?  These functions should be availible within R & should
+    ### not need to be copied and run but could instead be called within the running R shell.  SPS
     
-    #setwd(settings$outdir)
-    #source('PEcAn.functions.R') # This won't work yet
+    # setwd(settings$outdir) source('PEcAn.functions.R') # This won't work yet
     
-
+    
   } else {
     ### Make a copy of the settings object for use on the remote sever
-    save(settings,file=paste(settings$outdir,"settings.Rdata",sep=""))
+    save(settings, file = paste0(settings$outdir, "settings.Rdata"))
     
     ### Make a copy of required functions and place in file PEcAn.functions.R
-    dump(c("get.run.id", "left.pad.zeros", "read.ensemble.output",
-           "read.sa.output", "read.output", "model2netcdf.ED2", "get.results"),
-         file=paste(settings$outdir,"PEcAn.functions.R",sep=""))
+    dump(c("get.run.id", "left.pad.zeros", "read.ensemble.output", 
+           "read.sa.output", "read.output", "model2netcdf.ED2", "get.results"), 
+         file = paste0(settings$outdir, "PEcAn.functions.R"))
     
-    ### Add execution of get.results to the end of the PEcAn.functions.R file
-    ### This will execute all the code needed to extract output on remote host
-    ### --- added loading of pecan settings object
-    cat('load("settings.Rdata")',file=paste(settings$outdir,"PEcAn.functions.R",sep=""),
-        append=TRUE)
-    cat("\n",file=paste(settings$outdir,"PEcAn.functions.R",sep=""),
-        append=TRUE)
-    cat("get.results(settings)",file=paste(settings$outdir,"PEcAn.functions.R",sep=""),
-        append=TRUE)
-
+    ### Add execution of get.results to the end of the PEcAn.functions.R file This will execute all the
+    ### code needed to extract output on remote host --- added loading of pecan settings object
+    cat("load(\"settings.Rdata\")", file = paste0(settings$outdir, "PEcAn.functions.R"), append = TRUE)
+    cat("\n", file = paste0(settings$outdir, "PEcAn.functions.R"), append = TRUE)
+    cat("get.results(settings)", file = paste0(settings$outdir, "PEcAn.functions.R"), append = TRUE)
+    
     ### Copy required PEcAn.functions.R and settings object to remote host
-    rsync('-outi',paste(settings$outdir,"settings.Rdata",sep=""),
-          paste(settings$host$name, ':',settings$host$outdir, sep = '') )
-    rsync('-outi',paste(settings$outdir,"PEcAn.functions.R",sep=""),
-          paste(settings$host$name, ':',settings$host$outdir, sep = '') )
-
+    rsync("-outi", paste0(settings$outdir, "settings.Rdata"), paste0(settings$host$name, ":", settings$host$outdir))
+    rsync("-outi", paste0(settings$outdir, "PEcAn.functions.R"), paste0(settings$host$name, ":", settings$host$outdir))
+    
     ### Run script on remote host
-    system(paste("ssh -T", settings$host$name, "'",
-             "cd", settings$host$outdir, "; R --vanilla < PEcAn.functions.R'"))
+    system(paste("ssh -T", settings$host$name, "'", "cd", settings$host$outdir, "; R --vanilla < PEcAn.functions.R'"))
     
     ### Get PEcAn output from remote host
-    rsync('-outi', from = paste(settings$host$name, ':', settings$host$outdir, 'output.Rdata', sep=''),
-      to = settings$outdir)
-
-  } ### End of if/else
+    rsync("-outi", from = paste0(settings$host$name, ":", settings$host$outdir, "output.Rdata"), to = settings$outdir)
+    
+  }  ### End of if/else
   
-} ### End of function
-#==================================================================================================#
-
-
-####################################################################################################
-### EOF.  End of R script file.              
-####################################################################################################
+} # get.model.output.ED2
+# ==================================================================================================#

--- a/models/ed/R/met2model.ED2.R
+++ b/models/ed/R/met2model.ED2.R
@@ -31,7 +31,7 @@
 ##' @param overwrite should existing files be overwritten
 ##' @param verbose should the function be very verbose
 met2model.ED2 <- function(in.path, in.prefix, outfolder, start_date, end_date, lst = 0, lat = NA, 
-                          lon = NA, ..., overwrite = FALSE, verbose = FALSE) {
+                          lon = NA, overwrite = FALSE, verbose = FALSE, ...) {
   overwrite <- as.logical(overwrite)
   
   library(rhdf5)

--- a/models/ed/R/met2model.ED2.R
+++ b/models/ed/R/met2model.ED2.R
@@ -1,21 +1,21 @@
 #-------------------------------------------------------------------------------
 # Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
+# All rights reserved. This program and the accompanying materials 
 # are made available under the terms of the
 # University of Illinois/NCSA Open Source License
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-## R Code to convert from NACP intercomparison NETCDF met files
-## into ED2 ascii met files
+
+## R Code to convert from NACP intercomparison NETCDF met files into ED2 ascii met files
 
 ## It requires the rhdf5 library, which is not available on CRAN, but by can be installed locally:
-# >source("http://bioconductor.org/biocLite.R")
-# >biocLite("rhdf5")
+## >source('http://bioconductor.org/biocLite.R') 
+## >biocLite('rhdf5')
 
-##If files already exist in "Outfolder", the default function is NOT to overwrite them and
-##only gives user the notice that file already exists. If user wants to overwrite the existing files, just change
-##overwrite statement below to TRUE.
+## If files already exist in 'Outfolder', the default function is NOT to overwrite them and only
+## gives user the notice that file already exists. If user wants to overwrite the existing files,
+## just change overwrite statement below to TRUE.
 
 
 ##' met2model wrapper for ED2
@@ -30,297 +30,299 @@
 ##' @param lst timezone offset to GMT in hours
 ##' @param overwrite should existing files be overwritten
 ##' @param verbose should the function be very verbose
-met2model.ED2 <- function(in.path,in.prefix,outfolder,start_date, end_date, lst=0,lat=NA,lon=NA,..., overwrite=FALSE,verbose=FALSE){
-  overwrite = as.logical(overwrite)
-
-  require(rhdf5)
-  require(ncdf4)
-  #require(ncdf)
-  require(lubridate)
-  require(PEcAn.utils)
-
+met2model.ED2 <- function(in.path, in.prefix, outfolder, start_date, end_date, lst = 0, lat = NA, 
+                          lon = NA, ..., overwrite = FALSE, verbose = FALSE) {
+  overwrite <- as.logical(overwrite)
+  
+  library(rhdf5)
+  library(ncdf4)
+  library(lubridate)
+  library(PEcAn.utils)
+  
   # results are stored in folder prefix.start.end
   start_date <- as.POSIXlt(start_date, tz = "GMT")
-  end_date <- as.POSIXlt(end_date, tz = "GMT")
+  end_date   <- as.POSIXlt(end_date, tz = "GMT")
   met_folder <- outfolder
   met_header <- file.path(met_folder, "ED_MET_DRIVER_HEADER")
-
-  results <- data.frame(file=c(met_header),
-                        host=c(fqdn()),
-                        mimetype=c('text/plain'),
-                        formatname=c('ed.met_driver_header files format'),
-                        startdate=c(start_date),
-                        enddate=c(end_date),
-                        dbfile.name = "ED_MET_DRIVER_HEADER",
+  
+  results <- data.frame(file = c(met_header), 
+                        host = c(fqdn()), 
+                        mimetype = c("text/plain"), 
+                        formatname = c("ed.met_driver_header files format"), 
+                        startdate = c(start_date), 
+                        enddate = c(end_date), 
+                        dbfile.name = "ED_MET_DRIVER_HEADER", 
                         stringsAsFactors = FALSE)
-
+  
   ## check to see if the outfolder is defined, if not create directory for output
-  dir.create(met_folder, recursive=TRUE, showWarnings = FALSE)
-
-### FUNCTIONS
-dm <- c(0,32,60,91,121,152,182,213,244,274,305,335,366)
-dl <- c(0,32,61,92,122,153,183,214,245,275,306,336,367)
-month <- c("JAN","FEB","MAR","APR","MAY","JUN","JUL","AUG","SEP","OCT","NOV","DEC")
-mon_num <- c("01","02","03","04","05","06","07","08","09","10","11","12")
-day2mo <- function(year,day){
-  leap <- (year %% 4 == 0)
-  mo <- rep(NA,length(day))
-  mo[leap] <- findInterval(day[leap],dl)
-  mo[!leap] <- findInterval(day[!leap],dm)
-  return(mo)
-}
-
-# get start/end year since inputs are specified on year basis
-start_year <- year(start_date)
-end_year <- year(end_date)
-
-## loop over files
-for(year in start_year:end_year) {
-  ncfile <- file.path(in.path, paste(in.prefix, year, "nc", sep="."))
-
-  ## extract file root name
-  #froot <- substr(files[i],1,28)
-  #print(c(i,froot))
-
-  ## open netcdf
-  nc <- nc_open(ncfile)
-
-  # check lat/lon
-  flat <- try(ncvar_get(nc, "latitude"), silent=TRUE)
-  if (!is.numeric(flat)) flat <- nc$dim[[1]]$vals[1]
-  if (is.na(lat)) {
-    lat <- flat
-  } else if (lat != flat) {
-    logger.warn("Latitude does not match that of file", lat, "!=", flat)
-  }
-
-  flon <- try(ncvar_get(nc, "longitude"), silent=TRUE)
-  if (!is.numeric(flon)) flat <- nc$dim[[2]]$vals[1]
-  if (is.na(lon)) {
-    lon <- flon
-  } else if (lon != flon) {
-    logger.warn("Longitude does not match that of file", lon, "!=", flon)
-  }
-
-  ## determine GMT adjustment
-  ## lst <- site$LST_shift[which(site$acro == froot)]
-
-
-  ## extract variables
-  lat  <- eval(parse(text = lat))
-  lon  <- eval(parse(text = lon))
-  sec   <- nc$dim$time$vals
-  Tair <- ncvar_get(nc,"air_temperature")
-  Qair <- ncvar_get(nc,"specific_humidity")  #humidity (kg/kg)
-  U <- ncvar_get(nc,"eastward_wind")
-  V <- ncvar_get(nc,"northward_wind")
-  Rain <- ncvar_get(nc,"precipitation_flux")
-  pres <- ncvar_get(nc,"air_pressure")
-  SW   <- ncvar_get(nc,"surface_downwelling_shortwave_flux_in_air")
-  LW   <- ncvar_get(nc,"surface_downwelling_longwave_flux_in_air")
-  CO2  <- try(ncvar_get(nc,"mole_fraction_of_carbon_dioxide_in_air"), silent=TRUE)
-
-  useCO2 = is.numeric(CO2)
-
-  ## convert time to seconds
-  sec = udunits2::ud.convert(sec,unlist(strsplit(nc$dim$time$units," "))[1],"seconds")
-
-  nc_close(nc)
-
-  ifelse(leap_year(year)==TRUE,
-         dt <- (366*24*60*60)/length(sec), #leap year
-         dt <- (365*24*60*60)/length(sec)) #non-leap year
-
-  toff <- -as.numeric(lst)*3600/dt
-
-  ##buffer to get to GMT
-  slen <- length(SW)
-  Tair <- c(rep(Tair[1],toff),Tair)[1:slen]
-  Qair <- c(rep(Qair[1],toff),Qair)[1:slen]
-  U <- c(rep(U[1],toff),U)[1:slen]
-  V <- c(rep(V[1],toff),V)[1:slen]
-  Rain <- c(rep(Rain[1],toff),Rain)[1:slen]
-  pres <- c(rep(pres[1],toff),pres)[1:slen]
-  SW <- c(rep(SW[1],toff),SW)[1:slen]
-  LW <- c(rep(LW[1],toff),LW)[1:slen]
-  if(useCO2)  CO2 <- c(rep(CO2[1],toff),CO2)[1:slen]
-
-
-  ##build time variables (year, month, day of year)
-  skip <- FALSE
-  nyr <- floor(length(sec)/86400/365*dt)
-  yr <- NULL
-  doy <- NULL
-  hr <- NULL
-  asec <- sec
-  for(y in year+1:nyr-1){
-    ytmp <- rep(y,365*86400/dt)
-    dtmp <- rep(1:365,each=86400/dt)
-    if(y %% 4 == 0){  ## is leap
-      ytmp <- rep(y,366*86400/dt)
-      dtmp <- rep(1:366,each=86400/dt)
-    }
-    if(is.null(yr)){
-      yr <- ytmp
-      doy <- dtmp
-      hr <- rep(NA,length(dtmp))
-    } else {
-      yr <- c(yr,ytmp)
-      doy <- c(doy,dtmp)
-      hr <- c(hr,rep(NA,length(dtmp)))
-    }
-    rng <- length(doy) - length(ytmp):1 + 1
-    if(!all(rng>=0)){
-      skip = TRUE
-      logger.warn(paste(year,"is not a complete year and will not be included"))
-      break
-    }
-    asec[rng] <- asec[rng] - asec[rng[1]]
-    hr[rng] <- (asec[rng] - (dtmp-1)*86400)/86400*24
-  }
-  mo<-day2mo(yr,doy)
-  if(length(yr) < length(sec)){
-    rng <- (length(yr)+1):length(sec)
-    if(!all(rng>=0)){
-      skip = TRUE
-      logger.warn(paste(year,"is not a complete year and will not be included"))
-      break
-    }
-    yr[rng] <- rep(y+1,length(rng))
-    doy[rng] <- rep(1:366,each=86400/dt)[1:length(rng)]
-    hr[rng] <- rep(seq(0,length=86400/dt,by=dt/86400*24),366)[1:length(rng)]
-  }
-  if(skip){
-    print("Skipping to next year")
-    next
+  dir.create(met_folder, recursive = TRUE, showWarnings = FALSE)
+  
+  ### FUNCTIONS
+  dm <- c(0, 32, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366)
+  dl <- c(0, 32, 61, 92, 122, 153, 183, 214, 245, 275, 306, 336, 367)
+  month <- c("JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC")
+  mon_num <- c("01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12")
+  day2mo <- function(year, day) {
+    leap      <- (year%%4 == 0)
+    mo        <- rep(NA, length(day))
+    mo[leap]  <- findInterval(day[leap], dl)
+    mo[!leap] <- findInterval(day[!leap], dm)
+    return(mo)
   }
   
-
-  ## calculate potential radiation
-  ## in order to estimate diffuse/direct
-  f <- pi/180*(279.5+0.9856*doy)
-  et <- (-104.7*sin(f)+596.2*sin(2*f)+4.3*sin(4*f)-429.3*cos(f)-2.0*cos(2*f)+19.3*cos(3*f))/3600  #equation of time -> eccentricity and obliquity
-  merid <- floor(lon/15)*15
-  merid[merid<0] <- merid[merid<0]+15
-  lc <- (lon-merid)*-4/60  ## longitude correction
-  tz <- merid/360*24 ## time zone
-  midbin <- 0.5*dt/86400*24 ## shift calc to middle of bin
-  t0 <- 12+lc-et-tz-midbin   ## solar time
-  h <- pi/12*(hr-t0)  ## solar hour
-  dec <- -23.45*pi/180*cos(2*pi*(doy+10)/365)  ## declination
-
-  cosz <- sin(lat*pi/180)*sin(dec)+cos(lat*pi/180)*cos(dec)*cos(h)
-  cosz[cosz<0] <- 0
-
-  rpot <- 1366*cosz
-  rpot <- rpot[1:length(SW)]
-
-  SW[rpot < SW] <- rpot[rpot<SW] ## ensure radiation < max
-      ### this causes trouble at twilight bc of missmatch btw bin avergage and bin midpoint
-  frac <- SW/rpot
-  frac[frac>0.9] <- 0.9  ## ensure some diffuse
-  frac[frac < 0.0] <- 0.0
-  frac[is.na(frac)] <- 0.0
-  frac[is.nan(frac)] <- 0.0
-  SWd <- SW*(1-frac)  ## Diffuse portion of total short wave rad
-
-### convert to ED2.1 hdf met variables
-  n     <- length(Tair)
-  nbdsfA <- (SW - SWd) * 0.57 # near IR beam downward solar radiation [W/m2]
-  nddsfA <- SWd * 0.48        # near IR diffuse downward solar radiation [W/m2]
-  vbdsfA <- (SW - SWd) * 0.43 # visible beam downward solar radiation [W/m2]
-  vddsfA <- SWd * 0.52        # visible diffuse downward solar radiation [W/m2]
-  prateA <- Rain              # precipitation rate [kg_H2O/m2/s]
-  dlwrfA <- LW                # downward long wave radiation [W/m2]
-  presA  <- pres              # pressure [Pa]
-  hgtA   <- rep(50,n)         # geopotential height [m]
-  ugrdA  <- U                 # zonal wind [m/s]
-  vgrdA  <- V                 # meridional wind [m/s]
-  shA    <- Qair              # specific humidity [kg_H2O/kg_air]
-  tmpA   <- Tair              # temperature [K]
-  if(useCO2){
-    co2A   <- CO2 * 1e6               # surface co2 concentration [ppm] converted from mole fraction [kg/kg]
-  }
-
-  ## create directory
-  #if(system(paste("ls",froot),ignore.stderr=TRUE)>0) system(paste("mkdir",froot))
-
-  ## write by year and month
-  for(y in year+1:nyr-1){
-    sely <- which(yr == y)
-    for(m in unique(mo[sely])){
-      selm <- sely[which(mo[sely] == m)]
-      mout <- paste(met_folder,"/",y,month[m],".h5",sep="")
-      if(file.exists(mout)){
-        if(overwrite==TRUE){
-          file.remove(mout)
+  # get start/end year since inputs are specified on year basis
+  start_year <- year(start_date)
+  end_year <- year(end_date)
+  
+  ## loop over files
+  for (year in start_year:end_year) {
+    ncfile <- file.path(in.path, paste(in.prefix, year, "nc", sep = "."))
+    
+    ## extract file root name froot <- substr(files[i],1,28) print(c(i,froot))
+    
+    ## open netcdf
+    nc <- nc_open(ncfile)
+    
+    # check lat/lon
+    flat <- try(ncvar_get(nc, "latitude"), silent = TRUE)
+    if (!is.numeric(flat)) 
+      flat <- nc$dim[[1]]$vals[1]
+    if (is.na(lat)) {
+      lat <- flat
+    } else if (lat != flat) {
+      logger.warn("Latitude does not match that of file", lat, "!=", flat)
+    }
+    
+    flon <- try(ncvar_get(nc, "longitude"), silent = TRUE)
+    if (!is.numeric(flon)) 
+      flat <- nc$dim[[2]]$vals[1]
+    if (is.na(lon)) {
+      lon <- flon
+    } else if (lon != flon) {
+      logger.warn("Longitude does not match that of file", lon, "!=", flon)
+    }
+    
+    ## determine GMT adjustment lst <- site$LST_shift[which(site$acro == froot)]
+    
+    ## extract variables
+    lat  <- eval(parse(text = lat))
+    lon  <- eval(parse(text = lon))
+    sec  <- nc$dim$time$vals
+    Tair <- ncvar_get(nc, "air_temperature")
+    Qair <- ncvar_get(nc, "specific_humidity")  #humidity (kg/kg)
+    U    <- ncvar_get(nc, "eastward_wind")
+    V    <- ncvar_get(nc, "northward_wind")
+    Rain <- ncvar_get(nc, "precipitation_flux")
+    pres <- ncvar_get(nc, "air_pressure")
+    SW   <- ncvar_get(nc, "surface_downwelling_shortwave_flux_in_air")
+    LW   <- ncvar_get(nc, "surface_downwelling_longwave_flux_in_air")
+    CO2  <- try(ncvar_get(nc, "mole_fraction_of_carbon_dioxide_in_air"), silent = TRUE)
+    
+    useCO2 <- is.numeric(CO2)
+    
+    ## convert time to seconds
+    sec <- udunits2::ud.convert(sec, unlist(strsplit(nc$dim$time$units, " "))[1], "seconds")
+    
+    nc_close(nc)
+    
+    dt <- ifelse(leap_year(year) == TRUE, 
+                 366 * 24 * 60 * 60 / length(sec), # leap year
+                 365 * 24 * 60 * 60 / length(sec)) # non-leap year
+    
+    toff <- -as.numeric(lst) * 3600 / dt
+    
+    ## buffer to get to GMT
+    slen <- length(SW)
+    Tair <- c(rep(Tair[1], toff), Tair)[1:slen]
+    Qair <- c(rep(Qair[1], toff), Qair)[1:slen]
+    U    <- c(rep(U[1], toff), U)[1:slen]
+    V    <- c(rep(V[1], toff), V)[1:slen]
+    Rain <- c(rep(Rain[1], toff), Rain)[1:slen]
+    pres <- c(rep(pres[1], toff), pres)[1:slen]
+    SW   <- c(rep(SW[1], toff), SW)[1:slen]
+    LW   <- c(rep(LW[1], toff), LW)[1:slen]
+    if (useCO2) {
+      CO2 <- c(rep(CO2[1], toff), CO2)[1:slen]
+    }
+    
+    ## build time variables (year, month, day of year)
+    skip <- FALSE
+    nyr  <- floor(length(sec) / 86400 / 365 * dt)
+    yr   <- NULL
+    doy  <- NULL
+    hr   <- NULL
+    asec <- sec
+    for (y in (year + 1):(nyr - 1)) {
+      ytmp <- rep(y, 365 * 86400 / dt)
+      dtmp <- rep(1:365, each = 86400 / dt)
+      if (y%%4 == 0) {
+        ## is leap
+        ytmp <- rep(y, 366 * 86400 / dt)
+        dtmp <- rep(1:366, each = 86400 / dt)
+      }
+      if (is.null(yr)) {
+        yr  <- ytmp
+        doy <- dtmp
+        hr  <- rep(NA, length(dtmp))
+      } else {
+        yr  <- c(yr, ytmp)
+        doy <- c(doy, dtmp)
+        hr  <- c(hr, rep(NA, length(dtmp)))
+      }
+      rng <- length(doy) - length(ytmp):1 + 1
+      if (!all(rng >= 0)) {
+        skip <- TRUE
+        logger.warn(paste(year, "is not a complete year and will not be included"))
+        break
+      }
+      asec[rng] <- asec[rng] - asec[rng[1]]
+      hr[rng]   <- (asec[rng] - (dtmp - 1) * 86400) / 86400 * 24
+    }
+    mo <- day2mo(yr, doy)
+    if (length(yr) < length(sec)) {
+      rng <- (length(yr) + 1):length(sec)
+      if (!all(rng >= 0)) {
+        skip <- TRUE
+        logger.warn(paste(year, "is not a complete year and will not be included"))
+        break
+      }
+      yr[rng]  <- rep(y + 1, length(rng))
+      doy[rng] <- rep(1:366, each = 86400 / dt)[1:length(rng)]
+      hr[rng]  <- rep(seq(0, length = 86400 / dt, by = dt / 86400 * 24), 366)[1:length(rng)]
+    }
+    if (skip) {
+      print("Skipping to next year")
+      next
+    }
+    
+    
+    ## calculate potential radiation in order to estimate diffuse/direct
+    f                <- pi/180 * (279.5 + 0.9856 * doy)
+    et               <- (-104.7 * sin(f) + 596.2 * sin(2 * f) + 4.3 * sin(4 * f) - 429.3 * 
+                           cos(f) - 2 * cos(2 * f) + 19.3 * cos(3 * f)) / 3600  # equation of time -> eccentricity and obliquity
+    merid            <- floor(lon/15) * 15
+    merid[merid < 0] <- merid[merid < 0] + 15
+    lc               <- (lon - merid) * -4 / 60  ## longitude correction
+    tz               <- merid / 360 * 24  ## time zone
+    midbin           <- 0.5 * dt / 86400 * 24  ## shift calc to middle of bin
+    t0               <- 12 + lc - et - tz - midbin  ## solar time
+    h                <- pi/12 * (hr - t0)  ## solar hour
+    dec              <- -23.45 * pi/180 * cos(2 * pi * (doy + 10) / 365)  ## declination
+    
+    cosz             <- sin(lat * pi/180) * sin(dec) + cos(lat * pi/180) * cos(dec) * cos(h)
+    cosz[cosz < 0]   <- 0
+    
+    rpot <- 1366 * cosz
+    rpot <- rpot[1:length(SW)]
+    
+    SW[rpot < SW] <- rpot[rpot < SW]  ## ensure radiation < max
+    ### this causes trouble at twilight bc of missmatch btw bin avergage and bin midpoint
+    frac <- SW/rpot
+    frac[frac > 0.9] <- 0.9  ## ensure some diffuse
+    frac[frac < 0] <- 0
+    frac[is.na(frac)] <- 0
+    frac[is.nan(frac)] <- 0
+    SWd <- SW * (1 - frac)  ## Diffuse portion of total short wave rad
+    
+    ### convert to ED2.1 hdf met variables
+    n      <- length(Tair)
+    nbdsfA <- (SW - SWd) * 0.57  # near IR beam downward solar radiation [W/m2]
+    nddsfA <- SWd * 0.48  # near IR diffuse downward solar radiation [W/m2]
+    vbdsfA <- (SW - SWd) * 0.43  # visible beam downward solar radiation [W/m2]
+    vddsfA <- SWd * 0.52  # visible diffuse downward solar radiation [W/m2]
+    prateA <- Rain  # precipitation rate [kg_H2O/m2/s]
+    dlwrfA <- LW  # downward long wave radiation [W/m2]
+    presA  <- pres  # pressure [Pa]
+    hgtA   <- rep(50, n)  # geopotential height [m]
+    ugrdA  <- U  # zonal wind [m/s]
+    vgrdA  <- V  # meridional wind [m/s]
+    shA    <- Qair  # specific humidity [kg_H2O/kg_air]
+    tmpA   <- Tair  # temperature [K]
+    if (useCO2) {
+      co2A <- CO2 * 1e+06  # surface co2 concentration [ppm] converted from mole fraction [kg/kg]
+    }
+    
+    ## create directory if(system(paste('ls',froot),ignore.stderr=TRUE)>0)
+    ## system(paste('mkdir',froot))
+    
+    ## write by year and month
+    for (y in year + 1:nyr - 1) {
+      sely <- which(yr == y)
+      for (m in unique(mo[sely])) {
+        selm <- sely[which(mo[sely] == m)]
+        mout <- paste(met_folder, "/", y, month[m], ".h5", sep = "")
+        if (file.exists(mout)) {
+          if (overwrite == TRUE) {
+            file.remove(mout)
+            h5createFile(mout)
+          }
+          if (overwrite == FALSE) {
+            logger.warn("The file already exists! Moving to next month!")
+            next
+          }
+        } else {
           h5createFile(mout)
         }
-        if(overwrite==FALSE){
-          logger.warn("The file already exists! Moving to next month!")
-          next
+        dims  <- c(length(selm), 1, 1)
+        nbdsf <- array(nbdsfA[selm], dim = dims)
+        nddsf <- array(nddsfA[selm], dim = dims)
+        vbdsf <- array(vbdsfA[selm], dim = dims)
+        vddsf <- array(vddsfA[selm], dim = dims)
+        prate <- array(prateA[selm], dim = dims)
+        dlwrf <- array(dlwrfA[selm], dim = dims)
+        pres  <- array(presA[selm], dim = dims)
+        hgt   <- array(hgtA[selm], dim = dims)
+        ugrd  <- array(ugrdA[selm], dim = dims)
+        vgrd  <- array(vgrdA[selm], dim = dims)
+        sh    <- array(shA[selm], dim = dims)
+        tmp   <- array(tmpA[selm], dim = dims)
+        if (useCO2) {
+          co2 <- array(co2A[selm], dim = dims)
+        }
+        h5write(nbdsf, mout, "nbdsf")
+        h5write(nddsf, mout, "nddsf")
+        h5write(vbdsf, mout, "vbdsf")
+        h5write(vddsf, mout, "vddsf")
+        h5write(prate, mout, "prate")
+        h5write(dlwrf, mout, "dlwrf")
+        h5write(pres, mout, "pres")
+        h5write(hgt, mout, "hgt")
+        h5write(ugrd, mout, "ugrd")
+        h5write(vgrd, mout, "vgrd")
+        h5write(sh, mout, "sh")
+        h5write(tmp, mout, "tmp")
+        if (useCO2) {
+          h5write(co2, mout, "co2")
         }
       }
-      else h5createFile(mout)
-      dims <- c(length(selm),1,1)
-      nbdsf <- array(nbdsfA[selm],dim=dims)
-      nddsf <- array(nddsfA[selm],dim=dims)
-      vbdsf <- array(vbdsfA[selm],dim=dims)
-      vddsf <- array(vddsfA[selm],dim=dims)
-      prate <- array(prateA[selm],dim=dims)
-      dlwrf <- array(dlwrfA[selm],dim=dims)
-      pres  <- array(presA[selm],dim=dims)
-      hgt   <- array(hgtA[selm],dim=dims)
-      ugrd  <- array(ugrdA[selm],dim=dims)
-      vgrd  <- array(vgrdA[selm],dim=dims)
-      sh    <- array(shA[selm],dim=dims)
-      tmp   <- array(tmpA[selm],dim=dims)
-      if(useCO2){
-        co2   <- array(co2A[selm],dim=dims)
-      }
-      h5write(nbdsf,mout,"nbdsf")
-      h5write(nddsf,mout,"nddsf")
-      h5write(vbdsf,mout,"vbdsf")
-      h5write(vddsf,mout,"vddsf")
-      h5write(prate,mout,"prate")
-      h5write(dlwrf,mout,"dlwrf")
-      h5write(pres,mout,"pres")
-      h5write(hgt,mout,"hgt")
-      h5write(ugrd,mout,"ugrd")
-      h5write(vgrd,mout,"vgrd")
-      h5write(sh,mout,"sh")
-      h5write(tmp,mout,"tmp")
-      if(useCO2){
-          h5write(co2,mout,"co2")
-      }
-
-
     }
-  }
-
-  ## write DRIVER file
-  sites <- 1
-  metgrid <- c(1,1,1,1,lon,lat)
-  metvar <- c("nbdsf","nddsf","vbdsf","vddsf","prate","dlwrf","pres","hgt","ugrd","vgrd","sh","tmp","co2")
-  nmet <- length(metvar)
-  metfrq <- rep(dt,nmet)
-  metflag <- rep(1,nmet)
-  if(!useCO2){
-    metflag[metvar=="co2"] = 4
-    metfrq[metvar=="co2"] = 380
-  }
-  write.table("header",met_header,row.names=FALSE,col.names=FALSE)
-  write.table(sites,met_header,row.names=FALSE,col.names=FALSE,append=TRUE)
-  write.table(met_folder,met_header,row.names=FALSE,col.names=FALSE,append=TRUE,quote=FALSE)
-  write.table(matrix(metgrid,nrow=1),met_header,row.names=FALSE,col.names=FALSE,append=TRUE,quote=FALSE)
-  write.table(nmet,met_header,row.names=FALSE,col.names=FALSE,append=TRUE,quote=FALSE)
-  write.table(matrix(metvar,nrow=1),met_header,row.names=FALSE,col.names=FALSE,append=TRUE)
-  write.table(matrix(metfrq,nrow=1),met_header,row.names=FALSE,col.names=FALSE,append=TRUE,quote=FALSE)
-  write.table(matrix(metflag,nrow=1),met_header,row.names=FALSE,col.names=FALSE,append=TRUE,quote=FALSE)
-
-print("Done with met2model.ED2")
-
-} ### end loop over met files
+    
+    ## write DRIVER file
+    sites <- 1
+    metgrid <- c(1, 1, 1, 1, lon, lat)
+    metvar <- c("nbdsf", "nddsf", "vbdsf", "vddsf", "prate", "dlwrf", 
+                "pres", "hgt", "ugrd", "vgrd", "sh", "tmp", "co2")
+    nmet <- length(metvar)
+    metfrq <- rep(dt, nmet)
+    metflag <- rep(1, nmet)
+    if (!useCO2) {
+      metflag[metvar == "co2"] <- 4
+      metfrq[metvar == "co2"] <- 380
+    }
+    write.table("header", met_header, row.names = FALSE, col.names = FALSE)
+    write.table(sites, met_header, row.names = FALSE, col.names = FALSE, append = TRUE)
+    write.table(met_folder, met_header, row.names = FALSE, col.names = FALSE, append = TRUE, 
+                quote = FALSE)
+    write.table(matrix(metgrid, nrow = 1), met_header, row.names = FALSE, col.names = FALSE, 
+                append = TRUE, quote = FALSE)
+    write.table(nmet, met_header, row.names = FALSE, col.names = FALSE, append = TRUE, quote = FALSE)
+    write.table(matrix(metvar, nrow = 1), met_header, row.names = FALSE, col.names = FALSE, append = TRUE)
+    write.table(matrix(metfrq, nrow = 1), met_header, row.names = FALSE, col.names = FALSE, append = TRUE, 
+                quote = FALSE)
+    write.table(matrix(metflag, nrow = 1), met_header, row.names = FALSE, col.names = FALSE, 
+                append = TRUE, quote = FALSE)
+  }  ### end loop over met files
+  
+  print("Done with met2model.ED2")
   invisible(results)
-
-} ### end met2model.ED2
+} # met2model.ED2

--- a/models/ed/R/model2netcdf.ED2.R
+++ b/models/ed/R/model2netcdf.ED2.R
@@ -205,10 +205,9 @@ model2netcdf.ED2 <- function(outdir, sitelat, sitelon, start_date, end_date) {
         if (length(dim(soiltemp)) == 3) {
           fdepth <- array(0, dim = dim(soiltemp)[1:2])
           tdepth <- array(0, dim = dim(soiltemp)[1:2])
-          for (t in 1:dim(soiltemp)[1]) {
-            # time polygon depth
-            for (p in 1:dim(soiltemp)[2]) {
-              for (i in dim(soiltemp)[3]:2) {
+          for (t in 1:dim(soiltemp)[1]) { # time
+            for (p in 1:dim(soiltemp)[2]) { # polygon
+              for (i in dim(soiltemp)[3]:2) { # depth
                 if (fdepth[t, p] == 0 & soiltemp[t, p, i] < 273.15 & 
                     soiltemp[t, p, i - 1] > 273.13) {
                   fdepth[t, p] <- i
@@ -238,9 +237,8 @@ model2netcdf.ED2 <- function(outdir, sitelat, sitelon, start_date, end_date) {
           # no polygons, just time vs depth?
           fdepth <- array(0, ncol(soiltemp))
           tdepth <- array(0, ncol(soiltemp))
-          for (t in seq_along(soiltemp)) {
-            # time depth
-            for (d in 2:nrow(soiltemp)) {
+          for (t in 1:ncol(soiltemp)) { # time
+            for (d in 2:nrow(soiltemp)) { # depth
               if (fdepth[t] == 0 & soiltemp[d, t] < 273.15 & soiltemp[d - 1, t] > 273.13) {
                 fdepth[t] <- d
               }
@@ -358,10 +356,9 @@ model2netcdf.ED2 <- function(outdir, sitelat, sitelon, start_date, end_date) {
         if (length(dim(soiltemp)) == 3) {
           fdepth <- array(0, dim = dim(soiltemp)[1:2])
           tdepth <- array(0, dim = dim(soiltemp)[1:2])
-          for (t in 1:dim(soiltemp)[1]) {
-            # time polygon depth
-            for (p in 1:dim(soiltemp)[2]) {
-              for (i in dim(soiltemp)[3]:2) {
+          for (t in 1:dim(soiltemp)[1]) { # time
+            for (p in 1:dim(soiltemp)[2]) { # polygon
+              for (i in dim(soiltemp)[3]:2) { # depth
                 if (fdepth[t, p] == 0 & soiltemp[t, p, i] < 273.15 & 
                     soiltemp[t, p, i - 1] > 273.13) {
                   fdepth[t, p] <- i
@@ -391,9 +388,8 @@ model2netcdf.ED2 <- function(outdir, sitelat, sitelon, start_date, end_date) {
           # no polygons, just time vs depth?
           fdepth <- array(0, ncol(soiltemp))
           tdepth <- array(0, ncol(soiltemp))
-          for (t in seq_along(soiltemp)) {
-            # time depth
-            for (d in 2:nrow(soiltemp)) {
+          for (t in 1:ncol(soiltemp)) { # time
+            for (d in 2:nrow(soiltemp)) { # depth
               if (fdepth[t] == 0 & soiltemp[d, t] < 273.15 & soiltemp[d - 1, t] > 273.13) {
                 fdepth[t] <- d
               }

--- a/models/ed/R/model2netcdf.ED2.R
+++ b/models/ed/R/model2netcdf.ED2.R
@@ -1,11 +1,12 @@
-## -------------------------------------------------------------------------------
-## Copyright (c) 2012 University of Illinois, NCSA.
-## All rights reserved. This program and the accompanying materials
-## are made available under the terms of the 
-## University of Illinois/NCSA Open Source License
-## which accompanies this distribution, and is available at
-## http://opensource.ncsa.illinois.edu/license.html
-## ---------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+# Copyright (c) 2012 University of Illinois, NCSA.
+# All rights reserved. This program and the accompanying materials 
+# are made available under the terms of the
+# University of Illinois/NCSA Open Source License
+# which accompanies this distribution, and is available at
+# http://opensource.ncsa.illinois.edu/license.html
+#-------------------------------------------------------------------------------
+
 ##' Modified from Code to convert ED2.1's HDF5 output into the NACP Intercomparison format (ALMA using netCDF)
 ##' 
 ##' @name model2netcdf.ED2
@@ -19,37 +20,34 @@
 ##' @export
 ##'
 ##' @author Michael Dietze, Shawn Serbin, Rob Kooper, Toni Viskari
-## modified M. Dietze 07/08/12
-## modified S. Serbin 05/06/13
+## modified M. Dietze 07/08/12 modified S. Serbin 05/06/13
 model2netcdf.ED2 <- function(outdir, sitelat, sitelon, start_date, end_date) {
-  require(udunits2)
+  library(udunits2)
   
-  flist <- dir(outdir,"-T-")
+  flist <- dir(outdir, "-T-")
   if (length(flist) == 0) {
-    print(paste("*** WARNING: No tower output for :",outdir))
-    break
+    print(paste("*** WARNING: No tower output for :", outdir))
+    return(NULL)
   }
   
   ## extract data info from file names?
-  yr <- rep(NA,length(flist))
-  for(i in 1:length(flist)){
-    ## tmp <- sub(run.id,"",flist[i])  # Edited by SPS
-    ## tmp <- sub("-T-","",tmp)        # Edited by SPS
-    index <- gregexpr("-T-",flist[i])[[1]]
+  yr <- rep(NA, length(flist))
+  for (i in seq_along(flist)) {
+    ## tmp <- sub(run.id,'',flist[i]) # Edited by SPS tmp <- sub('-T-','',tmp) # Edited by SPS
+    index <- gregexpr("-T-", flist[i])[[1]]
     index <- index[1]
-    yr[i] <- as.numeric(substr(flist[i],index+3,index+6))
+    yr[i] <- as.numeric(substr(flist[i], index + 3, index + 6))
     ## yr[i] <- as.numeric(substr(tmp,1,4)) # Edited by SPS
   }
   
   ## set up storage
-  block <- 4 # assumes 6-hourly
-  ##block <- 24 # assumes hourly  
-  ##block <- 48 # assumes half-hourly  # Need to generalize (SPS)
-
- 
+  block <- 4  # assumes 6-hourly
+  ## block <- 24 # assumes hourly block <- 48 # assumes half-hourly # Need to generalize (SPS)
+  
+  
   add <- function(dat, col, row, year) {
-    ## data is always given for whole year, except it will start always at 0
-    ## the left over data is filled with 0's
+    ## data is always given for whole year, except it will start always at 0 the left over data is
+    ## filled with 0's
     if (year == strftime(start_date, "%Y")) {
       start <- (as.numeric(strftime(start_date, "%j")) - 1) * block
     } else {
@@ -60,42 +58,45 @@ model2netcdf.ED2 <- function(outdir, sitelat, sitelon, start_date, end_date) {
     } else {
       end <- as.numeric(strftime(paste0(year, "-12-31"), "%j")) * block
     }
-
+    
     dims <- dim(dat)
     if (is.null(dims)) {
       if (length(dat) == 1) {
         if (length(out) < col) {
-          out[[col]] <- array(dat, dim=(end-start))
+          out[[col]] <- array(dat, dim = (end - start))
         } else {
           if (start != 0) {
-            logger.warn("start date is not 0 this year, but data already exists in this col", col, "how is this possible?")
+            logger.warn("start date is not 0 this year, but data already exists in this col", 
+                        col, "how is this possible?")
           }
-          out[[col]] <- abind(out[[col]], array(dat, dim=(end-start)), along=1)
+          out[[col]] <- abind(out[[col]], array(dat, dim = (end - start)), along = 1)
         }
       } else {
         logger.warn("expected a single value")
       }
     } else if (length(dims) == 1) {
-      dat <- dat[1:(end-start)]
+      dat <- dat[1:(end - start)]
       if (length(out) < col) {
         out[[col]] <- dat
       } else {
         if (start != 0) {
-          logger.warn("start date is not 0 this year, but data already exists in this col", col, "how is this possible?")
+          logger.warn("start date is not 0 this year, but data already exists in this col", 
+                      col, "how is this possible?")
         }
-        out[[col]] <- abind(out[[col]], dat, along=1)
+        out[[col]] <- abind(out[[col]], dat, along = 1)
       }
     } else if (length(dims) == 2) {
       dat <- t(dat)
       dims <- dim(dat)
-      dat <- dat[1:(end-start),]
+      dat <- dat[1:(end - start), ]
       if (length(out) < col) {
         out[[col]] <- dat
       } else {
         if (start != 0) {
-          logger.warn("start date is not 0 this year, but data already exists in this col", col, "how is this possible?")
+          logger.warn("start date is not 0 this year, but data already exists in this col", 
+                      col, "how is this possible?")
         }
-        out[[col]] <- abind(out[[col]], dat, along=1)
+        out[[col]] <- abind(out[[col]], dat, along = 1)
       }
     } else {
       logger.debug("-------------------------------------------------------------")
@@ -106,7 +107,7 @@ model2netcdf.ED2 <- function(outdir, sitelat, sitelon, start_date, end_date) {
       logger.debug("dims=", dims)
       logger.warn("Don't know how to handle larger arrays yet.")
     }
-
+    
     ## finally make sure we use -999 for invalid values
     out[[col]][is.null(out[[col]])] <- -999
     out[[col]][is.na(out[[col]])] <- -999
@@ -115,17 +116,17 @@ model2netcdf.ED2 <- function(outdir, sitelat, sitelon, start_date, end_date) {
   }
   
   getHdf5Data <- function(nc, var) {
-    if(var %in% names(nc$var)) {
+    if (var %in% names(nc$var)) {
       return(ncvar_get(nc, var))
     } else {
       logger.warn("Could not find", var, "in ed hdf5 output.")
       return(-999)
     }
   }
-
+  
   CheckED2Version <- function(nc) {
-    if('FMEAN_BDEAD_PY' %in% names(nc$var)) {
-      return('Git')
+    if ("FMEAN_BDEAD_PY" %in% names(nc$var)) {
+      return("Git")
     }
   }
   
@@ -141,9 +142,9 @@ model2netcdf.ED2 <- function(outdir, sitelat, sitelon, start_date, end_date) {
     return(out)
   }
   
-  ## loop over files  ### break by YEAR
+  ## loop over files ### break by YEAR
   yrs <- sort(unique(yr))
-  for(y in 1:length(yrs)){
+  for (y in 1:length(yrs)) {
     ysel <- which(yr == yrs[y])
     if (yrs[y] < strftime(start_date, "%Y")) {
       print(paste0(yrs[y], "<", strftime(start_date, "%Y")))
@@ -155,328 +156,331 @@ model2netcdf.ED2 <- function(outdir, sitelat, sitelon, start_date, end_date) {
     }
     n <- length(ysel)
     out <- list()
-    ## prevTime <- NULL
-    ## print(y)
-    print(paste("----- Processing year: ",yrs[y]))
+    ## prevTime <- NULL print(y)
+    print(paste("----- Processing year: ", yrs[y]))
     ## if(haveTime) prevTime <- progressBar()
     row <- 1
-    for(i in ysel){
+    for (i in ysel) {
       ncT <- nc_open(file.path(outdir, flist[i]))
-      if (file.exists(file.path(outdir, sub('-T-', '-Y-', flist[i])))) {
-        ncY <- nc_open(file.path(outdir, sub('-T-', '-Y-', flist[i])))
-        slzdata <- getHdf5Data(ncY, 'SLZ')
+      if (file.exists(file.path(outdir, sub("-T-", "-Y-", flist[i])))) {
+        ncY <- nc_open(file.path(outdir, sub("-T-", "-Y-", flist[i])))
+        slzdata <- getHdf5Data(ncY, "SLZ")
         nc_close(ncY)
       } else {
         logger.warn("Could not find SLZ in Y file, making a crude assumpution.")
-        slzdata <- array(c(-2.00, -1.50, -1.00, -0.80, -0.60, -0.40, -0.20, -0.10, -0.05))
+        slzdata <- array(c(-2, -1.5, -1, -0.8, -0.6, -0.4, -0.2, -0.1, -0.05))
       }
-
+      
       ## Check for which version of ED2 we are using.
       ED2vc <- CheckED2Version(ncT)
       
       ## store for later use, will only use last data
       dz <- diff(slzdata)
-      dz <- dz[dz != 0.0]
-
-      if(!is.null(ED2vc)){      
-
-
-       ## out <- add(getHdf5Data(ncT, 'TOTAL_AGB,1,row, yrs[y]) ## AbvGrndWood
-       out <- add(getHdf5Data(ncT, 'FMEAN_BDEAD_PY'),1,row, yrs[y]) ## AbvGrndWood
-       out <- add(getHdf5Data(ncT, 'FMEAN_PLRESP_PY'),2,row, yrs[y]) ## AutoResp
-       out <- add(-999,3,row, yrs[y]) ## CarbPools
-       out <- add(getHdf5Data(ncT, 'FMEAN_CAN_CO2_PY'),4,row, yrs[y]) ## CO2CAS
-       out <- add(-999,5,row, yrs[y]) ## CropYield
-       out <- add(getHdf5Data(ncT, 'FMEAN_GPP_PY'),6,row, yrs[y]) ## GPP
-       out <- add(getHdf5Data(ncT, 'FMEAN_RH_PY'),7,row, yrs[y]) ## HeteroResp
-       out <- add(getHdf5Data(ncT, 'FMEAN_GPP_PY') - getHdf5Data(ncT, 'FMEAN_PLRESP_PY') - getHdf5Data(ncT, 'FMEAN_RH_PY'),8,row, yrs[y]) ## NEE
-       out <- add(getHdf5Data(ncT, 'FMEAN_GPP_PY') - getHdf5Data(ncT, 'FMEAN_PLRESP_PY'),9,row, yrs[y]) ## NPP
-       out <- add(getHdf5Data(ncT, 'FMEAN_RH_PY') + getHdf5Data(ncT, 'FMEAN_PLRESP_PY'),10,row, yrs[y]) ## TotalResp
-       ## out <- add(getHdf5Data(ncT, 'BDEAD + getHdf5Data(ncT, 'BALIVE,11,row, yrs[y]) ## TotLivBiom
-       out <- add(-999,11,row, yrs[y]) ## TotLivBiom
-       out <- add(getHdf5Data(ncT, 'FAST_SOIL_C_PY')+getHdf5Data(ncT, 'STRUCT_SOIL_C_PY')+getHdf5Data(ncT, 'SLOW_SOIL_C_PY'),12,row, yrs[y]) ## TotSoilCarb
+      dz <- dz[dz != 0]
       
-       ## depth from surface to frozen layer
-       tdepth <- 0
-       fdepth <- 0
-       soiltemp <- getHdf5Data(ncT, 'FMEAN_SOIL_TEMP_PY')
-       if(length(dim(soiltemp)) == 3){
-      	fdepth <- array(0,dim=dim(soiltemp)[1:2])
-       	tdepth <- array(0,dim=dim(soiltemp)[1:2])
-       	for(t in 1:dim(soiltemp)[1]){ #time
-       	for(p in 1:dim(soiltemp)[2]){ #polygon
-       	for(i in dim(soiltemp)[3]:2){ #depth
-       	if(fdepth[t,p] == 0 & soiltemp[t,p,i] < 273.15 & soiltemp[t, p, i-1] > 273.13){
-          fdepth[t,p] <- i
-       	  }
-      	if(tdepth[t,p] == 0 & soiltemp[t,p,i] > 273.15 & soiltemp[t, p, i-1] < 273.13){
-         tdepth[t,p] <- i
-       	  }
-       	}
-        SLZ <- c(slzdata[t,],0.0)
-        z1 <- (SLZ[fdepth[t,p]+1]+SLZ[fdepth[t,p]])/2
-        z2 <- (SLZ[fdepth[t,p]]+SLZ[fdepth[t,p]-1])/2
-        if(fdepth[t,p] > 0) {
-         fdepth[t,p] <- z1 + (z2-z1) * (273.15 - soiltemp[t, p, fdepth[t, p]]) /
-         (soiltemp[t, p, fdepth[t, p] - 1] - soiltemp[t, p, fdepth[t, p]])
-        }
-        if(tdepth[t,p] > 0) {
-          SLZ <- c(slzdata[t,],0.0)
-          z1 <- (SLZ[tdepth[t,p]+1]+SLZ[tdepth[t,p]])/2
-          z2 <- (SLZ[tdepth[t,p]]+SLZ[tdepth[t,p]-1])/2
-          tdepth[t,p] <- z1 + (z2-z1) * (273.15 - soiltemp[t, p, tdepth[t, p]]) /
-           (soiltemp[t, p, tdepth[t, p] - 1] - soiltemp[t, p, tdepth[t, p]])
-         }
-        }
-       }
-      } else {
-                                        # no polygons, just time vs depth?	
-        fdepth <- array(0, ncol(soiltemp))
-        tdepth <- array(0, ncol(soiltemp))
-        for(t in 1:ncol(soiltemp)){ #time
-          for(d in 2:nrow(soiltemp)){ #depth
-            if(fdepth[t] == 0 & soiltemp[d,t] < 273.15 & soiltemp[d-1,t] > 273.13){
-              fdepth[t] <- d
-            }
-            if(tdepth[t] == 0 & soiltemp[d,t] > 273.15 & soiltemp[d-1,t] < 273.13){
-              tdepth[t] <- d
-            }
-          }
-          if(fdepth[t] > 0) {
-            SLZ <- c(slzdata,0.0)
-            z1 <- (SLZ[fdepth[t]+1]+SLZ[fdepth[t]])/2
-            z2 <- (SLZ[fdepth[t]]+SLZ[fdepth[t]-1])/2
-            fdepth[t] <- z1 + (z2-z1) * (273.15 - soiltemp[fdepth[t], t]) / (soiltemp[fdepth[t] - 1, t] - soiltemp[fdepth[t], t])
-          }
-          if(tdepth[t] > 0) {
-            SLZ <- c(slzdata,0.0)
-            z1 <- (SLZ[tdepth[t]+1]+SLZ[tdepth[t]])/2
-            z2 <- (SLZ[tdepth[t]]+SLZ[tdepth[t]-1])/2
-            tdepth[t] <- z1 + (z2-z1) * (273.15 - soiltemp[tdepth[t], t]) / (soiltemp[tdepth[t] - 1, t] - soiltemp[tdepth[t], t])
-          }
-        }
-      }
-      
-      out <- add(fdepth,13,row, yrs[y]) ## Fdepth
-      out <- add(getHdf5Data(ncT, 'FMEAN_SFCW_DEPTH_PY'),14,row, yrs[y]) ## SnowDepth (ED2 currently groups snow in to surface water)
-      out <- add(1-getHdf5Data(ncT, 'FMEAN_SFCW_FLIQ_PY'),15,row, yrs[y]) ## SnowFrac (ED2 currently groups snow in to surface water)
-      out <- add(tdepth,16,row, yrs[y]) ## Tdepth
-      out <- add(getHdf5Data(ncT, 'FMEAN_ATM_CO2_PY'),17,row, yrs[y]) ## CO2air
-      out <- add(getHdf5Data(ncT, 'FMEAN_ATM_RLONG_PY'),18,row, yrs[y]) ## Lwdown
-      out <- add(getHdf5Data(ncT, 'FMEAN_ATM_PRSS_PY'),19,row, yrs[y]) ## Psurf
-      out <- add(getHdf5Data(ncT, 'FMEAN_ATM_SHV_PY'),20,row, yrs[y]) ## Qair
-      out <- add(getHdf5Data(ncT, 'FMEAN_PCPG_PY'),21,row, yrs[y]) ## Rainf
-      ##out <- add(getHdf5Data(ncT, 'AVG_NIR_BEAM') +
-      ##           getHdf5Data(ncT, 'AVG_NIR_DIFFUSE')+
-      ##           getHdf5Data(ncT, 'AVG_PAR_BEAM')+
-      ##           getHdf5Data(ncT, 'AVG_PAR_DIFFUSE'),22,row, yrs[y]) ## Swdown
-      ##out <- add(getHdf5Data(ncT, 'FMEAN_PAR_L_BEAM_PY')+
-      ##           getHdf5Data(ncT, 'FMEAN_PAR_L_DIFF_PY'),22,row, yrs[y]) ## Swdown
-      out <- add(getHdf5Data(ncT, 'FMEAN_ATM_PAR_PY'),22,row, yrs[y])  ## Swdown
-      out <- add(getHdf5Data(ncT, 'FMEAN_ATM_TEMP_PY'),23,row, yrs[y]) ## Tair
-      out <- add(getHdf5Data(ncT, 'FMEAN_ATM_VELS_PY'),24,row, yrs[y]) ## Wind
-      ##out <- add(getHdf5Data(ncT, 'FMEAN_ATM_RLONG_PY')-getHdf5Data(ncT, 'AVG_RLONGUP'),25,row, yrs[y]) ## Lwnet
-      out <- add(-999,25,row, yrs[y]) ## Lwnet
-      ##out <- add(getHdf5Data(ncT, 'AVG_SENSIBLE_GC') + getHdf5Data(ncT, 'AVG_VAPOR_GC')*2272000,26,row, yrs[y]) ## Qg
-      out <- add(-999,26,row, yrs[y]) ## Qg
-      ##out <- add(getHdf5Data(ncT, 'AVG_SENSIBLE_TOT'),27,row, yrs[y]) ## Qh
-      out <- add(getHdf5Data(ncT, 'FMEAN_SENSIBLE_AC_PY'),27,row, yrs[y]) ## Qh
-      out <- add(getHdf5Data(ncT, 'FMEAN_VAPOR_LC_PY')+getHdf5Data(ncT, 'FMEAN_VAPOR_WC_PY')+getHdf5Data(ncT, 'FMEAN_VAPOR_GC_PY'),28,row, yrs[y]) ## Qle
-      out <- add(-999,29,row, yrs[y]) ## Swnet
-      out <- add(-999,30,row, yrs[y]) ## RootMoist
-      out <- add(getHdf5Data(ncT, 'FMEAN_TRANSP_PY'),31,row, yrs[y]) ## Tveg
-      out <- add(getHdf5Data(ncT, 'ZBAR'),32,row, yrs[y]) ## WaterTableD
-      out <- add(-999,33,row, yrs[y]) ## fPAR
-      ##lai <- matrix(apply(getHdf5Data(ncT, 'LAI_PFT'),1,sum,na.rm=TRUE),nrow=block)
-      ## out <- add(lai,34,row, yrs[y]) ## LAI******************
-      ## out <- add(getHdf5Data(ncT, 'FMEAN_LAI_PY'),34,row, yrs[y]) ## LAI - no longer using FMEAN LAI
-
-      ## OLD - to be deprecated
-      #laidata <- getHdf5Data(ncT,"LAI_PY")
-      #if(length(dim(laidata)) == 3){
-      #  out <- add(apply(laidata,3,sum),34,row,yrs[y])
-      #} else {
-      #  out <- add(-999,34,row, yrs[y])
-      #}
-
-      # code changes proposed by MCD, tested by SPS 20160607
-      laidata <- getHdf5Data(ncT,"LAI_PY")
-      if(length(dim(laidata)) == 3){
-        laidata <- apply(laidata,3,sum)
-        out <- add(array(laidata,dim=length(laidata)),34,row,yrs[y])
-      } else {
-        out <- add(-999,34,row, yrs[y])
-      }
-
-      ##z <- getHdf5Data(ncT, 'SLZ')
-      ##if(z[length(z)] < 0.0) z <- c(z,0.0)
-      ##dz <- diff(z)
-      ##dz <- dz[dz != 0.0]
-      ##fliq <- sum(getHdf5Data(ncT, 'AVG_SOIL_FRACLIQ')*dz)/-min(z)
-      fliq <- NA#getHdf5Data(ncT, 'FMEAN_SFCW_FLIQ_PY')
-      out <- add(1-fliq,35,row, yrs[y]) ## SMFrozFrac
-      out <- add(fliq,36,row, yrs[y]) ## SMLiqFrac
-      ## This needs to be soil wetness, i.e. multilple levels deep
-      out <- add(getHdf5Data(ncT, 'FMEAN_SOIL_WATER_PY'),37,row, yrs[y]) ## SoilWater  **********
-      ##out <- add(sum(soiltemp*dz)/-min(z),38) ## SoilTemp
-      out <- add(soiltemp,38,row, yrs[y]) ## SoilTemp
-      out <- add(-999,39,row, yrs[y]) ## SoilWet
-      out <- add(getHdf5Data(ncT, 'FMEAN_ALBEDO_PY'),40,row, yrs[y]) ## Albedo
-      out <- add(getHdf5Data(ncT, 'FMEAN_SFCW_TEMP_PY'),41,row, yrs[y]) ## SnowT (ED2 currently groups snow in to surface water)
-      out <- add(getHdf5Data(ncT, 'FMEAN_SFCW_MASS_PY'),42,row, yrs[y]) ## SWE (ED2 currently groups snow in to surface water)
-      out <- add(getHdf5Data(ncT, 'FMEAN_LEAF_TEMP_PY'),43,row, yrs[y]) ## VegT
-      out <- add(getHdf5Data(ncT, 'FMEAN_VAPOR_LC_PY')+getHdf5Data(ncT, 'FMEAN_VAPOR_WC_PY')+getHdf5Data(ncT, 'FMEAN_VAPOR_GC_PY')+getHdf5Data(ncT, 'FMEAN_TRANSP_PY'),44,row, yrs[y]) ## Evap
-      out <- add(getHdf5Data(ncT, 'FMEAN_QRUNOFF_PY'),45,row, yrs[y]) ## Qs
-      out <- add(getHdf5Data(ncT, 'BASEFLOW'),46,row, yrs[y]) ## Qsb
-      
-      } else{
-
-      ## out <- add(getHdf5Data(ncT, 'TOTAL_AGB,1,row, yrs[y]) ## AbvGrndWood
-      out <- add(getHdf5Data(ncT, 'AVG_BDEAD'),1,row, yrs[y]) ## AbvGrndWood
-      out <- add(getHdf5Data(ncT, 'AVG_PLANT_RESP'),2,row, yrs[y]) ## AutoResp
-      out <- add(-999,3,row, yrs[y]) ## CarbPools
-      out <- add(getHdf5Data(ncT, 'AVG_CO2CAN'),4,row, yrs[y]) ## CO2CAS
-      out <- add(-999,5,row, yrs[y]) ## CropYield
-      out <- add(getHdf5Data(ncT, 'AVG_GPP'),6,row, yrs[y]) ## GPP
-      out <- add(getHdf5Data(ncT, 'AVG_HTROPH_RESP'),7,row, yrs[y]) ## HeteroResp
-      out <- add(getHdf5Data(ncT, 'AVG_GPP') - getHdf5Data(ncT, 'AVG_PLANT_RESP') - getHdf5Data(ncT, 'AVG_HTROPH_RESP'),8,row, yrs[y]) ## NEE
-      out <- add(getHdf5Data(ncT, 'AVG_GPP') - getHdf5Data(ncT, 'AVG_PLANT_RESP'),9,row, yrs[y]) ## NPP
-      out <- add(getHdf5Data(ncT, 'AVG_HTROPH_RESP') + getHdf5Data(ncT, 'AVG_PLANT_RESP'),10,row, yrs[y]) ## TotalResp
-      ## out <- add(getHdf5Data(ncT, 'AVG_BDEAD + getHdf5Data(ncT, 'AVG_BALIVE,11,row, yrs[y]) ## TotLivBiom
-      out <- add(-999,11,row, yrs[y]) ## TotLivBiom
-      out <- add(getHdf5Data(ncT, 'AVG_FSC')+getHdf5Data(ncT, 'AVG_STSC')+getHdf5Data(ncT, 'AVG_SSC'),12,row, yrs[y]) ## TotSoilCarb
-      
-      ## depth from surface to frozen layer
-      tdepth <- 0
-      fdepth <- 0
-      soiltemp <- getHdf5Data(ncT, 'AVG_SOIL_TEMP')
-      if(length(dim(soiltemp)) == 3){
-        fdepth <- array(0,dim=dim(soiltemp)[1:2])
-        tdepth <- array(0,dim=dim(soiltemp)[1:2])
-        for(t in 1:dim(soiltemp)[1]){ #time
-          for(p in 1:dim(soiltemp)[2]){ #polygon
-            for(i in dim(soiltemp)[3]:2){ #depth
-              if(fdepth[t,p] == 0 & soiltemp[t,p,i] < 273.15 & soiltemp[t, p, i-1] > 273.13){
-                fdepth[t,p] <- i
+      if (!is.null(ED2vc)) {
+        ## out <- add(getHdf5Data(ncT, 'TOTAL_AGB,1,row, yrs[y]) ## AbvGrndWood
+        out <- add(getHdf5Data(ncT, "FMEAN_BDEAD_PY"), 1, row, yrs[y])  ## AbvGrndWood
+        out <- add(getHdf5Data(ncT, "FMEAN_PLRESP_PY"), 2, row, yrs[y])  ## AutoResp
+        out <- add(-999, 3, row, yrs[y])  ## CarbPools
+        out <- add(getHdf5Data(ncT, "FMEAN_CAN_CO2_PY"), 4, row, yrs[y])  ## CO2CAS
+        out <- add(-999, 5, row, yrs[y])  ## CropYield
+        out <- add(getHdf5Data(ncT, "FMEAN_GPP_PY"), 6, row, yrs[y])  ## GPP
+        out <- add(getHdf5Data(ncT, "FMEAN_RH_PY"), 7, row, yrs[y])  ## HeteroResp
+        out <- add(getHdf5Data(ncT, "FMEAN_GPP_PY") - getHdf5Data(ncT, "FMEAN_PLRESP_PY") - 
+                     getHdf5Data(ncT, "FMEAN_RH_PY"), 8, row, yrs[y])  ## NEE
+        out <- add(getHdf5Data(ncT, "FMEAN_GPP_PY") - getHdf5Data(ncT, "FMEAN_PLRESP_PY"), 
+                   9, row, yrs[y])  ## NPP
+        out <- add(getHdf5Data(ncT, "FMEAN_RH_PY") + getHdf5Data(ncT, "FMEAN_PLRESP_PY"), 
+                   10, row, yrs[y])  ## TotalResp
+        ## out <- add(getHdf5Data(ncT, 'BDEAD + getHdf5Data(ncT, 'BALIVE,11,row, yrs[y]) ## TotLivBiom
+        out <- add(-999, 11, row, yrs[y])  ## TotLivBiom
+        out <- add(getHdf5Data(ncT, "FAST_SOIL_C_PY") + getHdf5Data(ncT, "STRUCT_SOIL_C_PY") + 
+                     getHdf5Data(ncT, "SLOW_SOIL_C_PY"), 12, row, yrs[y])  ## TotSoilCarb
+        
+        ## depth from surface to frozen layer
+        tdepth <- 0
+        fdepth <- 0
+        soiltemp <- getHdf5Data(ncT, "FMEAN_SOIL_TEMP_PY")
+        if (length(dim(soiltemp)) == 3) {
+          fdepth <- array(0, dim = dim(soiltemp)[1:2])
+          tdepth <- array(0, dim = dim(soiltemp)[1:2])
+          for (t in 1:dim(soiltemp)[1]) {
+            # time polygon depth
+            for (p in 1:dim(soiltemp)[2]) {
+              for (i in dim(soiltemp)[3]:2) {
+                if (fdepth[t, p] == 0 & soiltemp[t, p, i] < 273.15 & 
+                    soiltemp[t, p, i - 1] > 273.13) {
+                  fdepth[t, p] <- i
+                }
+                if (tdepth[t, p] == 0 & soiltemp[t, p, i] > 273.15 & 
+                    soiltemp[t, p, i - 1] < 273.13) {
+                  tdepth[t, p] <- i
+                }
               }
-              if(tdepth[t,p] == 0 & soiltemp[t,p,i] > 273.15 & soiltemp[t, p, i-1] < 273.13){
-                tdepth[t,p] <- i
+              SLZ <- c(slzdata[t, ], 0)
+              z1 <- (SLZ[fdepth[t, p] + 1] + SLZ[fdepth[t, p]]) / 2
+              z2 <- (SLZ[fdepth[t, p]] + SLZ[fdepth[t, p] - 1]) / 2
+              if (fdepth[t, p] > 0) {
+                fdepth[t, p] <- z1 + (z2 - z1) * (273.15 - soiltemp[t, p, fdepth[t, p]]) / 
+                  (soiltemp[t, p, fdepth[t, p] - 1] - soiltemp[t, p, fdepth[t, p]])
+              }
+              if (tdepth[t, p] > 0) {
+                SLZ <- c(slzdata[t, ], 0)
+                z1 <- (SLZ[tdepth[t, p] + 1] + SLZ[tdepth[t, p]]) / 2
+                z2 <- (SLZ[tdepth[t, p]] + SLZ[tdepth[t, p] - 1]) / 2
+                tdepth[t, p] <- z1 + (z2 - z1) * (273.15 - soiltemp[t, p, tdepth[t, p]]) / 
+                  (soiltemp[t, p, tdepth[t, p] - 1] - soiltemp[t, p, tdepth[t, p]])
               }
             }
-            SLZ <- c(slzdata[t,],0.0)
-            z1 <- (SLZ[fdepth[t,p]+1]+SLZ[fdepth[t,p]])/2
-            z2 <- (SLZ[fdepth[t,p]]+SLZ[fdepth[t,p]-1])/2
-            if(fdepth[t,p] > 0) {
-              fdepth[t,p] <- z1 + (z2-z1) * (273.15 - soiltemp[t, p, fdepth[t, p]]) /
-                (soiltemp[t, p, fdepth[t, p] - 1] - soiltemp[t, p, fdepth[t, p]])
+          }
+        } else {
+          # no polygons, just time vs depth?
+          fdepth <- array(0, ncol(soiltemp))
+          tdepth <- array(0, ncol(soiltemp))
+          for (t in seq_along(soiltemp)) {
+            # time depth
+            for (d in 2:nrow(soiltemp)) {
+              if (fdepth[t] == 0 & soiltemp[d, t] < 273.15 & soiltemp[d - 1, t] > 273.13) {
+                fdepth[t] <- d
+              }
+              if (tdepth[t] == 0 & soiltemp[d, t] > 273.15 & soiltemp[d - 1, t] < 273.13) {
+                tdepth[t] <- d
+              }
             }
-            if(tdepth[t,p] > 0) {
-              SLZ <- c(slzdata[t,],0.0)
-              z1 <- (SLZ[tdepth[t,p]+1]+SLZ[tdepth[t,p]])/2
-              z2 <- (SLZ[tdepth[t,p]]+SLZ[tdepth[t,p]-1])/2
-              tdepth[t,p] <- z1 + (z2-z1) * (273.15 - soiltemp[t, p, tdepth[t, p]]) /
-                (soiltemp[t, p, tdepth[t, p] - 1] - soiltemp[t, p, tdepth[t, p]])
+            if (fdepth[t] > 0) {
+              SLZ <- c(slzdata, 0)
+              z1 <- (SLZ[fdepth[t] + 1] + SLZ[fdepth[t]]) / 2
+              z2 <- (SLZ[fdepth[t]] + SLZ[fdepth[t] - 1]) / 2
+              fdepth[t] <- z1 + (z2 - z1) * (273.15 - soiltemp[fdepth[t], t]) / 
+                (soiltemp[fdepth[t] - 1, t] - soiltemp[fdepth[t], t])
+            }
+            if (tdepth[t] > 0) {
+              SLZ <- c(slzdata, 0)
+              z1 <- (SLZ[tdepth[t] + 1] + SLZ[tdepth[t]]) / 2
+              z2 <- (SLZ[tdepth[t]] + SLZ[tdepth[t] - 1]) / 2
+              tdepth[t] <- z1 + (z2 - z1) * (273.15 - soiltemp[tdepth[t], t]) / 
+                (soiltemp[tdepth[t] - 1, t] - soiltemp[tdepth[t], t])
             }
           }
         }
+        
+        out <- add(fdepth, 13, row, yrs[y])  ## Fdepth
+        out <- add(getHdf5Data(ncT, "FMEAN_SFCW_DEPTH_PY"), 14, row, yrs[y])  ## SnowDepth (ED2 currently groups snow in to surface water)
+        out <- add(1 - getHdf5Data(ncT, "FMEAN_SFCW_FLIQ_PY"), 15, row, yrs[y])  ## SnowFrac (ED2 currently groups snow in to surface water)
+        out <- add(tdepth, 16, row, yrs[y])  ## Tdepth
+        out <- add(getHdf5Data(ncT, "FMEAN_ATM_CO2_PY"), 17, row, yrs[y])  ## CO2air
+        out <- add(getHdf5Data(ncT, "FMEAN_ATM_RLONG_PY"), 18, row, yrs[y])  ## Lwdown
+        out <- add(getHdf5Data(ncT, "FMEAN_ATM_PRSS_PY"), 19, row, yrs[y])  ## Psurf
+        out <- add(getHdf5Data(ncT, "FMEAN_ATM_SHV_PY"), 20, row, yrs[y])  ## Qair
+        out <- add(getHdf5Data(ncT, "FMEAN_PCPG_PY"), 21, row, yrs[y])  ## Rainf
+        ## out <- add(getHdf5Data(ncT, 'AVG_NIR_BEAM') + getHdf5Data(ncT, 'AVG_NIR_DIFFUSE')+
+        ## getHdf5Data(ncT, 'AVG_PAR_BEAM')+ getHdf5Data(ncT, 'AVG_PAR_DIFFUSE'),22,row, yrs[y]) ## Swdown
+        ## out <- add(getHdf5Data(ncT, 'FMEAN_PAR_L_BEAM_PY')+ getHdf5Data(ncT,
+        ## 'FMEAN_PAR_L_DIFF_PY'),22,row, yrs[y]) ## Swdown
+        out <- add(getHdf5Data(ncT, "FMEAN_ATM_PAR_PY"), 22, row, yrs[y])  ## Swdown
+        out <- add(getHdf5Data(ncT, "FMEAN_ATM_TEMP_PY"), 23, row, yrs[y])  ## Tair
+        out <- add(getHdf5Data(ncT, "FMEAN_ATM_VELS_PY"), 24, row, yrs[y])  ## Wind
+        ## out <- add(getHdf5Data(ncT, 'FMEAN_ATM_RLONG_PY')-getHdf5Data(ncT, 'AVG_RLONGUP'),25,row,
+        ## yrs[y]) ## Lwnet
+        out <- add(-999, 25, row, yrs[y])  ## Lwnet
+        ## out <- add(getHdf5Data(ncT, 'AVG_SENSIBLE_GC') + getHdf5Data(ncT,
+        ## 'AVG_VAPOR_GC')*2272000,26,row, yrs[y]) ## Qg
+        out <- add(-999, 26, row, yrs[y])  ## Qg
+        ## out <- add(getHdf5Data(ncT, 'AVG_SENSIBLE_TOT'),27,row, yrs[y]) ## Qh
+        out <- add(getHdf5Data(ncT, "FMEAN_SENSIBLE_AC_PY"), 27, row, yrs[y])  ## Qh
+        out <- add(getHdf5Data(ncT, "FMEAN_VAPOR_LC_PY") + getHdf5Data(ncT, "FMEAN_VAPOR_WC_PY") + 
+                     getHdf5Data(ncT, "FMEAN_VAPOR_GC_PY"), 28, row, yrs[y])  ## Qle
+        out <- add(-999, 29, row, yrs[y])  ## Swnet
+        out <- add(-999, 30, row, yrs[y])  ## RootMoist
+        out <- add(getHdf5Data(ncT, "FMEAN_TRANSP_PY"), 31, row, yrs[y])  ## Tveg
+        out <- add(getHdf5Data(ncT, "ZBAR"), 32, row, yrs[y])  ## WaterTableD
+        out <- add(-999, 33, row, yrs[y])  ## fPAR
+        ## lai <- matrix(apply(getHdf5Data(ncT, 'LAI_PFT'),1,sum,na.rm=TRUE),nrow=block) out <-
+        ## add(lai,34,row, yrs[y]) ## LAI****************** out <- add(getHdf5Data(ncT,
+        ## 'FMEAN_LAI_PY'),34,row, yrs[y]) ## LAI - no longer using FMEAN LAI
+        
+        ## OLD - to be deprecated laidata <- getHdf5Data(ncT,'LAI_PY') if(length(dim(laidata)) == 3){ out
+        ## <- add(apply(laidata,3,sum),34,row,yrs[y]) } else { out <- add(-999,34,row, yrs[y]) }
+        
+        # code changes proposed by MCD, tested by SPS 20160607
+        laidata <- getHdf5Data(ncT, "LAI_PY")
+        if (length(dim(laidata)) == 3) {
+          laidata <- apply(laidata, 3, sum)
+          out <- add(array(laidata, dim = length(laidata)), 34, row, yrs[y])
+        } else {
+          out <- add(-999, 34, row, yrs[y])
+        }
+        
+        ## z <- getHdf5Data(ncT, 'SLZ') if(z[length(z)] < 0.0) z <- c(z,0.0) dz <- diff(z) dz <- dz[dz !=
+        ## 0.0] fliq <- sum(getHdf5Data(ncT, 'AVG_SOIL_FRACLIQ')*dz)/-min(z)
+        fliq <- NA  #getHdf5Data(ncT, 'FMEAN_SFCW_FLIQ_PY')
+        out <- add(1 - fliq, 35, row, yrs[y])  ## SMFrozFrac
+        out <- add(fliq, 36, row, yrs[y])  ## SMLiqFrac
+        ## This needs to be soil wetness, i.e. multilple levels deep
+        out <- add(getHdf5Data(ncT, "FMEAN_SOIL_WATER_PY"), 37, row, yrs[y])  ## SoilWater  **********
+        ## out <- add(sum(soiltemp*dz)/-min(z),38) ## SoilTemp
+        out <- add(soiltemp, 38, row, yrs[y])  ## SoilTemp
+        out <- add(-999, 39, row, yrs[y])  ## SoilWet
+        out <- add(getHdf5Data(ncT, "FMEAN_ALBEDO_PY"), 40, row, yrs[y])  ## Albedo
+        out <- add(getHdf5Data(ncT, "FMEAN_SFCW_TEMP_PY"), 41, row, yrs[y])  ## SnowT (ED2 currently groups snow in to surface water)
+        out <- add(getHdf5Data(ncT, "FMEAN_SFCW_MASS_PY"), 42, row, yrs[y])  ## SWE (ED2 currently groups snow in to surface water)
+        out <- add(getHdf5Data(ncT, "FMEAN_LEAF_TEMP_PY"), 43, row, yrs[y])  ## VegT
+        out <- add(getHdf5Data(ncT, "FMEAN_VAPOR_LC_PY") + getHdf5Data(ncT, "FMEAN_VAPOR_WC_PY") + 
+                     getHdf5Data(ncT, "FMEAN_VAPOR_GC_PY") + getHdf5Data(ncT, "FMEAN_TRANSP_PY"), 44, 
+                   row, yrs[y])  ## Evap
+        out <- add(getHdf5Data(ncT, "FMEAN_QRUNOFF_PY"), 45, row, yrs[y])  ## Qs
+        out <- add(getHdf5Data(ncT, "BASEFLOW"), 46, row, yrs[y])  ## Qsb
       } else {
-                                        # no polygons, just time vs depth?
-        fdepth <- array(0, ncol(soiltemp))
-        tdepth <- array(0, ncol(soiltemp))
-        for(t in 1:ncol(soiltemp)){ #time
-          for(d in 2:nrow(soiltemp)){ #depth
-            if(fdepth[t] == 0 & soiltemp[d,t] < 273.15 & soiltemp[d-1,t] > 273.13){
-              fdepth[t] <- d
-            }
-            if(tdepth[t] == 0 & soiltemp[d,t] > 273.15 & soiltemp[d-1,t] < 273.13){
-              tdepth[t] <- d
+        ## out <- add(getHdf5Data(ncT, 'TOTAL_AGB,1,row, yrs[y]) ## AbvGrndWood
+        out <- add(getHdf5Data(ncT, "AVG_BDEAD"), 1, row, yrs[y])  ## AbvGrndWood
+        out <- add(getHdf5Data(ncT, "AVG_PLANT_RESP"), 2, row, yrs[y])  ## AutoResp
+        out <- add(-999, 3, row, yrs[y])  ## CarbPools
+        out <- add(getHdf5Data(ncT, "AVG_CO2CAN"), 4, row, yrs[y])  ## CO2CAS
+        out <- add(-999, 5, row, yrs[y])  ## CropYield
+        out <- add(getHdf5Data(ncT, "AVG_GPP"), 6, row, yrs[y])  ## GPP
+        out <- add(getHdf5Data(ncT, "AVG_HTROPH_RESP"), 7, row, yrs[y])  ## HeteroResp
+        out <- add(getHdf5Data(ncT, "AVG_GPP") - getHdf5Data(ncT, "AVG_PLANT_RESP") - getHdf5Data(ncT, 
+                                                                                                  "AVG_HTROPH_RESP"), 8, row, yrs[y])  ## NEE
+        out <- add(getHdf5Data(ncT, "AVG_GPP") - getHdf5Data(ncT, "AVG_PLANT_RESP"), 9, row, 
+                   yrs[y])  ## NPP
+        out <- add(getHdf5Data(ncT, "AVG_HTROPH_RESP") + getHdf5Data(ncT, "AVG_PLANT_RESP"), 
+                   10, row, yrs[y])  ## TotalResp
+        ## out <- add(getHdf5Data(ncT, 'AVG_BDEAD + getHdf5Data(ncT, 'AVG_BALIVE,11,row, yrs[y]) ##
+        ## TotLivBiom
+        out <- add(-999, 11, row, yrs[y])  ## TotLivBiom
+        out <- add(getHdf5Data(ncT, "AVG_FSC") + getHdf5Data(ncT, "AVG_STSC") + 
+                     getHdf5Data(ncT, "AVG_SSC"), 12, row, yrs[y])  ## TotSoilCarb
+        ## depth from surface to frozen layer
+        tdepth <- 0
+        fdepth <- 0
+        soiltemp <- getHdf5Data(ncT, "AVG_SOIL_TEMP")
+        if (length(dim(soiltemp)) == 3) {
+          fdepth <- array(0, dim = dim(soiltemp)[1:2])
+          tdepth <- array(0, dim = dim(soiltemp)[1:2])
+          for (t in 1:dim(soiltemp)[1]) {
+            # time polygon depth
+            for (p in 1:dim(soiltemp)[2]) {
+              for (i in dim(soiltemp)[3]:2) {
+                if (fdepth[t, p] == 0 & soiltemp[t, p, i] < 273.15 & 
+                    soiltemp[t, p, i - 1] > 273.13) {
+                  fdepth[t, p] <- i
+                }
+                if (tdepth[t, p] == 0 & soiltemp[t, p, i] > 273.15 & 
+                    soiltemp[t, p, i - 1] < 273.13) {
+                  tdepth[t, p] <- i
+                }
+              }
+              SLZ <- c(slzdata[t, ], 0)
+              z1 <- (SLZ[fdepth[t, p] + 1] + SLZ[fdepth[t, p]]) / 2
+              z2 <- (SLZ[fdepth[t, p]] + SLZ[fdepth[t, p] - 1]) / 2
+              if (fdepth[t, p] > 0) {
+                fdepth[t, p] <- z1 + (z2 - z1) * (273.15 - soiltemp[t, p, fdepth[t, p]]) / 
+                  (soiltemp[t, p, fdepth[t, p] - 1] - soiltemp[t, p, fdepth[t, p]])
+              }
+              if (tdepth[t, p] > 0) {
+                SLZ <- c(slzdata[t, ], 0)
+                z1 <- (SLZ[tdepth[t, p] + 1] + SLZ[tdepth[t, p]]) / 2
+                z2 <- (SLZ[tdepth[t, p]] + SLZ[tdepth[t, p] - 1]) / 2
+                tdepth[t, p] <- z1 + (z2 - z1) * (273.15 - soiltemp[t, p, tdepth[t, p]]) / 
+                  (soiltemp[t, p, tdepth[t, p] - 1] - soiltemp[t, p, tdepth[t, p]])
+              }
             }
           }
-          if(fdepth[t] > 0) {
-            SLZ <- c(slzdata,0.0)
-            z1 <- (SLZ[fdepth[t]+1]+SLZ[fdepth[t]])/2
-            z2 <- (SLZ[fdepth[t]]+SLZ[fdepth[t]-1])/2
-            fdepth[t] <- z1 + (z2-z1) * (273.15 - soiltemp[fdepth[t], t]) / (soiltemp[fdepth[t] - 1, t] - soiltemp[fdepth[t], t])
-          }
-          if(tdepth[t] > 0) {
-            SLZ <- c(slzdata,0.0)
-            z1 <- (SLZ[tdepth[t]+1]+SLZ[tdepth[t]])/2
-            z2 <- (SLZ[tdepth[t]]+SLZ[tdepth[t]-1])/2
-            tdepth[t] <- z1 + (z2-z1) * (273.15 - soiltemp[tdepth[t], t]) / (soiltemp[tdepth[t] - 1, t] - soiltemp[tdepth[t], t])
+        } else {
+          # no polygons, just time vs depth?
+          fdepth <- array(0, ncol(soiltemp))
+          tdepth <- array(0, ncol(soiltemp))
+          for (t in seq_along(soiltemp)) {
+            # time depth
+            for (d in 2:nrow(soiltemp)) {
+              if (fdepth[t] == 0 & soiltemp[d, t] < 273.15 & soiltemp[d - 1, t] > 273.13) {
+                fdepth[t] <- d
+              }
+              if (tdepth[t] == 0 & soiltemp[d, t] > 273.15 & soiltemp[d - 1, t] < 273.13) {
+                tdepth[t] <- d
+              }
+            }
+            if (fdepth[t] > 0) {
+              SLZ <- c(slzdata, 0)
+              z1 <- (SLZ[fdepth[t] + 1] + SLZ[fdepth[t]]) / 2
+              z2 <- (SLZ[fdepth[t]] + SLZ[fdepth[t] - 1]) / 2
+              fdepth[t] <- z1 + (z2 - z1) * (273.15 - soiltemp[fdepth[t], t]) / 
+                (soiltemp[fdepth[t] - 1, t] - soiltemp[fdepth[t], t])
+            }
+            if (tdepth[t] > 0) {
+              SLZ <- c(slzdata, 0)
+              z1 <- (SLZ[tdepth[t] + 1] + SLZ[tdepth[t]]) / 2
+              z2 <- (SLZ[tdepth[t]] + SLZ[tdepth[t] - 1]) / 2
+              tdepth[t] <- z1 + (z2 - z1) * (273.15 - soiltemp[tdepth[t], t]) / 
+                (soiltemp[tdepth[t] - 1, t] - soiltemp[tdepth[t], t])
+            }
           }
         }
+        
+        out <- add(fdepth, 13, row, yrs[y])  ## Fdepth
+        out <- add(getHdf5Data(ncT, "AVG_SNOWDEPTH"), 14, row, yrs[y])  ## SnowDepth
+        out <- add(1 - getHdf5Data(ncT, "AVG_SNOWFRACLIQ"), 15, row, yrs[y])  ## SnowFrac
+        out <- add(tdepth, 16, row, yrs[y])  ## Tdepth
+        out <- add(getHdf5Data(ncT, "AVG_ATM_CO2"), 17, row, yrs[y])  ## CO2air
+        out <- add(getHdf5Data(ncT, "AVG_RLONG"), 18, row, yrs[y])  ## Lwdown
+        out <- add(getHdf5Data(ncT, "AVG_PRSS"), 19, row, yrs[y])  ## Psurf
+        out <- add(getHdf5Data(ncT, "AVG_ATM_SHV"), 20, row, yrs[y])  ## Qair
+        out <- add(getHdf5Data(ncT, "AVG_PCPG"), 21, row, yrs[y])  ## Rainf
+        ## out <- add(getHdf5Data(ncT, 'AVG_NIR_BEAM') + getHdf5Data(ncT, 'AVG_NIR_DIFFUSE')+
+        ## getHdf5Data(ncT, 'AVG_PAR_BEAM')+ getHdf5Data(ncT, 'AVG_PAR_DIFFUSE'),22,row, yrs[y]) ## Swdown
+        out <- add(getHdf5Data(ncT, "AVG_PAR_BEAM") + getHdf5Data(ncT, "AVG_PAR_DIFFUSE"), 
+                   22, row, yrs[y])  ## Swdown
+        out <- add(getHdf5Data(ncT, "AVG_ATM_TMP"), 23, row, yrs[y])  ## Tair
+        out <- add(getHdf5Data(ncT, "AVG_VELS"), 24, row, yrs[y])  ## Wind
+        ## out <- add(getHdf5Data(ncT, 'AVG_RLONG')-getHdf5Data(ncT, 'AVG_RLONGUP'),25,row, yrs[y]) ##
+        ## Lwnet
+        out <- add(-999, 25, row, yrs[y])  ## Lwnet
+        ## out <- add(getHdf5Data(ncT, 'AVG_SENSIBLE_GC') + getHdf5Data(ncT,
+        ## 'AVG_VAPOR_GC')*2272000,26,row, yrs[y]) ## Qg
+        out <- add(-999, 26, row, yrs[y])  ## Qg
+        ## out <- add(getHdf5Data(ncT, 'AVG_SENSIBLE_TOT'),27,row, yrs[y]) ## Qh
+        out <- add(getHdf5Data(ncT, "AVG_SENSIBLE_AC"), 27, row, yrs[y])  ## Qh
+        out <- add(getHdf5Data(ncT, "AVG_EVAP"), 28, row, yrs[y])  ## Qle
+        out <- add(-999, 29, row, yrs[y])  ## Swnet
+        out <- add(-999, 30, row, yrs[y])  ## RootMoist
+        out <- add(getHdf5Data(ncT, "AVG_TRANSP"), 31, row, yrs[y])  ## Tveg
+        out <- add(getHdf5Data(ncT, "ZBAR"), 32, row, yrs[y])  ## WaterTableD
+        out <- add(-999, 33, row, yrs[y])  ## fPAR
+        ## lai <- matrix(apply(getHdf5Data(ncT, 'LAI_PFT'),1,sum,na.rm=TRUE),nrow=block) out <-
+        ## add(lai,34,row, yrs[y]) ## LAI******************
+        out <- add(getHdf5Data(ncT, "LAI"), 34, row, yrs[y])  ## LAI
+        ## z <- getHdf5Data(ncT, 'SLZ') if(z[length(z)] < 0.0) z <- c(z,0.0) dz <- diff(z) dz <- dz[dz !=
+        ## 0.0] fliq <- sum(getHdf5Data(ncT, 'AVG_SOIL_FRACLIQ')*dz)/-min(z)
+        fliq <- NA  #getHdf5Data(ncT, 'AVG_SOIL_FRACLIQ')
+        out <- add(1 - fliq, 35, row, yrs[y])  ## SMFrozFrac
+        out <- add(fliq, 36, row, yrs[y])  ## SMLiqFrac
+        ## This needs to be soil wetness, i.e. multilple levels deep
+        out <- add(getHdf5Data(ncT, "AVG_SOIL_WATER"), 37, row, yrs[y])  ## SoilWater  **********
+        ## out <- add(sum(soiltemp*dz)/-min(z),38) ## SoilTemp
+        out <- add(soiltemp, 38, row, yrs[y])  ## SoilTemp
+        out <- add(-999, 39, row, yrs[y])  ## SoilWet
+        out <- add(getHdf5Data(ncT, "AVG_ALBEDO"), 40, row, yrs[y])  ## Albedo
+        out <- add(getHdf5Data(ncT, "AVG_SNOWTEMP"), 41, row, yrs[y])  ## SnowT
+        out <- add(getHdf5Data(ncT, "AVG_SNOWMASS"), 42, row, yrs[y])  ## SWE
+        out <- add(getHdf5Data(ncT, "AVG_VEG_TEMP"), 43, row, yrs[y])  ## VegT
+        out <- add(getHdf5Data(ncT, "AVG_EVAP") + getHdf5Data(ncT, "AVG_TRANSP"), 44, row, 
+                   yrs[y])  ## Evap
+        out <- add(getHdf5Data(ncT, "AVG_RUNOFF"), 45, row, yrs[y])  ## Qs
+        out <- add(getHdf5Data(ncT, "BASEFLOW"), 46, row, yrs[y])  ## Qsb      
       }
       
-      out <- add(fdepth,13,row, yrs[y]) ## Fdepth
-      out <- add(getHdf5Data(ncT, 'AVG_SNOWDEPTH'),14,row, yrs[y]) ## SnowDepth
-      out <- add(1-getHdf5Data(ncT, 'AVG_SNOWFRACLIQ'),15,row, yrs[y]) ## SnowFrac
-      out <- add(tdepth,16,row, yrs[y]) ## Tdepth
-      out <- add(getHdf5Data(ncT, 'AVG_ATM_CO2'),17,row, yrs[y]) ## CO2air
-      out <- add(getHdf5Data(ncT, 'AVG_RLONG'),18,row, yrs[y]) ## Lwdown
-      out <- add(getHdf5Data(ncT, 'AVG_PRSS'),19,row, yrs[y]) ## Psurf
-      out <- add(getHdf5Data(ncT, 'AVG_ATM_SHV'),20,row, yrs[y]) ## Qair
-      out <- add(getHdf5Data(ncT, 'AVG_PCPG'),21,row, yrs[y]) ## Rainf
-      ##out <- add(getHdf5Data(ncT, 'AVG_NIR_BEAM') +
-      ##           getHdf5Data(ncT, 'AVG_NIR_DIFFUSE')+
-      ##           getHdf5Data(ncT, 'AVG_PAR_BEAM')+
-      ##           getHdf5Data(ncT, 'AVG_PAR_DIFFUSE'),22,row, yrs[y]) ## Swdown
-      out <- add(getHdf5Data(ncT, 'AVG_PAR_BEAM')+
-                 getHdf5Data(ncT, 'AVG_PAR_DIFFUSE'),22,row, yrs[y]) ## Swdown
-      out <- add(getHdf5Data(ncT, 'AVG_ATM_TMP'),23,row, yrs[y]) ## Tair
-      out <- add(getHdf5Data(ncT, 'AVG_VELS'),24,row, yrs[y]) ## Wind
-      ##out <- add(getHdf5Data(ncT, 'AVG_RLONG')-getHdf5Data(ncT, 'AVG_RLONGUP'),25,row, yrs[y]) ## Lwnet
-      out <- add(-999,25,row, yrs[y]) ## Lwnet
-      ##out <- add(getHdf5Data(ncT, 'AVG_SENSIBLE_GC') + getHdf5Data(ncT, 'AVG_VAPOR_GC')*2272000,26,row, yrs[y]) ## Qg
-      out <- add(-999,26,row, yrs[y]) ## Qg
-      ##out <- add(getHdf5Data(ncT, 'AVG_SENSIBLE_TOT'),27,row, yrs[y]) ## Qh
-      out <- add(getHdf5Data(ncT, 'AVG_SENSIBLE_AC'),27,row, yrs[y]) ## Qh
-      out <- add(getHdf5Data(ncT, 'AVG_EVAP'),28,row, yrs[y]) ## Qle
-      out <- add(-999,29,row, yrs[y]) ## Swnet
-      out <- add(-999,30,row, yrs[y]) ## RootMoist
-      out <- add(getHdf5Data(ncT, 'AVG_TRANSP'),31,row, yrs[y]) ## Tveg
-      out <- add(getHdf5Data(ncT, 'ZBAR'),32,row, yrs[y]) ## WaterTableD
-      out <- add(-999,33,row, yrs[y]) ## fPAR
-      ##lai <- matrix(apply(getHdf5Data(ncT, 'LAI_PFT'),1,sum,na.rm=TRUE),nrow=block)
-      ## out <- add(lai,34,row, yrs[y]) ## LAI******************
-      out <- add(getHdf5Data(ncT, 'LAI'),34,row, yrs[y]) ## LAI
-      ##z <- getHdf5Data(ncT, 'SLZ')
-      ##if(z[length(z)] < 0.0) z <- c(z,0.0)
-      ##dz <- diff(z)
-      ##dz <- dz[dz != 0.0]
-      ##fliq <- sum(getHdf5Data(ncT, 'AVG_SOIL_FRACLIQ')*dz)/-min(z)
-      fliq <- NA#getHdf5Data(ncT, 'AVG_SOIL_FRACLIQ')
-      out <- add(1-fliq,35,row, yrs[y]) ## SMFrozFrac
-      out <- add(fliq,36,row, yrs[y]) ## SMLiqFrac
-      ## This needs to be soil wetness, i.e. multilple levels deep
-      out <- add(getHdf5Data(ncT, 'AVG_SOIL_WATER'),37,row, yrs[y]) ## SoilWater  **********
-      ##out <- add(sum(soiltemp*dz)/-min(z),38) ## SoilTemp
-      out <- add(soiltemp,38,row, yrs[y]) ## SoilTemp
-      out <- add(-999,39,row, yrs[y]) ## SoilWet
-      out <- add(getHdf5Data(ncT, 'AVG_ALBEDO'),40,row, yrs[y]) ## Albedo
-      out <- add(getHdf5Data(ncT, 'AVG_SNOWTEMP'),41,row, yrs[y]) ## SnowT
-      out <- add(getHdf5Data(ncT, 'AVG_SNOWMASS'),42,row, yrs[y]) ## SWE
-      out <- add(getHdf5Data(ncT, 'AVG_VEG_TEMP'),43,row, yrs[y]) ## VegT
-      out <- add(getHdf5Data(ncT, 'AVG_EVAP')+getHdf5Data(ncT, 'AVG_TRANSP'),44,row, yrs[y]) ## Evap
-      out <- add(getHdf5Data(ncT, 'AVG_RUNOFF'),45,row, yrs[y]) ## Qs
-      out <- add(getHdf5Data(ncT, 'BASEFLOW'),46,row, yrs[y]) ## Qsb      
-      }
-
       nc_close(ncT)
       ## prevTime <- progressBar(i/n,prevTime)
       row <- row + block
-
+      
     }  ## end file loop 
     
-                                        #out[[10]] <- out[[10]]*1.2e-8  
-    ## TODO see bug #1174
-    ## for(t in 1:dim(out[[37]])[1]){
-    ##  for(p in 1:dim(out[[37]])[2]){
-    ##    out[[37]][t,p,] <- out[[37]][t,p,]*1000*dz ## m/m -> kg/m2
-    ##  }
-    ##}
+    # out[[10]] <- out[[10]]*1.2e-8 TODO see bug #1174 for(t in 1:dim(out[[37]])[1]){ for(p in
+    # 1:dim(out[[37]])[2]){ out[[37]][t,p,] <- out[[37]][t,p,]*1000*dz ## m/m -> kg/m2 } }
     
     ## declare variables
-
+    
     ## figure out what start day is, if not same year as start_date then it is 1
     if (yrs[y] == strftime(start_date, "%Y")) {
       start <- (as.numeric(strftime(start_date, "%j")) - 1) * block
@@ -488,40 +492,34 @@ model2netcdf.ED2 <- function(outdir, sitelat, sitelon, start_date, end_date) {
     } else {
       end <- (as.numeric(strftime(paste0(yrs[y], "-12-31"), "%j"))) * block - 1
     }
-
-    t <- ncdim_def(name = "time",
-                   units = paste0("days since ", yrs[y], "-01-01 00:00:00"),
-                   vals = start:end / block,
+    
+    t <- ncdim_def(name = "time", units = paste0("days since ", yrs[y], "-01-01 00:00:00"), vals = start:end/block, 
                    calendar = "standard", unlim = TRUE)
-    lat <- ncdim_def("lat", "degrees_east",
-                     vals =  as.numeric(sitelat),
-                     longname = "station_latitude") 
-    lon <- ncdim_def("lon", "degrees_north",
-                     vals = as.numeric(sitelon),
-                     longname = "station_longitude")
-
-    zg <- ncdim_def("SoilLayerMidpoint", "meters", c(slzdata[1:length(dz)] + dz / 2, 0))
+    lat <- ncdim_def("lat", "degrees_east", vals = as.numeric(sitelat), longname = "station_latitude")
+    lon <- ncdim_def("lon", "degrees_north", vals = as.numeric(sitelon), longname = "station_longitude")
+    
+    zg <- ncdim_def("SoilLayerMidpoint", "meters", c(slzdata[1:length(dz)] + dz/2, 0))
     
     ## Conversion factor for umol C -> kg C
-    Mc <- 12.017 #molar mass of C, g/mol
+    Mc <- 12.017  #molar mass of C, g/mol
     umol2kg_C <- Mc * ud.convert(1, "umol", "mol") * ud.convert(1, "g", "kg")
-
+    
     var <- list()
-    out <- conversion( 1, ud.convert(1, "t ha-1", "kg m-2"))     ## tC/ha     -> kg/m2
-    var[[1]]  <- mstmipvar("AbvGrndWood", lat, lon, t, zg)
-    out <- conversion( 2, umol2kg_C)  ## umol/m2 s-1 -> kg/m2 s-1
-    var[[2]]  <- mstmipvar("AutoResp", lat, lon, t, zg)
-    var[[3]]  <- mstmipvar("CarbPools", lat, lon, t, zg)
-    var[[4]]  <- mstmipvar("CO2CAS", lat, lon, t, zg)
-    var[[5]]  <- mstmipvar("CropYield", lat, lon, t, zg)
-    out <- conversion( 6, umol2kg_C)  ## umol/m2 s-1 -> kg m-2 s-1
-    var[[6]]  <- mstmipvar("GPP", lat, lon, t, zg)
-    out <- conversion( 7, umol2kg_C)  ## umol/m2 s-1 -> kg m-2 s-1
-    var[[7]]  <- mstmipvar("HeteroResp", lat, lon, t, zg)
-    out <- conversion( 8, umol2kg_C)  ## umol/m2 s-1 -> kg m-2 s-1
-    var[[8]]  <- mstmipvar("NEE", lat, lon, t, zg)
-    out <- conversion( 9, umol2kg_C)  ## umol/m2 s-1 -> kg m-2 s-1
-    var[[9]]  <- mstmipvar("NPP", lat, lon, t, zg)
+    out <- conversion(1, ud.convert(1, "t ha-1", "kg m-2"))  ## tC/ha -> kg/m2
+    var[[1]] <- mstmipvar("AbvGrndWood", lat, lon, t, zg)
+    out <- conversion(2, umol2kg_C)  ## umol/m2 s-1 -> kg/m2 s-1
+    var[[2]] <- mstmipvar("AutoResp", lat, lon, t, zg)
+    var[[3]] <- mstmipvar("CarbPools", lat, lon, t, zg)
+    var[[4]] <- mstmipvar("CO2CAS", lat, lon, t, zg)
+    var[[5]] <- mstmipvar("CropYield", lat, lon, t, zg)
+    out <- conversion(6, umol2kg_C)  ## umol/m2 s-1 -> kg m-2 s-1
+    var[[6]] <- mstmipvar("GPP", lat, lon, t, zg)
+    out <- conversion(7, umol2kg_C)  ## umol/m2 s-1 -> kg m-2 s-1
+    var[[7]] <- mstmipvar("HeteroResp", lat, lon, t, zg)
+    out <- conversion(8, umol2kg_C)  ## umol/m2 s-1 -> kg m-2 s-1
+    var[[8]] <- mstmipvar("NEE", lat, lon, t, zg)
+    out <- conversion(9, umol2kg_C)  ## umol/m2 s-1 -> kg m-2 s-1
+    var[[9]] <- mstmipvar("NPP", lat, lon, t, zg)
     out <- conversion(10, umol2kg_C)  ## umol/m2 s-1 -> kg m-2 s-1
     var[[10]] <- mstmipvar("TotalResp", lat, lon, t, zg)
     var[[11]] <- mstmipvar("TotLivBiom", lat, lon, t, zg)
@@ -549,8 +547,8 @@ model2netcdf.ED2 <- function(outdir, sitelat, sitelon, start_date, end_date) {
     var[[32]] <- mstmipvar("WaterTableD", lat, lon, t, zg)
     var[[33]] <- mstmipvar("fPAR", lat, lon, t, zg)
     var[[34]] <- mstmipvar("LAI", lat, lon, t, zg)
-    ##var[[35]] <- mstmipvar("SMFrozFrac", lat, lon, t, zg)
-    ##var[[36]] <- mstmipvar("SMLiqFrac", lat, lon, t, zg)
+    ## var[[35]] <- mstmipvar('SMFrozFrac', lat, lon, t, zg) var[[36]] <- mstmipvar('SMLiqFrac', lat,
+    ## lon, t, zg)
     var[[35]] <- mstmipvar("SMFrozFrac", lat, lon, t, zg)
     var[[36]] <- mstmipvar("SMLiqFrac", lat, lon, t, zg)
     var[[37]] <- mstmipvar("SoilMoist", lat, lon, t, zg)
@@ -566,21 +564,16 @@ model2netcdf.ED2 <- function(outdir, sitelat, sitelon, start_date, end_date) {
     var[[44]] <- mstmipvar("Evap", lat, lon, t, zg)
     var[[45]] <- mstmipvar("Qs", lat, lon, t, zg)
     var[[46]] <- mstmipvar("Qsb", lat, lon, t, zg)
-
-
+    
     ## write ALMA
-    nc <- nc_create(file.path(outdir, paste(yrs[y], "nc", sep=".")), var)
-    varfile <- file(file.path(outdir, paste(yrs[y], "nc", "var", sep=".")), "w")
-    for(i in 1:length(var)) {
-      ncvar_put(nc,var[[i]],out[[i]])
-      cat(paste(var[[i]]$name, var[[i]]$longname), file=varfile, sep="\n")
+    nc <- nc_create(file.path(outdir, paste(yrs[y], "nc", sep = ".")), var)
+    varfile <- file(file.path(outdir, paste(yrs[y], "nc", "var", sep = ".")), "w")
+    for (i in seq_along(var)) {
+      ncvar_put(nc, var[[i]], out[[i]])
+      cat(paste(var[[i]]$name, var[[i]]$longname), file = varfile, sep = "\n")
     }
     close(varfile)
     nc_close(nc)
   }  ## end year loop
-}  ## end model2netcdf.ED2
-##==================================================================================================#
-
-####################################################################################################
-### EOF.  End of R script file.              
-####################################################################################################
+}  # model2netcdf.ED2
+## ==================================================================================================#

--- a/models/ed/R/parse.history.R
+++ b/models/ed/R/parse.history.R
@@ -1,13 +1,14 @@
 #-------------------------------------------------------------------------------
 # Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
+# All rights reserved. This program and the accompanying materials 
+# are made available under the terms of the
 # University of Illinois/NCSA Open Source License
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-require(XML)
-require(stringr)
+
+library(XML)
+library(stringr)
 
 ##' This will generate the CSV file needed by write configs to write the
 ##' config.xml. This is a hack right now, all this information should be
@@ -21,13 +22,12 @@ require(stringr)
 ##' @export
 ##'
 ##' @author Rob Kooper
-parse.history <- function(historyfile, outfile="") {
-	hist <- xmlToList(xmlParse(historyfile))
-	keys <- names(hist$pft)
-	
-	cat(paste(keys, collapse = ";"), sep="\n", file=outfile, append=FALSE)
-	for(pft in hist) {
-		cat(paste(lapply(pft[keys], str_trim), collapse = ";"), sep="\n", file=outfile, append=TRUE)
-	}
-}
-
+parse.history <- function(historyfile, outfile = "") {
+    hist <- xmlToList(xmlParse(historyfile))
+    keys <- names(hist$pft)
+    
+    cat(paste(keys, collapse = ";"), sep = "\n", file = outfile, append = FALSE)
+    for (pft in hist) {
+        cat(paste(lapply(pft[keys], str_trim), collapse = ";"), sep = "\n", file = outfile, append = TRUE)
+    }
+} # parse.history

--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -1,18 +1,18 @@
-##------------------------------------------------------------------------------
-##Copyright (c) 2012 University of Illinois, NCSA.
-##All rights reserved. This program and the accompanying materials
-##are made available under the terms of the 
-##University of Illinois/NCSA Open Source License
-##which accompanies this distribution, and is available at
-##http://opensource.ncsa.illinois.edu/license.html
-##------------------------------------------------------------------------------
-##-------------------------------------------------------------------------------------------------#
-##Functions to prepare and write out ED2.2 config.xml files for MA, SA, and Ensemble runs
-##-------------------------------------------------------------------------------------------------#
-
+#-------------------------------------------------------------------------------
+# Copyright (c) 2012 University of Illinois, NCSA.
+# All rights reserved. This program and the accompanying materials 
+# are made available under the terms of the
+# University of Illinois/NCSA Open Source License
+# which accompanies this distribution, and is available at
+# http://opensource.ncsa.illinois.edu/license.html
+#-------------------------------------------------------------------------------
 
 ##-------------------------------------------------------------------------------------------------#
-PREFIX_XML <- '<?xml version="1.0"?>\n<!DOCTYPE config SYSTEM "ed.dtd">\n'
+## Functions to prepare and write out ED2.2 config.xml files for MA, SA, and Ensemble runs
+##-------------------------------------------------------------------------------------------------#
+
+##-------------------------------------------------------------------------------------------------#
+PREFIX_XML <- "<?xml version=\"1.0\"?>\n<!DOCTYPE config SYSTEM \"ed.dtd\">\n"
 
 ## TODO: Update this script file to use the database for setting up ED2IN and config files
 ##-------------------------------------------------------------------------------------------------#
@@ -27,57 +27,56 @@ PREFIX_XML <- '<?xml version="1.0"?>\n<!DOCTYPE config SYSTEM "ed.dtd">\n'
 ##' @param trait.samples a matrix or dataframe of samples from the trait distribution
 ##' @return matrix or dataframe with values transformed
 ##' @author Shawn Serbin, David LeBauer, Carl Davidson, Ryan Kelly
-convert.samples.ED <- function(trait.samples){
+convert.samples.ED <- function(trait.samples) {
   DEFAULT.LEAF.C <- 0.48
-  DEFAULT.MAINTENANCE.RESPIRATION <- 1/2
-  ## convert SLA from m2 / kg leaf to m2 / kg C 
+  DEFAULT.MAINTENANCE.RESPIRATION <- 1 / 2
+  ## convert SLA from m2 / kg leaf to m2 / kg C
   
-  if('SLA' %in% names(trait.samples)){
-    sla <- as.numeric(trait.samples[['SLA']])
-    trait.samples[['SLA']] <- sla / DEFAULT.LEAF.C
+  if ("SLA" %in% names(trait.samples)) {
+    sla <- as.numeric(trait.samples[["SLA"]])
+    trait.samples[["SLA"]] <- sla/DEFAULT.LEAF.C
   }
   
   ## convert leaf width / 1000
-  if('leaf_width' %in% names(trait.samples)){
-    lw <- as.numeric(trait.samples[['leaf_width']])
-    trait.samples[['leaf_width']] <- lw / 1000.0
+  if ("leaf_width" %in% names(trait.samples)) {
+    lw <- as.numeric(trait.samples[["leaf_width"]])
+    trait.samples[["leaf_width"]] <- lw / 1000
   }
   
-  if('root_respiration_rate' %in% names(trait.samples)) {
-    rrr1 <- as.numeric(trait.samples[['root_respiration_rate']])
-    rrr2 <-  rrr1 * DEFAULT.MAINTENANCE.RESPIRATION
-    trait.samples[['root_respiration_rate']] <- arrhenius.scaling(rrr2, old.temp = 25, 
-                                                                  new.temp = 15)
+  if ("root_respiration_rate" %in% names(trait.samples)) {
+    rrr1 <- as.numeric(trait.samples[["root_respiration_rate"]])
+    rrr2 <- rrr1 * DEFAULT.MAINTENANCE.RESPIRATION
+    trait.samples[["root_respiration_rate"]] <- arrhenius.scaling(rrr2, old.temp = 25, new.temp = 15)
   }
   
-  if('Vcmax' %in% names(trait.samples)) {
-    vcmax <- as.numeric(trait.samples[['Vcmax']])
-    trait.samples[['Vcmax']] <- arrhenius.scaling(vcmax, old.temp = 25, new.temp = 15)
+  if ("Vcmax" %in% names(trait.samples)) {
+    vcmax <- as.numeric(trait.samples[["Vcmax"]])
+    trait.samples[["Vcmax"]] <- arrhenius.scaling(vcmax, old.temp = 25, new.temp = 15)
     
     ## Convert leaf_respiration_rate_m2 to dark_resp_factor; requires Vcmax
-    if('leaf_respiration_rate_m2' %in% names(trait.samples)) {
-      leaf_resp = as.numeric(trait.samples[['leaf_respiration_rate_m2']])
+    if ("leaf_respiration_rate_m2" %in% names(trait.samples)) {
+      leaf_resp <- as.numeric(trait.samples[["leaf_respiration_rate_m2"]])
       
       ## First scale variables to 15 degC
-      trait.samples[['leaf_respiration_rate_m2']] <- 
+      trait.samples[["leaf_respiration_rate_m2"]] <- 
         arrhenius.scaling(leaf_resp, old.temp = 25, new.temp = 15)
       
       ## Calculate dark_resp_factor -- Will be depreciated when moving from older versions of ED2
-      trait.samples[['dark_respiration_factor']] <- trait.samples[['leaf_respiration_rate_m2']]/
-        trait.samples[['Vcmax']]
+      trait.samples[["dark_respiration_factor"]] <- 
+        trait.samples[["leaf_respiration_rate_m2"]] / trait.samples[["Vcmax"]]
       
       ## Remove leaf_respiration_rate from trait samples
-      trait.samples$leaf_respiration_rate_m2 = NULL # !!!WHY DO WE DO THIS??!!!
+      trait.samples$leaf_respiration_rate_m2 <- NULL  # !!!WHY DO WE DO THIS??!!!
       
-    } ## End dark_respiration_factor loop
-  } ## End Vcmax  
-  # for debugging conversions
-  #save(trait.samples, file = file.path(settings$outdir, 'trait.samples.Rdata'))
+    }  ## End dark_respiration_factor loop
+  }  ## End Vcmax  
+  # for debugging conversions save(trait.samples, file = file.path(settings$outdir,
+  # 'trait.samples.Rdata'))
   
   # return converted samples
   return(trait.samples)
 }
-#==================================================================================================#
+# ==================================================================================================#
 
 
 ##-------------------------------------------------------------------------------------------------#
@@ -95,21 +94,18 @@ convert.samples.ED <- function(trait.samples){
 ##' @export
 ##' @author David LeBauer, Shawn Serbin, Carl Davidson, Alexey Shiklomanov
 ##-------------------------------------------------------------------------------------------------#
-write.config.ED2 <- function(trait.values, settings, run.id, defaults=settings$constants){
+write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings$constants) {
   
   
-  jobsh <- write.config.jobsh.ED2(settings = settings,
-                                  run.id = run.id)
-
-  writeLines(jobsh, con=file.path(settings$rundir, run.id, "job.sh"))
+  jobsh <- write.config.jobsh.ED2(settings = settings, run.id = run.id)
+  
+  writeLines(jobsh, con = file.path(settings$rundir, run.id, "job.sh"))
   Sys.chmod(file.path(settings$rundir, run.id, "job.sh"))
-
+  
   ## Write ED2 config.xml file
-  xml <- write.config.xml.ED2(defaults = defaults,
-                              settings = settings,
-                              trait.values = trait.values)
-
-  saveXML(xml, file = file.path(settings$rundir, run.id, "config.xml"), indent=TRUE, prefix = PREFIX_XML)
+  xml <- write.config.xml.ED2(defaults = defaults, settings = settings, trait.values = trait.values)
+  
+  saveXML(xml, file = file.path(settings$rundir, run.id, "config.xml"), indent = TRUE, prefix = PREFIX_XML)
   
   startdate <- as.Date(settings$run$start.date)
   enddate <- as.Date(settings$run$end.date)
@@ -117,15 +113,15 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults=settings$c
   ##----------------------------------------------------------------------
   ## Edit ED2IN file for runs
   if (!is.null(settings$model$edin) && file.exists(settings$model$edin)) {
-    ed2in.text <- readLines(con=settings$model$edin, n=-1)
+    ed2in.text <- readLines(con = settings$model$edin, n = -1)
   } else {
     filename <- system.file(settings$model$edin, package = "PEcAn.ED2")
     if (filename == "") {
       if (!is.null(settings$model$revision)) {
-        rev <- gsub('^r', '', settings$model$revision)
+        rev <- gsub("^r", "", settings$model$revision)
       } else {
-        model <- db.query(paste("SELECT * FROM models WHERE id =", settings$model$id), params=settings$database$bety)
-        rev <- gsub('^r', '', model$revision)
+        model <- db.query(paste("SELECT * FROM models WHERE id =", settings$model$id), params = settings$database$bety)
+        rev <- gsub("^r", "", model$revision)
       }
       filename <- system.file(paste0("ED2IN.r", rev), package = "PEcAn.ED2")
     }
@@ -133,125 +129,118 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults=settings$c
       logger.severe("Could not find ED template")
     }
     logger.info("Using", filename, "as template")
-    ed2in.text <- readLines(con=filename, n=-1)
+    ed2in.text <- readLines(con = filename, n = -1)
   }
   
-  metstart <- tryCatch(format(as.Date(settings$run$site$met.start), "%Y"), error=function(e) settings$run$site$met.start)
-  metend   <- tryCatch(format(as.Date(settings$run$site$met.end), "%Y"), error=function(e) settings$run$site$met.end)
+  metstart <- tryCatch(format(as.Date(settings$run$site$met.start), "%Y"), 
+                       error = function(e) settings$run$site$met.start)
+  metend <- tryCatch(format(as.Date(settings$run$site$met.end), "%Y"), 
+                     error = function(e) settings$run$site$met.end)
   
-  ed2in.text <- gsub('@SITE_LAT@', settings$run$site$lat, ed2in.text)
-  ed2in.text <- gsub('@SITE_LON@', settings$run$site$lon, ed2in.text)
-  ed2in.text <- gsub('@SITE_MET@', settings$run$inputs$me$path, ed2in.text)
-  ed2in.text <- gsub('@MET_START@', metstart, ed2in.text)
-  ed2in.text <- gsub('@MET_END@', metend, ed2in.text)
+  ed2in.text <- gsub("@SITE_LAT@", settings$run$site$lat, ed2in.text)
+  ed2in.text <- gsub("@SITE_LON@", settings$run$site$lon, ed2in.text)
+  ed2in.text <- gsub("@SITE_MET@", settings$run$inputs$me$path, ed2in.text)
+  ed2in.text <- gsub("@MET_START@", metstart, ed2in.text)
+  ed2in.text <- gsub("@MET_END@", metend, ed2in.text)
   
-  if(is.null(settings$model$phenol.scheme)){
-    print(paste("no phenology scheme set; \n",
-                "need to add <phenol.scheme> tag under <model> tag in settings file"))
-  } else if(settings$model$phenol.scheme==1) {
+  if (is.null(settings$model$phenol.scheme)) {
+    print(paste("no phenology scheme set; \n", "need to add <phenol.scheme> tag under <model> tag in settings file"))
+  } else if (settings$model$phenol.scheme == 1) {
     ## Set prescribed phenology switch in ED2IN
-    ed2in.text <- gsub('@PHENOL_SCHEME@', settings$model$phenol.scheme, ed2in.text)
+    ed2in.text <- gsub("@PHENOL_SCHEME@", settings$model$phenol.scheme, ed2in.text)
     ## Phenology filename
-    ed2in.text <- gsub('@PHENOL@', settings$model$phenol, ed2in.text)
+    ed2in.text <- gsub("@PHENOL@", settings$model$phenol, ed2in.text)
     ## Set start year of phenology
-    ed2in.text <- gsub('@PHENOL_START@', settings$model$phenol.start, ed2in.text)
+    ed2in.text <- gsub("@PHENOL_START@", settings$model$phenol.start, ed2in.text)
     ## Set end year of phenology
-    ed2in.text <- gsub('@PHENOL_END@', settings$model$phenol.end, ed2in.text)
+    ed2in.text <- gsub("@PHENOL_END@", settings$model$phenol.end, ed2in.text)
     
     ## If not prescribed set alternative phenology scheme.
   } else {
-    ed2in.text <- gsub(' @PHENOL_SCHEME@', settings$model$phenol.scheme, ed2in.text)
+    ed2in.text <- gsub(" @PHENOL_SCHEME@", settings$model$phenol.scheme, ed2in.text)
     # Insert blanks into ED2IN file so ED2 runs without error
-    ed2in.text <- gsub('@PHENOL@', "", ed2in.text)
-    ed2in.text <- gsub('@PHENOL_START@', "", ed2in.text)
-    ed2in.text <- gsub('@PHENOL_END@', "", ed2in.text)
+    ed2in.text <- gsub("@PHENOL@", "", ed2in.text)
+    ed2in.text <- gsub("@PHENOL_START@", "", ed2in.text)
+    ed2in.text <- gsub("@PHENOL_END@", "", ed2in.text)
   }
   
   ##----------------------------------------------------------------------
-  # Get prefix of filename, append to dirname. 
-  # Assumes pattern 'DIR/PREFIX.lat<REMAINDER OF FILENAME>' 
-  # Slightly overcomplicated to avoid error if path name happened to contain '.lat'
+  # Get prefix of filename, append to dirname.  Assumes pattern 'DIR/PREFIX.lat<REMAINDER OF
+  # FILENAME>' Slightly overcomplicated to avoid error if path name happened to contain '.lat'
   
   # when pss or css not exists, case 0
-  if (is.null(settings$run$inputs$pss$path)|is.null(settings$run$inputs$css$path)){
-    ed2in.text <- gsub('@INIT_MODEL@', 0, ed2in.text)
-    ed2in.text <- gsub('@SITE_PSSCSS@', "", ed2in.text)
-  }
-  else{
+  if (is.null(settings$run$inputs$pss$path) | is.null(settings$run$inputs$css$path)) {
+    ed2in.text <- gsub("@INIT_MODEL@", 0, ed2in.text)
+    ed2in.text <- gsub("@SITE_PSSCSS@", "", ed2in.text)
+  } else {
     prefix.pss <- sub(".lat.*", "", settings$run$inputs$css$path)
     prefix.css <- sub(".lat.*", "", settings$run$inputs$pss$path)
     # pss and css prefix is not the same, kill
-    if (!identical(prefix.pss , prefix.css)){
+    if (!identical(prefix.pss, prefix.css)) {
       logger.severe("ED2 css/pss/ files have different prefix")
-    }
-    # pss and css are both present
-    else{
+    } else {
+      # pss and css are both present
       value <- 2
-      # site exists 
-      if (!is.null(settings$run$inputs$site$path)){
+      # site exists
+      if (!is.null(settings$run$inputs$site$path)) {
         prefix.sites <- sub(".lat.*", "", settings$run$inputs$site$path)
-        # sites and pss have different prefix name, kill 
-        if (!identical (prefix.sites, prefix.pss)){
+        # sites and pss have different prefix name, kill
+        if (!identical(prefix.sites, prefix.pss)) {
           logger.severe("ED2 sites/pss/ files have different prefix")
-        }
-        #sites and pass same prefix name, case 3
-        else{
+        } else {
+          # sites and pass same prefix name, case 3
           value <- 3
         }
       }
     }
-    ed2in.text <- gsub('@INIT_MODEL@', value, ed2in.text)
-    ed2in.text <- gsub('@SITE_PSSCSS@', paste0(prefix.pss, '.'), ed2in.text)
-  } 
-  
+    ed2in.text <- gsub("@INIT_MODEL@", value, ed2in.text)
+    ed2in.text <- gsub("@SITE_PSSCSS@", paste0(prefix.pss, "."), ed2in.text)
+  }
   
   ##----------------------------------------------------------------------
   
-  ed2in.text <- gsub('@ED_VEG@', settings$run$inputs$veg$path, ed2in.text)
-  ed2in.text <- gsub('@ED_SOIL@', settings$run$inputs$soil$path, ed2in.text)
-  ed2in.text <- gsub('@ED_LU@', settings$run$inputs$lu$path, ed2in.text)
-  ed2in.text <- gsub('@ED_THSUM@', ifelse(str_sub(settings$run$inputs$thsum$path, -1) == "/",
-                                          settings$run$inputs$thsum$path,
+  ed2in.text <- gsub("@ED_VEG@", settings$run$inputs$veg$path, ed2in.text)
+  ed2in.text <- gsub("@ED_SOIL@", settings$run$inputs$soil$path, ed2in.text)
+  ed2in.text <- gsub("@ED_LU@", settings$run$inputs$lu$path, ed2in.text)
+  ed2in.text <- gsub("@ED_THSUM@", ifelse(str_sub(settings$run$inputs$thsum$path, -1) == "/", settings$run$inputs$thsum$path, 
                                           paste0(settings$run$inputs$thsum$path, "/")), ed2in.text)
   
   ##----------------------------------------------------------------------
-  ed2in.text <- gsub('@START_MONTH@', format(startdate, "%m"), ed2in.text)
-  ed2in.text <- gsub('@START_DAY@', format(startdate, "%d"), ed2in.text)
-  ed2in.text <- gsub('@START_YEAR@', format(startdate, "%Y"), ed2in.text)
-  ed2in.text <- gsub('@END_MONTH@', format(enddate, "%m"), ed2in.text)
-  ed2in.text <- gsub('@END_DAY@', format(enddate, "%d"), ed2in.text)
-  ed2in.text <- gsub('@END_YEAR@', format(enddate, "%Y"), ed2in.text)
+  ed2in.text <- gsub("@START_MONTH@", format(startdate, "%m"), ed2in.text)
+  ed2in.text <- gsub("@START_DAY@", format(startdate, "%d"), ed2in.text)
+  ed2in.text <- gsub("@START_YEAR@", format(startdate, "%Y"), ed2in.text)
+  ed2in.text <- gsub("@END_MONTH@", format(enddate, "%m"), ed2in.text)
+  ed2in.text <- gsub("@END_DAY@", format(enddate, "%d"), ed2in.text)
+  ed2in.text <- gsub("@END_YEAR@", format(enddate, "%Y"), ed2in.text)
   
   ##-----------------------------------------------------------------------
-  #Set The flag for IMETAVG telling ED what to do given how input radiation was originally averaged
-  # -1 = I don't know, use linear interpolation
-  # 0 = No average, the values are instantaneous 
-  # 1 = Averages ending at the reference time
-  # 2 = Averages beginning at the reference time
-  # 3 = Averages centered at the reference time
-  ## Deafult is -1
+  # Set The flag for IMETAVG telling ED what to do given how input radiation was originally
+  # averaged -1 = I don't know, use linear interpolation 0 = No average, the values are
+  # instantaneous 1 = Averages ending at the reference time 2 = Averages beginning at the reference
+  # time 3 = Averages centered at the reference time Deafult is -1
   
-  ed2in.text <- gsub('@MET_SOURCE@', -1,ed2in.text)    
- 
+  ed2in.text <- gsub("@MET_SOURCE@", -1, ed2in.text)
+  
   ##----------------------------------------------------------------------
   if (is.null(settings$host$scratchdir)) {
     modeloutdir <- file.path(settings$host$outdir, run.id)
   } else {
     modeloutdir <- file.path(settings$host$scratchdir, settings$workflow$id, run.id)
   }
-  ed2in.text <- gsub('@OUTDIR@', modeloutdir, ed2in.text)
-  ed2in.text <- gsub('@ENSNAME@', run.id, ed2in.text)
-  ed2in.text <- gsub('@CONFIGFILE@', file.path(settings$host$rundir, run.id, "config.xml"), ed2in.text)
-  #ed2in.text <- gsub('@CONFIGFILE@',"config.xml", ed2in.text) # for ED2.r81 on Kang.  Temporary hack
+  ed2in.text <- gsub("@OUTDIR@", modeloutdir, ed2in.text)
+  ed2in.text <- gsub("@ENSNAME@", run.id, ed2in.text)
+  ed2in.text <- gsub("@CONFIGFILE@", file.path(settings$host$rundir, run.id, "config.xml"), ed2in.text)
+  # ed2in.text <- gsub('@CONFIGFILE@','config.xml', ed2in.text) # for ED2.r81 on Kang.  Temporary
+  # hack
   
   ##----------------------------------------------------------------------
-  ed2in.text <- gsub('@FFILOUT@', file.path(modeloutdir, "analysis"), ed2in.text)
-  ed2in.text <- gsub('@SFILOUT@', file.path(modeloutdir, "history"), ed2in.text)
+  ed2in.text <- gsub("@FFILOUT@", file.path(modeloutdir, "analysis"), ed2in.text)
+  ed2in.text <- gsub("@SFILOUT@", file.path(modeloutdir, "history"), ed2in.text)
   
   ##----------------------------------------------------------------------
   writeLines(ed2in.text, con = file.path(settings$rundir, run.id, "ED2IN"))
-}
-#==================================================================================================#
+} # write.config.ED2
+# ==================================================================================================#
 
 
 ##-------------------------------------------------------------------------------------------------#
@@ -262,24 +251,22 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults=settings$c
 ##' @author David LeBauer, Shawn Serbin, Rob Kooper, Mike Dietze
 ##' @import PEcAn.utils
 ##-------------------------------------------------------------------------------------------------#
-write.run.ED <- function(settings){
-  scratch = paste(Sys.getenv("USER"),"/",settings$run$scratch, sep='')
-  run.script.template = system.file("run.template.ED2", package="PEcAn.ED2")
-  run.text <- scan(file = run.script.template, 
-                   what="character",sep='@', quote=NULL, quiet=TRUE)
-  run.text <- gsub('TMP', paste("/scratch/",scratch,sep=""), run.text)
-  run.text <- gsub('BINARY', settings$model$binary, run.text)
-  run.text <- gsub('OUTDIR', settings$host$outdir, run.text)
-  runfile <- paste(settings$outdir, 'run', sep='')
+write.run.ED <- function(settings) {
+  scratch <- paste0(Sys.getenv("USER"), "/", settings$run$scratch)
+  run.script.template <- system.file("run.template.ED2", package = "PEcAn.ED2")
+  run.text <- scan(file = run.script.template, what = "character", sep = "@", quote = NULL, quiet = TRUE)
+  run.text <- gsub("TMP", paste("/scratch/", scratch, sep = ""), run.text)
+  run.text <- gsub("BINARY", settings$model$binary, run.text)
+  run.text <- gsub("OUTDIR", settings$host$outdir, run.text)
+  runfile <- paste0(settings$outdir, "run")
   writeLines(run.text, con = runfile)
-  if(settings$host$name == 'localhost') {
-    system(paste('cp ', runfile, settings$host$rundir))
-  }else{
-    system(paste("rsync -outi ", runfile , ' ', settings$host$name, ":",
-                 settings$host$rundir, sep = ''))
+  if (settings$host$name == "localhost") {
+    system(paste("cp ", runfile, settings$host$rundir))
+  } else {
+    system(paste0("rsync -outi ", runfile, " ", settings$host$name, ":", settings$host$rundir))
   }
-}
-#==================================================================================================#
+} # write.run.ED
+# ==================================================================================================#
 
 
 ##-------------------------------------------------------------------------------------------------#
@@ -292,40 +279,36 @@ write.run.ED <- function(settings){
 ##' @author Shawn Serbin, David LeBauer, Alexey Shikomanov
 remove.config.ED2 <- function(main.outdir = settings$outdir, settings) {
   
-  
   print(" ")
   print("---- Removing previous ED2 config files and output before starting new run ----")
   print(" ")
   
-  todelete <- dir(settings$outdir,
-                  pattern = c('/c.*', '/ED2INc.*'),
-                  recursive=TRUE, full.names = TRUE)
+  todelete <- dir(settings$outdir, pattern = c("/c.*", "/ED2INc.*"), recursive = TRUE, full.names = TRUE)
   
-  if(length(todelete>0)){
+  if (length(todelete > 0)) {
     file.remove(todelete)
-  } 
+  }
   rm(todelete)
-
+  
   ## Remove model run configs and model run log files on local/remote host
-  if(!settings$host$name == 'localhost'){
+  if (!settings$host$name == "localhost") {
     ## Remove model run congfig and log files on remote host
     remote_ls <- function(path, pattern) {
-        remote.execute.cmd(host = settings$host,
-                           cmd = "ls",
-                           args = file.path(path, pattern))
+      remote.execute.cmd(host = settings$host, cmd = "ls", args = file.path(path, pattern))
     }
     config <- remote_ls(settings$host$rundir, "c.*")
     ed2in <- remote_ls(settings$host$rundir, "ED2INc.*")
     output_remote <- remote_ls(settings$host$outdir, ".")
     output <- file.path(settings$host$outdir, output_remote)
-
-    if(length(config) > 0 | length(ed2in) > 0) {
-      todelete <- c(config, ed2in[-grep('log', ed2in)], output) ## Keep log files
+    
+    if (length(config) > 0 | length(ed2in) > 0) {
+      todelete <- c(config, ed2in[-grep("log", ed2in)], output)  ## Keep log files
       remote.execute.cmd(settings$host, "rm", c("-f", todelete))
     }
   }
-}
-#==================================================================================================#
+} # remove.config.ED2
+# ==================================================================================================#
+
 #' @name write.config.xml.ED2
 #' @title Write ED2 config.xml file
 #' @details Refactored by Alexey Shiklomanov to allow use in PEcAn RTM module.
@@ -335,94 +318,91 @@ remove.config.ED2 <- function(main.outdir = settings$outdir, settings) {
 #' @param defaults List of defaults to process. Default = settings$constants
 #' @return R XML object containing full ED2 XML file
 #' @author David LeBauer, Shawn Serbin, Carl Davidson, Alexey Shiklomanov
-write.config.xml.ED2 <- function(settings, trait.values, defaults=settings$constants){
-
-  ## Find history file
-  ## TODO this should come from the database
-  histfile <- paste("data/history.r", settings$model$revision, ".csv", sep='')
-  if (file.exists(system.file(histfile, package="PEcAn.ED2"))) {
-    print(paste("--- Using ED2 History File: ","data/history.r", settings$model$revision, ".csv", sep=''))
-    edhistory <- read.csv2(system.file(histfile, package="PEcAn.ED2"), sep=";", 
-                           stringsAsFactors=FALSE, dec='.')
+write.config.xml.ED2 <- function(settings, trait.values, defaults = settings$constants) {
+  
+  ## Find history file TODO this should come from the database
+  histfile <- paste0("data/history.r", settings$model$revision, ".csv")
+  if (file.exists(system.file(histfile, package = "PEcAn.ED2"))) {
+    print(paste0("--- Using ED2 History File: ", "data/history.r", settings$model$revision, ".csv"))
+    edhistory <- read.csv2(system.file(histfile, package = "PEcAn.ED2"), sep = ";", 
+                           stringsAsFactors = FALSE, dec = ".")
   } else {
     print("--- Using Generic ED2 History File: data/history.csv")
-    edhistory <- read.csv2(system.file("data/history.csv",  package="PEcAn.ED2"), sep=";",
-                           stringsAsFactors=FALSE, dec='.')
+    edhistory <- read.csv2(system.file("data/history.csv", package = "PEcAn.ED2"), sep = ";", 
+                           stringsAsFactors = FALSE, dec = ".")
   }
-
+  
   edtraits <- names(edhistory)
   data(pftmapping)
-
+  
   ## Get ED2 specific model settings and put into output config xml file
-  xml <- listToXml(settings$model$config.header, 'config')
-
-  ## Process the names in defaults. Runs only if names(defaults) are null or have at least one instance of name attribute "pft". Otherwise, AS assumes that names in defaults are already set to the corresponding PFT names.
+  xml <- listToXml(settings$model$config.header, "config")
+  
+  ## Process the names in defaults. Runs only if names(defaults) are null or have at least one
+  ## instance of name attribute 'pft'. Otherwise, AS assumes that names in defaults are already set
+  ## to the corresponding PFT names.
   currentnames <- names(defaults)
-  if(is.null(currentnames) | "pft" %in% currentnames){
+  if (is.null(currentnames) | "pft" %in% currentnames) {
     newnames <- sapply(defaults, "[[", "name")
     newnames.notnull <- which(!sapply(newnames, is.null))
     names(defaults)[newnames.notnull] <- newnames[newnames.notnull]
   }
   
-  for(i in seq_along(trait.values)){
+  for (i in seq_along(trait.values)) {
     group <- names(trait.values)[i]
-    if(group == "env"){
+    if (group == "env") {
       
       ## set defaults from config.header
       
-      ##
-      
     } else {
-      # Make this agnostic to the way PFT names are defined in `trait.values` -- either directly as list names or as object "name" within each sublist is fine
-      if(group == "pft"){
+      # Make this agnostic to the way PFT names are defined in `trait.values` -- either directly as
+      # list names or as object 'name' within each sublist is fine
+      if (group == "pft") {
         pft <- trait.values[[i]]$name
       } else {
         pft <- group
       }
-
-      # RyK: Changed this so that pftmapping is required. pft$constants$num is the number that
-      # will be written to config.xml, and it's used by fia.to.ed when mapping spp to a PFT #.
-      # But if you're overriding an existing ED2 pft, then you might not want that PFT number to be 
-      # used to look up default param values. 
-      #
-      # e.g. if you're trying to run temperate.Hydric PFT, which which doesn't exist in ED,
-      # you would need to assign it either an existing but currently unused ED2 PFT number 
-      # (e.g. #2 = "early tropical"), or an unused one (e.g. #18). Either way, that number
-      # isn't necessarily what you'd want to look up default parameters for the PFT. 
-      #
-      # What really should happen is for there to be two settings for each PFT: the "num"
-      # to use to represent the PFT to ED, and the "defaults.PFT" (name or number) to use
-      # for pulling default parameter values. 
+      
+      # RyK: Changed this so that pftmapping is required. pft$constants$num is the number that will be
+      # written to config.xml, and it's used by fia.to.ed when mapping spp to a PFT #.  But if you're
+      # overriding an existing ED2 pft, then you might not want that PFT number to be used to look up
+      # default param values.  e.g. if you're trying to run temperate.Hydric PFT, which which doesn't
+      # exist in ED, you would need to assign it either an existing but currently unused ED2 PFT number
+      # (e.g. #2 = 'early tropical'), or an unused one (e.g. #18). Either way, that number isn't
+      # necessarily what you'd want to look up default parameters for the PFT.  What really should
+      # happen is for there to be two settings for each PFT: the 'num' to use to represent the PFT to
+      # ED, and the 'defaults.PFT' (name or number) to use for pulling default parameter values.
       pft.number <- pftmapping$ED[which(pftmapping == pft)]
-      if(length(pft.number) == 0){
-          logger.error(pft, 'was not matched with a number in settings$constants or pftmapping data. Consult the PEcAn instructions on defining new PFTs.')
-          stop('Unable to set PFT number')
+      if (length(pft.number) == 0) {
+        logger.error(pft, "was not matched with a number in settings$constants or pftmapping data. Consult the PEcAn instructions on defining new PFTs.")
+        stop("Unable to set PFT number")
       }
-        # TODO: Also modify web app to not default to 1 
-
+      # TODO: Also modify web app to not default to 1
+      
       ## Get default trait values from ED history
-      vals <- as.list(edhistory[edhistory$num == pft.number,])
-
+      vals <- as.list(edhistory[edhistory$num == pft.number, ])
+      
       ## Convert trait values to ED units
       converted.trait.values <- convert.samples.ED(trait.values[[i]])
       
       ## Selectively replace defaults with trait values
       vals <- modifyList(vals, converted.trait.values)
-
+      
       ## Convert settings constants to ED units
       converted.defaults <- convert.samples.ED(defaults[[pft]]$constants)
-
+      
       ## Selectively replace defaults and trait values with constants from settings
-      if(!is.null(converted.defaults)) vals <- modifyList(vals, converted.defaults)
-
-      pft.xml <- listToXml(vals, 'pft')
+      if (!is.null(converted.defaults)) 
+        vals <- modifyList(vals, converted.defaults)
+      
+      pft.xml <- listToXml(vals, "pft")
       xml <- append.xmlNode(xml, pft.xml)
     }
   }
   return(xml)
-}
+} # write.config.xml.ED2
 
-#==================================================================================================#
+# ==================================================================================================#
 #' @name write.config.jobsh.ED2
 #' @title Write ED2 config.xml file
 #' @description Function for writing job.sh file for ED2 runs
@@ -436,8 +416,7 @@ write.config.xml.ED2 <- function(settings, trait.values, defaults=settings$const
 #' @param run.id PEcAn run ID
 #' @return Character vector containing job.sh file
 #' @author David LeBauer, Shawn Serbin, Carl Davidson, Alexey Shiklomanov
-
-write.config.jobsh.ED2 <- function(settings, run.id){
+write.config.jobsh.ED2 <- function(settings, run.id) {
   # find out where to write run/ouput
   rundir <- file.path(settings$host$rundir, run.id)
   outdir <- file.path(settings$host$outdir, run.id)
@@ -445,68 +424,65 @@ write.config.jobsh.ED2 <- function(settings, run.id){
   # command if scratch is used
   if (is.null(settings$host$scratchdir)) {
     modeloutdir <- outdir
-    mkdirscratch <- "# no need to mkdir for scratch" 
+    mkdirscratch <- "# no need to mkdir for scratch"
     copyscratch <- "# no need to copy from scratch"
     clearscratch <- "# no need to clear scratch"
   } else {
     modeloutdir <- file.path(settings$host$scratchdir, settings$workflow$id, run.id)
     mkdirscratch <- paste("mkdir -p", modeloutdir)
-    copyscratch <- paste("rsync", "-a", paste0('"', file.path(modeloutdir, ""), '"'), paste0('"', file.path(outdir, ""), '"'))
-    if (is.null(settings$host$clearscratch) || is.na(as.logical(settings$host$clearscratch)) || as.logical(settings$host$clearscratch)) {
-      clearscratch <- paste("rm", "-rf", paste0('"', modeloutdir, '"'))
+    copyscratch <- paste("rsync", "-a", 
+                         paste0("\"", file.path(modeloutdir, ""), "\""), 
+                         paste0("\"", file.path(outdir, ""), "\""))
+    if (is.null(settings$host$clearscratch) || is.na(as.logical(settings$host$clearscratch)) || 
+        as.logical(settings$host$clearscratch)) {
+      clearscratch <- paste("rm", "-rf", paste0("\"", modeloutdir, "\""))
     } else {
       clearscratch <- "# scratch is not cleared"
     }
   }
   # create launch script (which will create symlink)
   if (!is.null(settings$model$jobtemplate) && file.exists(settings$model$jobtemplate)) {
-    jobsh <- readLines(con=settings$model$jobtemplate, n=-1)
+    jobsh <- readLines(con = settings$model$jobtemplate, n = -1)
   } else {
-    jobsh <- readLines(con=system.file("template.job", package = "PEcAn.ED2"), n=-1)
+    jobsh <- readLines(con = system.file("template.job", package = "PEcAn.ED2"), n = -1)
   }
   
   # create host specific setttings
   hostsetup <- ""
   if (!is.null(settings$model$prerun)) {
-    hostsetup <- paste(hostsetup, sep="\n", paste(settings$model$prerun, collapse="\n"))
+    hostsetup <- paste(hostsetup, sep = "\n", paste(settings$model$prerun, collapse = "\n"))
   }
   if (!is.null(settings$host$prerun)) {
-    hostsetup <- paste(hostsetup, sep="\n", paste(settings$host$prerun, collapse="\n"))
+    hostsetup <- paste(hostsetup, sep = "\n", paste(settings$host$prerun, collapse = "\n"))
   }
-
+  
   hostteardown <- ""
   if (!is.null(settings$model$postrun)) {
-    hostteardown <- paste(hostteardown, sep="\n", paste(settings$model$postrun, collapse="\n"))
+    hostteardown <- paste(hostteardown, sep = "\n", paste(settings$model$postrun, collapse = "\n"))
   }
   if (!is.null(settings$host$postrun)) {
-    hostteardown <- paste(hostteardown, sep="\n", paste(settings$host$postrun, collapse="\n"))
+    hostteardown <- paste(hostteardown, sep = "\n", paste(settings$host$postrun, collapse = "\n"))
   }
-
+  
   # create job.sh
-  jobsh <- gsub('@HOST_SETUP@', hostsetup, jobsh)
-  jobsh <- gsub('@HOST_TEARDOWN@', hostteardown, jobsh)
-
-  jobsh <- gsub('@SITE_LAT@', settings$run$site$lat, jobsh)
-  jobsh <- gsub('@SITE_LON@', settings$run$site$lon, jobsh)
-  jobsh <- gsub('@SITE_MET@', settings$run$inputs$met$path, jobsh)
+  jobsh <- gsub("@HOST_SETUP@", hostsetup, jobsh)
+  jobsh <- gsub("@HOST_TEARDOWN@", hostteardown, jobsh)
   
-  jobsh <- gsub('@SCRATCH_MKDIR@', mkdirscratch, jobsh)
-  jobsh <- gsub('@SCRATCH_COPY@', copyscratch, jobsh)
-  jobsh <- gsub('@SCRATCH_CLEAR@', clearscratch, jobsh)
+  jobsh <- gsub("@SITE_LAT@", settings$run$site$lat, jobsh)
+  jobsh <- gsub("@SITE_LON@", settings$run$site$lon, jobsh)
+  jobsh <- gsub("@SITE_MET@", settings$run$inputs$met$path, jobsh)
   
-  jobsh <- gsub('@START_DATE@', settings$run$start.date, jobsh)
-  jobsh <- gsub('@END_DATE@', settings$run$end.date, jobsh)
+  jobsh <- gsub("@SCRATCH_MKDIR@", mkdirscratch, jobsh)
+  jobsh <- gsub("@SCRATCH_COPY@", copyscratch, jobsh)
+  jobsh <- gsub("@SCRATCH_CLEAR@", clearscratch, jobsh)
   
-  jobsh <- gsub('@OUTDIR@', outdir, jobsh)
-  jobsh <- gsub('@RUNDIR@', rundir, jobsh)
+  jobsh <- gsub("@START_DATE@", settings$run$start.date, jobsh)
+  jobsh <- gsub("@END_DATE@", settings$run$end.date, jobsh)
   
-  jobsh <- gsub('@BINARY@', settings$model$binary, jobsh)
-
+  jobsh <- gsub("@OUTDIR@", outdir, jobsh)
+  jobsh <- gsub("@RUNDIR@", rundir, jobsh)
+  
+  jobsh <- gsub("@BINARY@", settings$model$binary, jobsh)
+  
   return(jobsh)
-  
-}
-
-
-####################################################################################################
-### EOF.  End of R script file.              
-####################################################################################################
+} # write.config.jobsh.ED2


### PR DESCRIPTION
Ran through formatR::tidy_dir with arrow=TRUE and indent=2; made sure all if blocks have braces; took advantage of paste0 and file.path; changed require calls to library. Tried to make sure `formatR` didn’t make things too jaggy. Moved ellipses to end of met2model definition.