### PR TITLE
Style cleanup for `models/gday/R/*.R` scripts 

### DIFF
--- a/models/gday/R/met2model.GDAY.R
+++ b/models/gday/R/met2model.GDAY.R
@@ -6,13 +6,12 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-#
-## R Code to convert NetCDF CF met files into GDAY met files
 
-##If files already exist in "Outfolder", the default function is NOT to
-## overwrite them and only gives user the notice that file already exists. If
-## user wants to overwrite the existing files, just change overwrite statement
-## below to TRUE.
+# R Code to convert NetCDF CF met files into GDAY met files
+
+## If files already exist in 'Outfolder', the default function is NOT to overwrite them and only
+## gives user the notice that file already exists. If user wants to overwrite the existing files,
+## just change overwrite statement below to TRUE.
 
 ##' met2model for GDAY
 ##'
@@ -29,10 +28,9 @@
 ##' @param verbose should the function be very verbose
 ##'
 ##' @author Martin De Kauwe
-
-met2model.GDAY <- function(in.path, in.prefix, outfolder, start_date,
-                           end_date, ..., overwrite=FALSE, verbose=FALSE){
-
+met2model.GDAY <- function(in.path, in.prefix, outfolder, start_date, end_date, 
+                           overwrite = FALSE, verbose = FALSE, ...) {
+  
   ## GDAY driver format (.csv):
   ## 30min: year (-), doy (-; NB. leap years), hod (-), rainfall (mm 30 min-1),
   ##        par (umol m-2 s-1), tair (deg C), tsoil (deg C), vpd (kPa),
@@ -45,263 +43,229 @@ met2model.GDAY <- function(in.path, in.prefix, outfolder, start_date,
   ##        vpd_pm (kPa), co2 (ppm), ndep (t ha-1 day-1), wind (m-2 s-1),
   ##        press (kPa), wind_am (m-2 s-1), wind_pm (m-2 s-1),
   ##        par_am (umol m-2 s-1), par_pm (umol m-2 s-1)
-
+  
   SW_2_PAR <- 2.3
   PA_2_KPA <- 0.001
-  SEC_TO_HFHR <- 60.0 * 30.0
+  SEC_TO_HFHR <- 60 * 30
   K_TO_DEG <- -273.15
-  MOL_2_UMOL <- 1E6
-
-  if(!require(PEcAn.utils)) print("install PEcAn.utils")
-
+  MOL_2_UMOL <- 1e+06
+  
+  library(PEcAn.utils)
+  
   start_date <- as.POSIXlt(start_date, tz = "GMT")
-  end_date<- as.POSIXlt(end_date, tz = "GMT")
-  out.file <- paste(in.prefix,
-                    strptime(start_date, "%Y-%m-%d"),
-                    strptime(end_date, "%Y-%m-%d"),
-                    "dat", sep=".")
+  end_date <- as.POSIXlt(end_date, tz = "GMT")
+  out.file <- paste(in.prefix, strptime(start_date, "%Y-%m-%d"), 
+                    strptime(end_date, "%Y-%m-%d"), 
+                    "dat", sep = ".")
   out.file.full <- file.path(outfolder, out.file)
-
-  results <- data.frame(file=c(out.file.full),
-                        host=c(fqdn()),
-                        mimetype=c('text/plain'),
-                        formatname=c('GDAY meteorology'),
-                        startdate=c(start_date),
-                        enddate=c(end_date),
-                        dbfile.name=out.file,
-                        stringsAsFactors=FALSE)
-
+  
+  results <- data.frame(file = c(out.file.full), 
+                        host = c(fqdn()), 
+                        mimetype = c("text/plain"), 
+                        formatname = c("GDAY meteorology"), 
+                        startdate = c(start_date), 
+                        enddate = c(end_date), 
+                        dbfile.name = out.file, 
+                        stringsAsFactors = FALSE)
+  
   if (file.exists(out.file.full) && !overwrite) {
-    logger.debug("File '", out.file.full,
-                 "' already exists, skipping to next file.")
+    logger.debug("File '", out.file.full, "' already exists, skipping to next file.")
     return(invisible(results))
   }
-
-  require(ncdf4)
-  require(lubridate)
-  require(PEcAn.data.atmosphere)
-
-  ## check to see if the outfolder is defined, if not create directory for
-  ## output
-  if (!file.exists(outfolder)){
+  
+  library(ncdf4)
+  library(lubridate)
+  library(PEcAn.data.atmosphere)
+  
+  ## check to see if the outfolder is defined, if not create directory for output
+  if (!file.exists(outfolder)) {
     dir.create(outfolder)
   }
-
+  
   ## For now setting this to be false till we resolve the best route forward
-  sub_daily = FALSE
-
+  sub_daily <- FALSE
+  
   # Create an empty holder for each (hour)days translated met file
   out <- NULL
-
+  
   start_year <- year(start_date)
   end_year <- year(end_date)
-
+  
   for (year in start_year:end_year) {
-    old.file <- file.path(in.path, paste(in.prefix, year, "nc", sep="."))
-
+    old.file <- file.path(in.path, paste(in.prefix, year, "nc", sep = "."))
+    
     nc <- nc_open(old.file)
-
+    
     ## extract variables
-    lat <- ncvar_get(nc, "latitude")
-    lon <- ncvar_get(nc, "longitude")
+    lat  <- ncvar_get(nc, "latitude")
+    lon  <- ncvar_get(nc, "longitude")
     Tair <- ncvar_get(nc, "air_temperature")  ## in Kelvin
     Tair <- Tair + K_TO_DEG
-    PAR <- try(ncvar_get(nc,
-                     "surface_downwelling_photosynthetic_photon_flux_in_air"))
-    PAR <- PAR * MOL_2_UMOL
+    PAR  <- try(ncvar_get(nc, "surface_downwelling_photosynthetic_photon_flux_in_air"))
+    PAR  <- PAR * MOL_2_UMOL
     if (!is.numeric(PAR)) {
-      SW <- ncvar_get(nc, "surface_downwelling_shortwave_flux_in_air") ##in W/m2
+      SW <- ncvar_get(nc, "surface_downwelling_shortwave_flux_in_air")  ##in W/m2
       PAR <- SW * SW_2_PAR
     }
     CO2 <- try(ncvar_get(nc, "mole_fraction_of_carbon_dioxide_in_air"))
-    SH <- try(ncvar_get(nc, "specific_humidity")) ## kg/kg
-    VPD <- try(ncvar_get(nc, "water_vapor_saturation_deficit")) ## Pa
+    SH  <- try(ncvar_get(nc, "specific_humidity"))  ## kg/kg
+    VPD <- try(ncvar_get(nc, "water_vapor_saturation_deficit"))  ## Pa
     if (!is.numeric(VPD)) {
-      RH = qair2rh(SH, Tair)
-      VPD = get.vpd(RH, Tair) * MB_2_KPA
+      RH  <- qair2rh(SH, Tair)
+      VPD <- get.vpd(RH, Tair) * MB_2_KPA
     } else {
       VPD <- VPD * PA_2_KPA
     }
-
-    wind_speed  <- try(ncvar_get(nc, "wind_speed")) ## m/s
-    air_pressure <- try(ncvar_get(nc, "air_pressure")) ## Pa
-    ppt <- try(ncvar_get(nc, "precipitation_flux")) ## kg/m2/s
-
+    
+    wind_speed <- try(ncvar_get(nc, "wind_speed"))  ## m/s
+    air_pressure <- try(ncvar_get(nc, "air_pressure"))  ## Pa
+    ppt <- try(ncvar_get(nc, "precipitation_flux"))  ## kg/m2/s
+    
     nc_close(nc)
-
+    
     ## is CO2 present?
     if (!is.numeric(CO2)) {
       logger.warn("CO2 not found in", old.file, "setting to default: 400 ppm")
-      CO2 = rep(400, length(Tair))
+      CO2 <- rep(400, length(Tair))
     } else {
       CO2 <- CO2 * MOL_2_UMOL
     }
-
+    
     if (sub_daily) {
-
-      if(year %% 4 == 0) {
-        ndays <= 366
+      
+      if (year%%4 == 0) {
+        ndays <- 366
       } else {
         ndays <- 365
       }
-
+      
       for (doy in 1:ndays) {
-
-        day_idx <- idx:((idx-1) + 48)
-
+        
+        day_idx <- idx:((idx - 1) + 48)
+        
         # Grab the days data
-        tair_day = Tair[day_idx]
-        rain_day = ppt[day_idx]
-        par_day = PAR[day_idx]
-        vpd_day = VPD[day_idx]
-        wind_day = wind_speed[day_idx]
-        press_day = air_pressure[day_idx] * PA_2_KPA
-        co2_day = CO2[day_idx]
-
-        ## If there is no Tsoil variabile use Tair...it doesn't look like Tsoil
-        ## is a standard input
-        tsoil_out = mean(tair_day)
-
+        tair_day  <- Tair[day_idx]
+        rain_day  <- ppt[day_idx]
+        par_day   <- PAR[day_idx]
+        vpd_day   <- VPD[day_idx]
+        wind_day  <- wind_speed[day_idx]
+        press_day <- air_pressure[day_idx] * PA_2_KPA
+        co2_day   <- CO2[day_idx]
+        
+        ## If there is no Tsoil variabile use Tair...it doesn't look like Tsoil is a standard input
+        tsoil_out <- mean(tair_day)
+        
         for (hod in 1:48) {
-
-          rain_out = rain_day[hod] * SEC_TO_HFHR
-          par_out = par_day[hod]
-          tair_out = tair_day[hod]
-          wind_out = wind_day[hod]
-          press_out = press_day[hod]
-          vpd_out = vpd_day[hod]
-          co2_out = co2_day[hod]
-
+          
+          rain_out  <- rain_day[hod] * SEC_TO_HFHR
+          par_out   <- par_day[hod]
+          tair_out  <- tair_day[hod]
+          wind_out  <- wind_day[hod]
+          press_out <- press_day[hod]
+          vpd_out   <- vpd_day[hod]
+          co2_out   <- co2_day[hod]
+          
           # This is an assumption of the Medlyn gs model
           if (vpd_out < 0.05) {
-            vpd_out = 0.05
+            vpd_out <- 0.05
           }
-
+          
           ## No NDEP, so N-cycle will have to be switched off by default
-          ndep_out = -999.9
-
+          ndep_out <- -999.9
+          
           ## build output data matrix
-          tmp <- cbind(year,
-                       doy,
-                       hod,
-                       rain_out,
-                       par_out,
-                       tair_out,
-                       tsoil_out,
-                       vpd_out,
-                       co2_out,
-                       ndep_out,
-                       wind_out,
-                       press_out)
-
+          tmp <- cbind(year, doy, hod, 
+                       rain_out, par_out, tair_out, tsoil_out, vpd_out, 
+                       co2_out, ndep_out, wind_out, press_out)
+          
           if (is.null(out)) {
-            out = tmp
+            out <- tmp
           } else {
-            out = rbind(out, tmp)
+            out <- rbind(out, tmp)
           }
-
+          
           idx <- idx + 48
-        } ## Hour of day loop
-      } ## Day of year loop
-
+        }  ## Hour of day loop
+      }  ## Day of year loop
+      
     } else {
-
-      if (year %% 4 == 0) {
-        ndays <= 366
+      
+      if (year%%4 == 0) {
+        ndays <- 366
       } else {
         ndays <- 365
       }
-
+      
       for (doy in 1:ndays) {
-
+        
         # Build day, morning and afternoon indicies
-        day_idx <- idx:((idx-1) + 48)
+        day_idx <- idx:((idx - 1) + 48)
         mor_idx <- 1:24
         eve_idx <- 25:48
-
+        
         # Grab the days data
-        tair_day = Tair[day_idx]
-        par_day = PAR[day_idx]
-        vpd_day = VPD[day_idx]
-        wind_day = wind_speed[day_idx]
-
+        tair_day <- Tair[day_idx]
+        par_day  <- PAR[day_idx]
+        vpd_day  <- VPD[day_idx]
+        wind_day <- wind_speed[day_idx]
+        
         # Calculate the output met vars
-        tair_out = mean(tair_day)
-        rain_out = sum(ppt[day_idx] * SEC_TO_HFHR)
-
-        ## If there is no Tsoil variabile use Tair...it doesn't look like Tsoil
-        ## is a standard input
-        tsoil_out = mean(tair_day)
-
+        tair_out <- mean(tair_day)
+        rain_out <- sum(ppt[day_idx] * SEC_TO_HFHR)
+        
+        ## If there is no Tsoil variabile use Tair...it doesn't look like Tsoil is a standard input
+        tsoil_out <- mean(tair_day)
+        
         ## No NDEP, so N-cycle will have to be switched off by default
-        ndep_out = -999.9
-
-        co2_out = mean(CO2[day_idx])
-        wind_out = mean(wind_speed[day_idx])
-        press_out = mean(air_pressure[day_idx] * PA_2_KPA)
-
+        ndep_out <- -999.9
+        
+        co2_out   <- mean(CO2[day_idx])
+        wind_out  <- mean(wind_speed[day_idx])
+        press_out <- mean(air_pressure[day_idx] * PA_2_KPA)
+        
         ## Needs to be morning (am) / afternoon (pm)
-        tair_am_out = mean(tair_day[mor_idx][par_day[mor_idx] > 0.0])
-        tair_pm_out = mean(tair_day[eve_idx][par_day[eve_idx] > 0.0])
-        tmin_out = min(tair_day)
-        tmax_out = max(tair_day)
-        tday_out = mean(tair_day)
-
-        vpd_am_out = mean(vpd_day[mor_idx][par_day[mor_idx] > 0.0])
+        tair_am_out <- mean(tair_day[mor_idx][par_day[mor_idx] > 0])
+        tair_pm_out <- mean(tair_day[eve_idx][par_day[eve_idx] > 0])
+        tmin_out    <- min(tair_day)
+        tmax_out    <- max(tair_day)
+        tday_out    <- mean(tair_day)
+        
+        vpd_am_out <- mean(vpd_day[mor_idx][par_day[mor_idx] > 0])
         # This is an assumption of the Medlyn gs model
         if (vpd_am_out < 0.05) {
-          vpd_am_out = 0.05
+          vpd_am_out <- 0.05
         }
-
-        vpd_pm_out = mean(vpd_day[eve_idx][par_day[eve_idx] > 0.0])
+        
+        vpd_pm_out <- mean(vpd_day[eve_idx][par_day[eve_idx] > 0])
         # This is an assumption of the Medlyn gs model
         if (vpd_pm_out < 0.05) {
-          vpd_pm_out = 0.05
+          vpd_pm_out <- 0.05
         }
-
-        wind_am_out = mean(wind_day[mor_idx][par_day[mor_idx] > 0.0])
-        wind_pm_out = mean(wind_day[eve_idx][par_day[eve_idx] > 0.0])
-        par_am_out = sum(par_day[mor_idx][par_day[mor_idx] > 0.0])
-        par_pm_out = sum(par_day[eve_idx][par_day[eve_idx] > 0.0])
-
+        
+        wind_am_out <- mean(wind_day[mor_idx][par_day[mor_idx] > 0])
+        wind_pm_out <- mean(wind_day[eve_idx][par_day[eve_idx] > 0])
+        par_am_out <- sum(par_day[mor_idx][par_day[mor_idx] > 0])
+        par_pm_out <- sum(par_day[eve_idx][par_day[eve_idx] > 0])
+        
         ## build output data matrix
-        tmp <- cbind(year,
-                     doy,
-                     tair_out,
-                     rain_out,
-                     tsoil_out,
-                     tair_am_out,
-                     tair_pm_out,
-                     tmin_out,
-                     tmax_out,
-                     tday_out,
-                     vpd_am_out,
-                     vpd_pm_out,
-                     co2_out,
-                     ndep_out,
-                     wind_out,
-                     press_out,
-                     wind_am_out,
-                     wind_pm_out,
-                     par_am_out,
-                     par_pm_out)
-
+        tmp <- cbind(year, doy, tair_out, rain_out, tsoil_out, tair_am_out, tair_pm_out, 
+                     tmin_out, tmax_out, tday_out, vpd_am_out, vpd_pm_out, co2_out, ndep_out, wind_out, 
+                     press_out, wind_am_out, wind_pm_out, par_am_out, par_pm_out)
+        
         if (is.null(out)) {
-          out = tmp
+          out <- tmp
         } else {
-          out = rbind(out,tmp)
+          out <- rbind(out, tmp)
         }
-
+        
         idx <- idx + 1
-      } ## end of day loop
-
-    } ## end sub-daily/day if/else block
-  } ## end loop over years
-
+      }  ## end of day loop
+      
+    }  ## end sub-daily/day if/else block
+  }  ## end loop over years
+  
   ## write output
-  write.table(out, out.file.full, quote=FALSE, sep=",", row.names=FALSE,
-              col.names=FALSE)
-
+  write.table(out, out.file.full, quote = FALSE, sep = ",", row.names = FALSE, col.names = FALSE)
+  
   invisible(results)
-
-}
+} # met2model.GDAY

--- a/models/gday/R/model2netcdf.GDAY.R
+++ b/models/gday/R/model2netcdf.GDAY.R
@@ -1,11 +1,12 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2012 NCSA.
+# Copyright (c) 2015 Boston University, NCSA.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the
-# University of Illinois/NCSA Open Source License
+# NCSA Open Source License
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
+
 #------------------------------------------------------------------------------#
 ##' Convert GDAY output to netCDF
 ##'
@@ -20,124 +21,107 @@
 ##' @export
 ##' @author Martin De Kauwe
 model2netcdf.GDAY <- function(outdir, sitelat, sitelon, start_date, end_date) {
-
-require(PEcAn.utils)
-require(ncdf4)
-
+  
+  library(PEcAn.utils)
+  library(ncdf4)
+  
   G_2_KG <- 0.001
-  TONNES_PER_HA_TO_G_M2 <- 100.0
+  TONNES_PER_HA_TO_G_M2 <- 100
   THA_2_KG_M2 <- TONNES_PER_HA_TO_G_M2 * 0.001
-
+  
   ### Read in model output in GDAY format
-  GDAY.output <- read.csv(file.path(outdir, "out.txt"), header=TRUE, sep=',',
-                          skip=1)
+  GDAY.output <- read.csv(file.path(outdir, "out.txt"), header = TRUE, sep = ",", skip = 1)
   GDAY.output.dims <- dim(GDAY.output)
-
+  
   ### Determine number of years and output timestep
-  days = as.Date(start_date):as.Date(end_date)
-  year = strftime(as.Date(days, origin="1970-01-01"), "%Y")
+  days <- as.Date(start_date):as.Date(end_date)
+  year <- strftime(as.Date(days, origin = "1970-01-01"), "%Y")
   num.years <- length(unique(year))
   years <- unique(year)
   timestep.s <- 86400
-
+  
   ### Loop over years in GDAY output to create separate netCDF outputs
-  for (y in years){
-    if (file.exists(file.path(outdir, paste(y, "nc", sep=".")))) {
+  for (y in years) {
+    if (file.exists(file.path(outdir, paste(y, "nc", sep = ".")))) {
       next
     }
-
+    
     ## Subset data for processing
     sub.GDAY.output <- subset(GDAY.output, year == y)
     sub.GDAY.output.dims <- dim(sub.GDAY.output)
-
+    
     ## Setup outputs for netCDF file in appropriate units
     output <- list()
-
+    
     ## standard variables: C-Fluxes
-    output[[1]] <- (sub.GDAY.output[,"auto_resp"] * THA_2_KG_M2) / timestep.s
-    output[[2]] <- (sub.GDAY.output[,"hetero_resp"] * THA_2_KG_M2) / timestep.s
-    output[[3]] <- (sub.GDAY.output[,"auto_resp"] +
-                    sub.GDAY.output[,"hetero_resp"] * THA_2_KG_M2) / timestep.s
-    output[[4]] <- (sub.GDAY.output[,"gpp"] * THA_2_KG_M2) / timestep.s
-    output[[5]] <- (sub.GDAY.output[,"nep"] * -1.0 * THA_2_KG_M2) / timestep.s
-    output[[6]] <- (sub.GDAY.output[,"npp"] * THA_2_KG_M2) / timestep.s
-
+    output[[1]] <- (sub.GDAY.output[, "auto_resp"] * THA_2_KG_M2) / timestep.s
+    output[[2]] <- (sub.GDAY.output[, "hetero_resp"] * THA_2_KG_M2) / timestep.s
+    output[[3]] <- (sub.GDAY.output[, "auto_resp"] + sub.GDAY.output[, "hetero_resp"] *
+                      THA_2_KG_M2) / timestep.s
+    output[[4]] <- (sub.GDAY.output[, "gpp"] * THA_2_KG_M2) / timestep.s
+    output[[5]] <- (sub.GDAY.output[, "nep"] * -1 * THA_2_KG_M2) / timestep.s
+    output[[6]] <- (sub.GDAY.output[, "npp"] * THA_2_KG_M2) / timestep.s
+    
     ## standard variables: C-State
-    output[[7]] <- (sub.GDAY.output[,"stem"] +
-                    sub.GDAY.output[,"branch"] * THA_2_KG_M2) / timestep.s
-    output[[8]] <- (sub.GDAY.output[,"soilc"] * THA_2_KG_M2) / timestep.s
-    output[[9]] <- (sub.GDAY.output[,"lai"])
-
+    output[[7]] <- (sub.GDAY.output[, "stem"] + sub.GDAY.output[, "branch"] * THA_2_KG_M2) / timestep.s
+    output[[8]] <- (sub.GDAY.output[, "soilc"] * THA_2_KG_M2) / timestep.s
+    output[[9]] <- (sub.GDAY.output[, "lai"])
+    
     ## standard variables: water fluxes
-    output[[10]] <- (sub.GDAY.output[,"et"]) / timestep.s
-    output[[11]] <- (sub.GDAY.output[,"transpiration"]) / timestep.s
-
-
-    #******************** Declare netCDF variables ********************#
-    t <- ncdim_def(name = "time",
-                   units = paste0("days since ", y, "-01-01 00:00:00"),
-                   vals = 1:nrow(sub.GDAY.output),
+    output[[10]] <- (sub.GDAY.output[, "et"]) / timestep.s
+    output[[11]] <- (sub.GDAY.output[, "transpiration"]) / timestep.s
+    
+    # ******************** Declare netCDF variables ********************#
+    t <- ncdim_def(name = "time", units = paste0("days since ", y, "-01-01 00:00:00"), 
+                   vals = 1:nrow(sub.GDAY.output), 
                    calendar = "standard", unlim = TRUE)
-    lat <- ncdim_def("lat", "degrees_east",
-                     vals =  as.numeric(sitelat),
-                     longname = "station_latitude")
-    lon <- ncdim_def("lon", "degrees_north",
-                     vals = as.numeric(sitelon),
-                     longname = "station_longitude")
-
-   ## ***** Need to dynamically update the UTC offset here *****
-
-    for(i in 1:length(output)){
-      if(length(output[[i]])==0) output[[i]] <- rep(-999,length(t$vals))
+    lat <- ncdim_def("lat", "degrees_east", vals = as.numeric(sitelat), longname = "station_latitude")
+    lon <- ncdim_def("lon", "degrees_north", vals = as.numeric(sitelon), longname = "station_longitude")
+    
+    ## ***** Need to dynamically update the UTC offset here *****
+    
+    for (i in seq_along(output)) {
+      if (length(output[[i]]) == 0) 
+        output[[i]] <- rep(-999, length(t$vals))
     }
-
+    
     var <- list()
     ## C-Fluxes
-    var[[1]]  <- mstmipvar("AutoResp", lat, lon, t, NA)
-    var[[2]]  <- mstmipvar("HeteroResp", lat, lon, t, NA)
-    var[[3]]  <- mstmipvar("TotalResp", lat, lon, t, NA)
-    var[[4]]  <- mstmipvar("GPP", lat, lon, t, NA)
-    var[[5]]  <- mstmipvar("NEE", lat, lon, t, NA)
-    var[[6]]  <- mstmipvar("NPP", lat, lon, t, NA)
-
-
+    var[[1]] <- mstmipvar("AutoResp", lat, lon, t, NA)
+    var[[2]] <- mstmipvar("HeteroResp", lat, lon, t, NA)
+    var[[3]] <- mstmipvar("TotalResp", lat, lon, t, NA)
+    var[[4]] <- mstmipvar("GPP", lat, lon, t, NA)
+    var[[5]] <- mstmipvar("NEE", lat, lon, t, NA)
+    var[[6]] <- mstmipvar("NPP", lat, lon, t, NA)
+    
     ## C-State
-    var[[7]]  <- mstmipvar("AbvGrndWood", lat, lon, t, NA)
-    var[[8]]  <- mstmipvar("TotSoilCarb", lat, lon, t, NA)
-    var[[9]]  <- mstmipvar("LAI", lat, lon, t, NA)
-
+    var[[7]] <- mstmipvar("AbvGrndWood", lat, lon, t, NA)
+    var[[8]] <- mstmipvar("TotSoilCarb", lat, lon, t, NA)
+    var[[9]] <- mstmipvar("LAI", lat, lon, t, NA)
+    
     ## Water fluxes
-    var[[10]]  <- mstmipvar("Evap", lat, lon, t, NA)
-    var[[11]]  <- mstmipvar("TVeg", lat, lon, t, NA)
-
-
-    #var[[6]]  <- ncvar_def("LeafLitter", "kgC/m2/s", list(lon,lat,t), -999)
-    #var[[7]]  <- ncvar_def("WoodyLitter", "kgC/m2/s", list(lon,lat,t), -999)
-    #var[[8]]  <- ncvar_def("RootLitter", "kgC/m2/s", list(lon,lat,t), -999)
-    #var[[9]]  <- ncvar_def("LeafBiomass", "kgC/m2", list(lon,lat,t), -999)
-    #var[[10]]  <- ncvar_def("WoodBiomass", "kgC/m2", list(lon,lat,t), -999)
-    #var[[11]]  <- ncvar_def("RootBiomass", "kgC/m2", list(lon,lat,t), -999)
-    #var[[12]]  <- ncvar_def("LitterBiomass", "kgC/m2", list(lon,lat,t), -999)
-    #var[[13]]  <- ncvar_def("SoilC", "kgC/m2", list(lon,lat,t), -999)
-
-    #******************** Declar netCDF variables ********************#
-
-
+    var[[10]] <- mstmipvar("Evap", lat, lon, t, NA)
+    var[[11]] <- mstmipvar("TVeg", lat, lon, t, NA)
+    
+    # var[[6]] <- ncvar_def('LeafLitter', 'kgC/m2/s', list(lon,lat,t), -999) var[[7]] <-
+    # ncvar_def('WoodyLitter', 'kgC/m2/s', list(lon,lat,t), -999) var[[8]] <- ncvar_def('RootLitter',
+    # 'kgC/m2/s', list(lon,lat,t), -999) var[[9]] <- ncvar_def('LeafBiomass', 'kgC/m2',
+    # list(lon,lat,t), -999) var[[10]] <- ncvar_def('WoodBiomass', 'kgC/m2', list(lon,lat,t), -999)
+    # var[[11]] <- ncvar_def('RootBiomass', 'kgC/m2', list(lon,lat,t), -999) var[[12]] <-
+    # ncvar_def('LitterBiomass', 'kgC/m2', list(lon,lat,t), -999) var[[13]] <- ncvar_def('SoilC',
+    # 'kgC/m2', list(lon,lat,t), -999)
+    
+    # ******************** Declare netCDF variables ********************#
+    
     ### Output netCDF data
-    nc <- nc_create(file.path(outdir, paste(y,"nc", sep=".")), var)
-    varfile <- file(file.path(outdir, paste(y, "nc", "var", sep=".")), "w")
-    for(i in 1:length(var)) {
+    nc <- nc_create(file.path(outdir, paste(y, "nc", sep = ".")), var)
+    varfile <- file(file.path(outdir, paste(y, "nc", "var", sep = ".")), "w")
+    for (i in seq_along(var)) {
       ncvar_put(nc, var[[i]], output[[i]])
-      cat(paste(var[[i]]$name, var[[i]]$longname), file=varfile, sep="\n")
+      cat(paste(var[[i]]$name, var[[i]]$longname), file = varfile, sep = "\n")
     }
     close(varfile)
     nc_close(nc)
-
-  } ### End of year loop
-} ### End of function
-#==============================================================================#
-
-
-################################################################################
-### EOF.  End of R script file.
-################################################################################
+  }  ### End of year loop
+} # model2netcdf.GDAY
+# ==============================================================================#

--- a/models/gday/R/write.config.GDAY.R
+++ b/models/gday/R/write.config.GDAY.R
@@ -1,8 +1,8 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.
+# Copyright (c) 2015 Boston University, NCSA.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the
-# University of Illinois/NCSA Open Source License
+# NCSA Open Source License
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
@@ -23,59 +23,56 @@
 ##' @export
 ##' @author Martin De Kauwe
 ##-------------------------------------------------------------------------------------------------#
-write.config.GDAY <- function(defaults, trait.values, settings, run.id){
-
-
-  # find out where to write run/ouput
-  rundir <- file.path(settings$host$rundir, as.character(run.id))
-  outdir <- file.path(settings$host$outdir, as.character(run.id))
-  if (is.null(settings$host$qsub) &&
-     (settings$host$name == "localhost")) {
-    rundir <- file.path(settings$rundir, as.character(run.id))
-    outdir <- file.path(settings$modeloutdir, as.character(run.id))
-  }
-  #-----------------------------------------------------------------------
-  # create launch script (which will create symlink)
-  if (!is.null(settings$model$jobtemplate) && file.exists(settings$model$jobtemplate)) {
-    jobsh <- readLines(con=settings$model$jobtemplate, n=-1)
-  } else {
-    jobsh <- readLines(con=system.file("template.job", package = "PEcAn.GDAY"),n=-1)
-  }
-
-  # create host specific setttings
-  hostsetup <- ""
-  if (!is.null(settings$model$prerun)) {
-    hostsetup <- paste(hostsetup, sep="\n", paste(settings$model$prerun, collapse="\n"))
-  }
-  if (!is.null(settings$host$prerun)) {
-    hostsetup <- paste(hostsetup, sep="\n", paste(settings$host$prerun, collapse="\n"))
-  }
-
-  hostteardown <- ""
-  if (!is.null(settings$model$postrun)) {
-    hostteardown <- paste(hostteardown, sep="\n", paste(settings$model$postrun, collapse="\n"))
-  }
-  if (!is.null(settings$host$postrun)) {
-    hostteardown <- paste(hostteardown, sep="\n", paste(settings$host$postrun, collapse="\n"))
-  }
-
-  # create job.sh
-  jobsh <- gsub('@HOST_SETUP@', hostsetup, jobsh)
-  jobsh <- gsub('@HOST_TEARDOWN@', hostteardown, jobsh)
-  
-  jobsh <- gsub('@SITE_LAT@', settings$run$site$lat, jobsh)
-  jobsh <- gsub('@SITE_LON@', settings$run$site$lon, jobsh)
-  jobsh <- gsub('@SITE_MET@', settings$run$input$met$path, jobsh)
-  
-  jobsh <- gsub('@START_DATE@', settings$run$start.date, jobsh)
-  jobsh <- gsub('@END_DATE@', settings$run$end.date, jobsh)
-  
-  jobsh <- gsub('@OUTDIR@', outdir, jobsh)
-  jobsh <- gsub('@RUNDIR@', rundir, jobsh)
-  
-  jobsh <- gsub('@BINARY@', settings$model$binary, jobsh)
-  
-  writeLines(jobsh, con=file.path(settings$rundir, run.id, "job.sh"))
-  Sys.chmod(file.path(settings$rundir, run.id, "job.sh"))
-
-}
+write.config.GDAY <- function(defaults, trait.values, settings, run.id) {
+    
+    # find out where to write run/ouput
+    rundir <- file.path(settings$host$rundir, as.character(run.id))
+    outdir <- file.path(settings$host$outdir, as.character(run.id))
+    if (is.null(settings$host$qsub) && (settings$host$name == "localhost")) {
+        rundir <- file.path(settings$rundir, as.character(run.id))
+        outdir <- file.path(settings$modeloutdir, as.character(run.id))
+    }
+    #-----------------------------------------------------------------------
+    # create launch script (which will create symlink)
+    if (!is.null(settings$model$jobtemplate) && file.exists(settings$model$jobtemplate)) {
+        jobsh <- readLines(con = settings$model$jobtemplate, n = -1)
+    } else {
+        jobsh <- readLines(con = system.file("template.job", package = "PEcAn.GDAY"), n = -1)
+    }
+    
+    # create host specific setttings
+    hostsetup <- ""
+    if (!is.null(settings$model$prerun)) {
+        hostsetup <- paste(hostsetup, sep = "\n", paste(settings$model$prerun, collapse = "\n"))
+    }
+    if (!is.null(settings$host$prerun)) {
+        hostsetup <- paste(hostsetup, sep = "\n", paste(settings$host$prerun, collapse = "\n"))
+    }
+    
+    hostteardown <- ""
+    if (!is.null(settings$model$postrun)) {
+        hostteardown <- paste(hostteardown, sep = "\n", paste(settings$model$postrun, collapse = "\n"))
+    }
+    if (!is.null(settings$host$postrun)) {
+        hostteardown <- paste(hostteardown, sep = "\n", paste(settings$host$postrun, collapse = "\n"))
+    }
+    
+    # create job.sh
+    jobsh <- gsub("@HOST_SETUP@", hostsetup, jobsh)
+    jobsh <- gsub("@HOST_TEARDOWN@", hostteardown, jobsh)
+    
+    jobsh <- gsub("@SITE_LAT@", settings$run$site$lat, jobsh)
+    jobsh <- gsub("@SITE_LON@", settings$run$site$lon, jobsh)
+    jobsh <- gsub("@SITE_MET@", settings$run$input$met$path, jobsh)
+    
+    jobsh <- gsub("@START_DATE@", settings$run$start.date, jobsh)
+    jobsh <- gsub("@END_DATE@", settings$run$end.date, jobsh)
+    
+    jobsh <- gsub("@OUTDIR@", outdir, jobsh)
+    jobsh <- gsub("@RUNDIR@", rundir, jobsh)
+    
+    jobsh <- gsub("@BINARY@", settings$model$binary, jobsh)
+    
+    writeLines(jobsh, con = file.path(settings$rundir, run.id, "job.sh"))
+    Sys.chmod(file.path(settings$rundir, run.id, "job.sh"))
+} # write.config.GDAY


### PR DESCRIPTION
Ran through formatR::tidy_dir with arrow=TRUE and indent=2; made sure all if blocks have braces; took advantage of paste0 and file.path; changed require calls to library. Tried to make sure formatR didn’t make things too jaggy. Moved ellipses to end of met2model definition.

Fixes issue #1049.