### PR TITLE
Style cleanup for `models/maespa/R/*.R` scripts 

### DIFF
--- a/models/maespa/R/met2model.MAESPA.R
+++ b/models/maespa/R/met2model.MAESPA.R
@@ -1,17 +1,17 @@
 #-------------------------------------------------------------------------------
 # Copyright (c) 2012 University of Illinois, NCSA.
 # All rights reserved. This program and the accompanying materials
-# are made available under the terms of the
+# are made available under the terms of the 
 # University of Illinois/NCSA Open Source License
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-#
-## R Code to convert NetCDF CF met files into MAESPA met files
 
-##If files already exist in "Outfolder", the default function is NOT to overwrite them and
-##only gives user the notice that file already exists. If user wants to overwrite the existing files, just change
-##overwrite statement below to TRUE.
+# R Code to convert NetCDF CF met files into MAESPA met files
+
+## If files already exist in 'Outfolder', the default function is NOT to overwrite them and only
+## gives user the notice that file already exists. If user wants to overwrite the existing files,
+## just change overwrite statement below to TRUE.
 
 ##' met2model wrapper for MAESPA
 ##'
@@ -26,189 +26,178 @@
 ##' @param verbose should the function be very verbose
 ##'
 ##' @author Tony Gardella
-
-met2model.MAESPA <- function(in.path, in.prefix, outfolder, start_date,
-                             end_date, ..., overwrite=FALSE,verbose=FALSE) {
-                             
+met2model.MAESPA <- function(in.path, in.prefix, outfolder, start_date, end_date, 
+                             overwrite = FALSE, verbose = FALSE, ...) {
+  
   library(PEcAn.utils)
-                
+  
   print("START met2model.MAESPA")
   start.date <- as.POSIXlt(start_date, tz = "GMT")
-  end.date <-as.POSIXlt(end_date, tz = "GMT")
+  end.date <- as.POSIXlt(end_date, tz = "GMT")
   
-  out.file <-paste(in.prefix, 
-                   strptime(start.date, "%Y-%m-%d"),
-                   strptime(end.date, "%Y-%m-%d"),
-                   "dat", 
-                   sep =".")
+  out.file <- paste(in.prefix, 
+                    strptime(start.date, "%Y-%m-%d"), 
+                    strptime(end.date, "%Y-%m-%d"), 
+                    "dat", 
+                    sep = ".")
   
-  out.file.full <-file.path(outfolder, out.file)
-                             
+  out.file.full <- file.path(outfolder, out.file)
+  
   results <- data.frame(file = out.file.full,
                         host = fqdn(),
-                        mimetype = 'text/plain',
-                        formatname = 'maespa.met' ,
-                        startdate = start_date ,
+                        mimetype = "text/plain", 
+                        formatname = "maespa.met", 
+                        startdate = start_date,
                         enddate = end_date,
-                        dbfile.name = out.file,
+                        dbfile.name = out.file, 
                         stringsAsFactors = FALSE)
   
- print("internal results")
- print(results)
-                             
- if (file.exists(out.file.full) && !overwrite) {
-                               logger.debug("File '", out.file.full,
-                                            "' already exists, skipping to next file.")
-                               return(invisible(results))
-                             }
-                             
-                             
- library(ncdf4)
- library(lubridate)
- library(PEcAn.data.atmosphere)
- library(Maeswrap)
- 
- ## check to see if the outfolder is defined, if not create directory for output
- if (!file.exists(outfolder)) {
-   dir.create(outfolder)
- }
- 
- out <- NULL
- 
- # get start/end year since inputs are specified on year basis
- start_year <- year(start.date)
- end_year <- year(end.date)
- 
- ## loop over files
- for (year in start_year:end_year) {
-   print(year)
-   
-   old.file <-
-     file.path(in.path, paste(in.prefix, year, "nc", sep = "."))
-   
-   if (file.exists(old.file)) {
-     ## open netcdf
-     nc <- nc_open(old.file)
-     ## convert time to seconds
-     sec   <- nc$dim$time$vals
-     sec <- udunits2::ud.convert(sec,unlist(strsplit(nc$dim$time$units," "))[1],"seconds")
-     
-     ifelse(
-       leap_year(year),
-       dt <-(366 * 24 * 60 * 60) / length(sec), #leap year
-       dt <-(365 * 24 * 60 * 60) / length(sec)
-     ) #non-leap year
-     tstep <- round(86400 / dt)
-     dt <- 86400 / tstep
-     
-     #Check wich variabales are available and which are not
-     
-     ## extract variables
-     lat <- ncvar_get(nc,"latitude")
-     lon <- ncvar_get(nc,"longitude")
-     RAD <- ncvar_get(nc,"surface_downwelling_shortwave_flux_in_air") #W m-2
-     PAR <- try(ncvar_get(nc,"surface_downwelling_photosynthetic_photon_flux_in_air")) #mol m-2 s-1
-     TAIR <- ncvar_get(nc,"air_temperature") # K
-     QAIR <- ncvar_get(nc,"specific_humidity")# 1
-     PPT <- ncvar_get(nc,"precipitation_flux") #kg m-2 s-1
-     CA <- try(ncvar_get(nc,"mole_fraction_of_carbon_dioxide_in_air")) #mol/mol
-     PRESS <- ncvar_get(nc,"air_pressure")# Pa
-     
-     ##Convert specific humidity to fractional relative humidity
-     RH <- qair2rh(QAIR,TAIR,PRESS)
- 
-     ## Process PAR
-     if (!is.numeric(PAR)) {
-       #Function from data.atmosphere will convert SW to par in W/m2
-       PAR <- sw2par(RAD)
-     }else{
-       #convert
-       PAR <- udunits2::ud.convert(PAR,"mol","umol")
-     }
-
-     # Convert air temperature to Celsius 
-     TAIR <- udunits2::ud.convert(TAIR,"kelvin","celsius")
-     
-     ####ppm. atmospheric CO2 concentration. Constant from Environ namelist used instead if CA is nonexistant
-     defaultCO2 = 400
-     if (!is.numeric(CA)) {
-       print(
-         "Atmospheric CO2 concentration will be set to constant value set in ENVIRON namelist "
-       )
-       rm(CA)
-     } else {
-       CA <- CA*1e6
-     } 
-     
-     nc_close(nc)
-   } else {
-     print("Skipping to next year")
-     next
-   }
-   
-   if (exists("CA")){
-   tmp <- cbind(TAIR,PPT,RAD,PRESS,PAR,RH,CA)
-   } else {
-   tmp <- cbind(TAIR,PPT,RAD,PRESS,PAR,RH)
-   }
-   
-   if (is.null(out)) {
-     out = tmp
-   } else {
-     out = rbind(out,tmp)
-   }
-   
- }### end loop over years
- 
- ### Check for NA
- if(anyNA(out)){
-   logger.debug("NA introduced in met data. Maespa will not be able to run properly. Please change Met Data Source or Site")
- } else {
-   logger.debug("No NA values contained in data")
- }
- 
- ## Set Variable names
- columnnames <- colnames(out)
-
- #Set number of timesteps in a day(timetsep of input data)
- timesteps <- tstep
- # Set distribution of diffuse radiation incident from the sky.(0.0) is default.
- difsky <- 0.5
- #Change format of date to DD/MM/YY
- startdate <- paste0(format(as.Date(start_date),"%d/%m/%y"))
- enddate <- paste0(format(as.Date(end_date),"%d/%m/%y"))
- 
- ## Units of Latitude and longitude
- if (nc$dim$latitude$units == "degree_north") {
-   latunits = "N"
- }else{
-   latunits = "S"
- }
- 
- if (nc$dim$longitude$units == "degree_east") {
-   lonunits = "E"
- }else{
-   lonunits = "W"
- }
- 
- ##Write output met.dat file
- metfile <- system.file("met.dat",
-                        package = "PEcAn.MAESPA")
- 
- met.dat <- replacemetdata(out,
-                           oldmetfile = metfile,
-                           newmetfile = out.file.full)
- 
- 
- replacePAR(out.file.full, "difsky","environ", newval = difsky, noquotes = TRUE)
- replacePAR(out.file.full, "ca","environ", newval = defaultCO2, noquotes = TRUE)
- replacePAR(out.file.full, "lat","latlong", newval = lat, noquotes = TRUE)
- replacePAR(out.file.full, "long","latlong", newval = lon, noquotes = TRUE)
- replacePAR(out.file.full, "lonhem","latlong", newval = lonunits, noquotes = TRUE)
- replacePAR(out.file.full, "lathem","latlong", newval = latunits, noquotes = TRUE)
- replacePAR(out.file.full, "startdate","metformat", newval = startdate, noquotes = TRUE)
- replacePAR(out.file.full, "enddate","metformat", newval = enddate, noquotes = TRUE)
- replacePAR(out.file.full, "columns","metformat", newval = columnnames, noquotes = TRUE)
- 
- invisible(results)
- }  ### End of function
+  print("internal results")
+  print(results)
+  
+  if (file.exists(out.file.full) && !overwrite) {
+    logger.debug("File '", out.file.full, "' already exists, skipping to next file.")
+    return(invisible(results))
+  }
+  
+  library(ncdf4)
+  library(lubridate)
+  library(PEcAn.data.atmosphere)
+  library(Maeswrap)
+  
+  ## check to see if the outfolder is defined, if not create directory for output
+  if (!file.exists(outfolder)) {
+    dir.create(outfolder)
+  }
+  
+  out <- NULL
+  
+  # get start/end year since inputs are specified on year basis
+  start_year <- year(start.date)
+  end_year <- year(end.date)
+  
+  ## loop over files
+  for (year in start_year:end_year) {
+    print(year)
+    
+    old.file <- file.path(in.path, paste(in.prefix, year, "nc", sep = "."))
+    
+    if (file.exists(old.file)) {
+      ## open netcdf
+      nc <- nc_open(old.file)
+      ## convert time to seconds
+      sec <- nc$dim$time$vals
+      sec <- udunits2::ud.convert(sec, unlist(strsplit(nc$dim$time$units, " "))[1], "seconds")
+      
+      dt <- ifelse(leap_year(year) == TRUE, 
+                   366 * 24 * 60 * 60 / length(sec), # leap year
+                   365 * 24 * 60 * 60 / length(sec)) # non-leap year
+      tstep <- round(86400 / dt)
+      dt <- 86400 / tstep
+      
+      # Check wich variables are available and which are not
+      
+      ## extract variables
+      lat   <- ncvar_get(nc, "latitude")
+      lon   <- ncvar_get(nc, "longitude")
+      RAD   <- ncvar_get(nc, "surface_downwelling_shortwave_flux_in_air")  #W m-2
+      PAR   <- try(ncvar_get(nc, "surface_downwelling_photosynthetic_photon_flux_in_air"))  #mol m-2 s-1
+      TAIR  <- ncvar_get(nc, "air_temperature")  # K
+      QAIR  <- ncvar_get(nc, "specific_humidity")  # 1
+      PPT   <- ncvar_get(nc, "precipitation_flux")  #kg m-2 s-1
+      CA    <- try(ncvar_get(nc, "mole_fraction_of_carbon_dioxide_in_air"))  #mol/mol
+      PRESS <- ncvar_get(nc, "air_pressure")  # Pa
+      
+      ## Convert specific humidity to fractional relative humidity
+      RH <- qair2rh(QAIR, TAIR, PRESS)
+      
+      ## Process PAR
+      if (!is.numeric(PAR)) {
+        # Function from data.atmosphere will convert SW to par in W/m2
+        PAR <- sw2par(RAD)
+      } else {
+        # convert
+        PAR <- udunits2::ud.convert(PAR, "mol", "umol")
+      }
+      
+      # Convert air temperature to Celsius
+      TAIR <- udunits2::ud.convert(TAIR, "kelvin", "celsius")
+      
+      #### ppm. atmospheric CO2 concentration. 
+      ### Constant from Environ namelist used instead if CA is nonexistent
+      defaultCO2 <- 400
+      if (!is.numeric(CA)) {
+        print("Atmospheric CO2 concentration will be set to constant value set in ENVIRON namelist ")
+        rm(CA)
+      } else {
+        CA <- CA * 1e+06
+      }
+      
+      nc_close(nc)
+    } else {
+      print("Skipping to next year")
+      next
+    }
+    
+    if (exists("CA")) {
+      tmp <- cbind(TAIR, PPT, RAD, PRESS, PAR, RH, CA)
+    } else {
+      tmp <- cbind(TAIR, PPT, RAD, PRESS, PAR, RH)
+    }
+    
+    if (is.null(out)) {
+      out <- tmp
+    } else {
+      out <- rbind(out, tmp)
+    }
+    
+  }  ### end loop over years
+  
+  ### Check for NA
+  if (anyNA(out)) {
+    logger.debug("NA introduced in met data. Maespa will not be able to run properly. Please change Met Data Source or Site")
+  } else {
+    logger.debug("No NA values contained in data")
+  }
+  
+  ## Set Variable names
+  columnnames <- colnames(out)
+  
+  # Set number of timesteps in a day(timetsep of input data)
+  timesteps <- tstep
+  # Set distribution of diffuse radiation incident from the sky.(0.0) is default.
+  difsky <- 0.5
+  # Change format of date to DD/MM/YY
+  startdate <- paste0(format(as.Date(start_date), "%d/%m/%y"))
+  enddate <- paste0(format(as.Date(end_date), "%d/%m/%y"))
+  
+  ## Units of Latitude and longitude
+  if (nc$dim$latitude$units == "degree_north") {
+    latunits <- "N"
+  } else {
+    latunits <- "S"
+  }
+  
+  if (nc$dim$longitude$units == "degree_east") {
+    lonunits <- "E"
+  } else {
+    lonunits <- "W"
+  }
+  
+  ## Write output met.dat file
+  metfile <- system.file("met.dat", package = "PEcAn.MAESPA")
+  
+  met.dat <- replacemetdata(out, oldmetfile = metfile, newmetfile = out.file.full)
+  
+  replacePAR(out.file.full, "difsky", "environ", newval = difsky, noquotes = TRUE)
+  replacePAR(out.file.full, "ca", "environ", newval = defaultCO2, noquotes = TRUE)
+  replacePAR(out.file.full, "lat", "latlong", newval = lat, noquotes = TRUE)
+  replacePAR(out.file.full, "long", "latlong", newval = lon, noquotes = TRUE)
+  replacePAR(out.file.full, "lonhem", "latlong", newval = lonunits, noquotes = TRUE)
+  replacePAR(out.file.full, "lathem", "latlong", newval = latunits, noquotes = TRUE)
+  replacePAR(out.file.full, "startdate", "metformat", newval = startdate, noquotes = TRUE)
+  replacePAR(out.file.full, "enddate", "metformat", newval = enddate, noquotes = TRUE)
+  replacePAR(out.file.full, "columns", "metformat", newval = columnnames, noquotes = TRUE)
+  
+  invisible(results)
+} # met2model.MAESPA

--- a/models/maespa/R/model2netcdf.MAESPA.R
+++ b/models/maespa/R/model2netcdf.MAESPA.R
@@ -1,8 +1,11 @@
-# ------------------------------------------------------------------------------- Copyright (c) 2012
-# University of Illinois, NCSA.  All rights reserved. This program and the accompanying materials are
-# made available under the terms of the University of Illinois/NCSA Open Source License which
-# accompanies this distribution, and is available at http://opensource.ncsa.illinois.edu/license.html
-# -------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+# Copyright (c) 2012 University of Illinois, NCSA.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the 
+# University of Illinois/NCSA Open Source License
+# which accompanies this distribution, and is available at
+# http://opensource.ncsa.illinois.edu/license.html
+#-------------------------------------------------------------------------------
 
 ## -------------------------------------------------------------------------------------------------#
 ##' Convert MAESPA output into the NACP Intercomparison format (ALMA using netCDF)
@@ -20,82 +23,77 @@
 ##'
 ##' @author Tony Gardella
 model2netcdf.MAESPA <- function(outdir, sitelat, sitelon, start_date, end_date, stem_density) {
+  
+  library(ncdf4)
+  library(lubridate)
+  library(Maeswrap)
+  
+  ### Read in model output using Maeswrap. Dayflx.dat, watbalday.dat
+  
+  dayflx.dataframe <- readdayflux(filename = "Dayflx.dat")
+  
+  watbalday.dataframe <- readwatbal(filename = "watbalday.dat")
+  
+  # moles of Carbon to kilograms
+  mole2kg_C <- 0.0120107
+  # Seconds in a day
+  secINday <- 60 * 60 * 24
+  
+  ### Determine number of years and output timestep
+  start_date <- as.POSIXlt(start_date, tz = "GMT")
+  end_date <- as.POSIXlt(end_date, tz = "GMT")
+  start_year <- year(start_date)
+  end_year <- year(end_date)
+  years <- start_year:end_year
+  
+  for (y in years) {
+    if (file.exists(file.path(outdir, paste(y, "nc", sep = ".")))) {
+      next
+    }
+    print(paste("---- Processing year: ", y))  # turn on for debugging
     
-    library(ncdf4)
-    library(lubridate)
-    library(Maeswrap)
+    ## Setup outputs for netCDF file in appropriate units
+    output <- list()
+    output[[1]] <- (dayflx.dataframe$totPs) * mole2kg_C * stem_density  # (GPP) gross photosynthesis. mol tree-1 d-1 -> kg C m-2 s-1
+    output[[2]] <- (dayflx.dataframe$netPs) * mole2kg_C * stem_density  # (NPP) photosynthesis net of foliar resp mol tree-1 d-1 -> kg C m-2 s-1
+    output[[3]] <- (watbalday.dataframe$et)/secINday  # (Tveg) modeled canopy transpiration   mm -> kg m-2 s-1
+    output[[4]] <- (watbalday.dataframe$qh) * 1e+06  # (Qh) Sensible heat flux MJ m-2 day-1 -> W m-2
+    output[[5]] <- (watbalday.dataframe$qe) * 1e+06  # (Qle)latent Heat flux MJ m-2 day-1 -> W m-2
     
+    # ******************** Declare netCDF variables ********************#
+    t <- ncdim_def(name = "time", 
+                   units = paste0("days since ", y, "-01-01 00:00:00"), 
+                   vals = (dayflx.dataframe$DOY), 
+                   calendar = "standard", 
+                   unlim = TRUE)
+    lat <- ncdim_def("lat", "degrees_east", vals = as.numeric(sitelat), longname = "station_latitude")
+    lon <- ncdim_def("lon", "degrees_north", vals = as.numeric(sitelon), longname = "station_longitude")
     
-    ### Read in model output using Maeswrap. Dayflx.dat, watbalday.dat
+    for (i in seq_along(output)) {
+      if (length(output[[i]]) == 0) 
+        output[[i]] <- rep(-999, length(t$vals))
+    }
     
+    mstmipvar <- PEcAn.utils::mstmipvar
+    var      <- list()
+    var[[1]] <- ncvar_def("GPP", units = ("kg C m-2 s-1"), dim = list(lat, lon, t), missval = -999, 
+                          longname = "Gross Primary Production")
+    var[[2]] <- ncvar_def("NPP", units = ("kg C m-2 s-1"), dim = list(lat, lon, t), missval = -999, 
+                          longname = " Net Primary Production")
+    var[[3]] <- ncvar_def("TVeg", units = ("kg m-2 s-1"), dim = list(lat, lon, t), missval = -999, 
+                          longname = "EvapoTranpiration")
+    var[[4]] <- ncvar_def("Qh", units = ("W m-2"), dim = list(lat, lon, t), missval = -999, longname = "Sensible Heat Flux")
+    var[[5]] <- ncvar_def("Qle", units = ("W m-2"), dim = list(lat, lon, t), missval = -999, longname = "latent Heat Flux")
     
-    dayflx.dataframe <- readdayflux(filename = "Dayflx.dat")
-    
-    watbalday.dataframe <- readwatbal(filename = "watbalday.dat")
-    
-    # moles of Carbon to kilograms
-    mole2kg_C <- 0.0120107
-    # Seconds in a day
-    secINday <- 60 * 60 * 24
-    
-    ### Determine number of years and output timestep
-    start_date <- as.POSIXlt(start_date, tz = "GMT")
-    end_date <- as.POSIXlt(end_date, tz = "GMT")
-    start_year <- year(start_date)
-    end_year <- year(end_date)
-    years <- start_year:end_year
-    
-    
-    for (y in years) {
-        if (file.exists(file.path(outdir, paste(y, "nc", sep = ".")))) {
-            next
-        }
-        print(paste("---- Processing year: ", y))  # turn on for debugging
-        
-        
-        ## Setup outputs for netCDF file in appropriate units
-        output <- list()
-        output[[1]] <- (dayflx.dataframe$totPs) * mole2kg_C * stem_density  #(GPP) gross photosynthesis. mol tree-1 d-1 -> kg C m-2 s-1
-        output[[2]] <- (dayflx.dataframe$netPs) * mole2kg_C * stem_density  #(NPP) photosynthesis net of foliar resp mol tree-1 d-1 -> kg C m-2 s-1
-        output[[3]] <- (watbalday.dataframe$et)/secINday  #(Tveg) modeled canopy transpiration   mm -> kg m-2 s-1
-        output[[4]] <- (watbalday.dataframe$qh) * 1e+06  #(Qh) Sensible heat flux MJ m-2 day-1 -> W m-2
-        output[[5]] <- (watbalday.dataframe$qe) * 1e+06  #(Qle)latent Heat flux MJ m-2 day-1 -> W m-2
-        
-        # ******************** Declare netCDF variables ********************#
-        t <- ncdim_def(name = "time", units = paste0("days since ", y, "-01-01 00:00:00"), vals = (dayflx.dataframe$DOY), 
-            calendar = "standard", unlim = TRUE)
-        lat <- ncdim_def("lat", "degrees_east", vals = as.numeric(sitelat), longname = "station_latitude")
-        lon <- ncdim_def("lon", "degrees_north", vals = as.numeric(sitelon), longname = "station_longitude")
-        
-        for (i in 1:length(output)) {
-            if (length(output[[i]]) == 0) 
-                output[[i]] <- rep(-999, length(t$vals))
-        }
-        
-        mstmipvar <- PEcAn.utils::mstmipvar
-        var <- list()
-        var[[1]] <- ncvar_def("GPP", units = ("kg C m-2 s-1"), dim = list(lat, lon, t), missval = -999, 
-            longname = "Gross Primary Production")
-        var[[2]] <- ncvar_def("NPP", units = ("kg C m-2 s-1"), dim = list(lat, lon, t), missval = -999, 
-            longname = " Net Primary Production")
-        var[[3]] <- ncvar_def("TVeg", units = ("kg m-2 s-1"), dim = list(lat, lon, t), missval = -999, 
-            longname = "EvapoTranpiration")
-        var[[4]] <- ncvar_def("Qh", units = ("W m-2"), dim = list(lat, lon, t), missval = -999, longname = "Sensible Heat Flux")
-        var[[5]] <- ncvar_def("Qle", units = ("W m-2"), dim = list(lat, lon, t), missval = -999, longname = "latent Heat Flux")
-        
-        
-        ### Output netCDF data
-        nc <- nc_create(file.path(outdir, paste(y, "nc", sep = ".")), var)
-        varfile <- file(file.path(outdir, paste(y, "nc", "var", sep = ".")), "w")
-        for (i in 1:length(var)) {
-            # print(i)
-            ncvar_put(nc, var[[i]], output[[i]])
-            cat(paste(var[[i]]$name, var[[i]]$longname), file = varfile, sep = "\n")
-        }
-        close(varfile)
-        nc_close(nc)
-    }  ### End of year loop
-    
-    
-    
-}  ### End of function  
+    ### Output netCDF data
+    nc <- nc_create(file.path(outdir, paste(y, "nc", sep = ".")), var)
+    varfile <- file(file.path(outdir, paste(y, "nc", "var", sep = ".")), "w")
+    for (i in seq_along(var)) {
+      # print(i)
+      ncvar_put(nc, var[[i]], output[[i]])
+      cat(paste(var[[i]]$name, var[[i]]$longname), file = varfile, sep = "\n")
+    }
+    close(varfile)
+    nc_close(nc)
+  }  ### End of year loop
+} # model2netcdf.MAESPA

--- a/models/maespa/R/write.config.MAESPA.R
+++ b/models/maespa/R/write.config.MAESPA.R
@@ -1,8 +1,11 @@
-# ------------------------------------------------------------------------------- Copyright (c) 2012
-# University of Illinois, NCSA.  All rights reserved. This program and the accompanying materials are
-# made available under the terms of the University of Illinois/NCSA Open Source License which
-# accompanies this distribution, and is available at http://opensource.ncsa.illinois.edu/license.html
-# -------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+# Copyright (c) 2012 University of Illinois, NCSA.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the 
+# University of Illinois/NCSA Open Source License
+# which accompanies this distribution, and is available at
+# http://opensource.ncsa.illinois.edu/license.html
+#-------------------------------------------------------------------------------
 
 ## -------------------------------------------------------------------------------------------------#
 ##' Writes a config file for Maespa
@@ -20,10 +23,10 @@
 ##' @export
 ##' @author Tony Gardella
 ##-------------------------------------------------------------------------------------------------#
-write.config.MAESPA <- function(defaults, trait.values, settings, run.id){
-
+write.config.MAESPA <- function(defaults, trait.values, settings, run.id) {
+  
   library(Maeswrap)
-
+  
   # find out where to write run/ouput
   rundir <- file.path(settings$host$rundir, as.character(run.id))
   outdir <- file.path(settings$host$outdir, as.character(run.id))
@@ -34,34 +37,33 @@ write.config.MAESPA <- function(defaults, trait.values, settings, run.id){
   #-----------------------------------------------------------------------
   # create launch script (which will create symlink)
   if (!is.null(settings$model$jobtemplate) && file.exists(settings$model$jobtemplate)) {
-    jobsh <- readLines(con=settings$model$jobtemplate, n=-1)
+    jobsh <- readLines(con = settings$model$jobtemplate, n = -1)
   } else {
-    jobsh <- readLines(con=system.file("template.job", package = "PEcAn.MAESPA"), n=-1)
+    jobsh <- readLines(con = system.file("template.job", package = "PEcAn.MAESPA"), n = -1)
     
   }
   
   # create host specific setttings
   hostsetup <- ""
   if (!is.null(settings$model$prerun)) {
-    hostsetup <- paste(hostsetup, sep="\n", paste(settings$model$prerun, collapse="\n"))
+    hostsetup <- paste(hostsetup, sep = "\n", paste(settings$model$prerun, collapse = "\n"))
   }
   if (!is.null(settings$host$prerun)) {
-    hostsetup <- paste(hostsetup, sep="\n", paste(settings$host$prerun, collapse="\n"))
+    hostsetup <- paste(hostsetup, sep = "\n", paste(settings$host$prerun, collapse = "\n"))
   }
-
+  
   hostteardown <- ""
   if (!is.null(settings$model$postrun)) {
-    hostteardown <- paste(hostteardown, sep="\n", paste(settings$model$postrun, collapse="\n"))
+    hostteardown <- paste(hostteardown, sep = "\n", paste(settings$model$postrun, collapse = "\n"))
   }
   if (!is.null(settings$host$postrun)) {
-    hostteardown <- paste(hostteardown, sep="\n", paste(settings$host$postrun, collapse="\n"))
+    hostteardown <- paste(hostteardown, sep = "\n", paste(settings$host$postrun, collapse = "\n"))
   }
-
-  # ------------------------------------------------------------------------------------ 
-  #Begin writing input Maespa files
+  
+  # ------------------------------------------------------------------------------------ Begin
+  # writing input Maespa files
   
   ## Change Start/end Dates to dy/mo/yr
-  
   start_date <- format(strptime(settings$run$start.date, format = "%Y/%m/%d"), "%d/%m/%y")
   end_date <- format(strptime(settings$run$end.date, format = "%Y/%m/%d"), "%d/%m/%y")
   
@@ -77,7 +79,6 @@ write.config.MAESPA <- function(defaults, trait.values, settings, run.id){
   vcmax <- as.numeric(params["Vcmax"])
   jmax <- as.numeric(params["Jmax"])
   
-  
   ## Set default plot as 30x30 meter plot with 100 trees
   xmax <- 30
   ymax <- 30
@@ -85,8 +86,8 @@ write.config.MAESPA <- function(defaults, trait.values, settings, run.id){
   stem_density <- (xmax * ymax)/notrees
   
   ### Confile.dat
-  confile.path <- system.file("confile.dat", package = "PEcAn.MAESPA")
-  confile <- readLines(confile.path)
+  confile.path     <- system.file("confile.dat", package = "PEcAn.MAESPA")
+  confile          <- readLines(confile.path)
   confile.run.path <- file.path(settings$rundir, run.id, "confile.dat")
   writeLines(confile, con = confile.run.path)
   
@@ -96,14 +97,14 @@ write.config.MAESPA <- function(defaults, trait.values, settings, run.id){
   replacePAR(confile.run.path, "enddate", "dates", newval = end_date)
   
   ### str.dat USING DEFAULT EXAMPLE VERSION RIGHT NOW AS IS
-  strfile.path <- system.file("str.dat", package = "PEcAn.MAESPA")
-  strfile <- readLines(strfile.path)
+  strfile.path     <- system.file("str.dat", package = "PEcAn.MAESPA")
+  strfile          <- readLines(strfile.path)
   strfile.run.path <- file.path(settings$rundir, run.id, "str.dat")
   writeLines(strfile, con = strfile.run.path)
   
   ### phy.dat
-  phyfile.path <- system.file("phy.dat", package = "PEcAn.MAESPA")
-  phyfile <- readLines(phyfile.path)
+  phyfile.path     <- system.file("phy.dat", package = "PEcAn.MAESPA")
+  phyfile          <- readLines(phyfile.path)
   phyfile.run.path <- file.path(settings$rundir, run.id, "phy.dat")
   writeLines(phyfile, con = phyfile.run.path)
   
@@ -128,29 +129,27 @@ write.config.MAESPA <- function(defaults, trait.values, settings, run.id){
   watparsfile.run.path <- file.path(settings$rundir, run.id, "watpars.dat")
   writeLines(watparsfile, con = watparsfile.run.path)
   
-  #MET FILE
-  metdat <- settings$run$input$met$path 
+  # MET FILE
+  metdat <- settings$run$input$met$path
   
   #---------------------------------------------------------------------------------------------
-  #create job.sh
-  jobsh <- gsub('@HOST_SETUP@', hostsetup, jobsh)
-  jobsh <- gsub('@HOST_TEARDOWN@', hostteardown, jobsh)  
-
-  jobsh <- gsub('@SITE_LAT@', settings$run$site$lat, jobsh)
-  jobsh <- gsub('@SITE_LON@', settings$run$site$lon, jobsh)
+  # create job.sh
+  jobsh <- gsub("@HOST_SETUP@", hostsetup, jobsh)
+  jobsh <- gsub("@HOST_TEARDOWN@", hostteardown, jobsh)
+  
+  jobsh <- gsub("@SITE_LAT@", settings$run$site$lat, jobsh)
+  jobsh <- gsub("@SITE_LON@", settings$run$site$lon, jobsh)
   jobsh <- gsub("@SITE_MET@", metdat, jobsh)
   jobsh <- gsub("@STEM_DENS@", stem_density, jobsh)
   
-  jobsh <- gsub('@START_DATE@', settings$run$start.date, jobsh)
-  jobsh <- gsub('@END_DATE@', settings$run$end.date, jobsh)
+  jobsh <- gsub("@START_DATE@", settings$run$start.date, jobsh)
+  jobsh <- gsub("@END_DATE@", settings$run$end.date, jobsh)
   
-  jobsh <- gsub('@OUTDIR@', outdir, jobsh)
-  jobsh <- gsub('@RUNDIR@', rundir, jobsh)
+  jobsh <- gsub("@OUTDIR@", outdir, jobsh)
+  jobsh <- gsub("@RUNDIR@", rundir, jobsh)
   
-  jobsh <- gsub('@BINARY@', settings$model$binary, jobsh)
+  jobsh <- gsub("@BINARY@", settings$model$binary, jobsh)
   
-  writeLines(jobsh, con=file.path(settings$rundir, run.id, "job.sh"))
+  writeLines(jobsh, con = file.path(settings$rundir, run.id, "job.sh"))
   Sys.chmod(file.path(settings$rundir, run.id, "job.sh"))
-
-    
-}  ### END SCRIPT 
+} # write.config.MAESPA


### PR DESCRIPTION
Ran through formatR::tidy_dir with arrow=TRUE and indent=2; made sure all if blocks have braces. Tried to make sure formatR didn’t make things too jaggy. Moved ellipses to end of `met2model.MAESPA.R` declaration. Substituted `seq_len` and `seq_along`.