### PR TITLE
Style cleanup for `models/sipnet/R/*.R` scripts

### DIFF
--- a/models/sipnet/R/get.model.output.SIPNET.R
+++ b/models/sipnet/R/get.model.output.SIPNET.R
@@ -6,8 +6,6 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-#--------------------------------------------------------------------------------------------------#
-
 
 #--------------------------------------------------------------------------------------------------#
 ##' Function to retrieve model output from local or remote server
@@ -18,44 +16,34 @@
 ##' @import PEcAn.utils
 ##' @export
 get.model.output.SIPNET <- function(settings) {
-
-  model="SIPNET"
+  
+  model <- "SIPNET"
   
   ### Get model output on the localhost
-  if(settings$host$name == 'localhost'){
+  if (settings$host$name == "localhost") {
     get.results(settings)
-    
   } else {
-
-    ## model output is on a remote host
-    remoteScript = paste(settings$outdir,"PEcAn.functions.R",sep="")
-        
-    ### Make a copy of required functions and place in file PEcAn.functions.R
-    dump(c(paste("model2netcdf",model,sep="."),"get.run.id","read.ensemble.output","read.sa.output","read.output","get.results"),
-         file=remoteScript)
     
-    ### Add execution of get.results to the end of the PEcAn.functions.R file
-    ### This will execute all the code needed to extract output on remote host
-    cat("get.results()",file=remoteScript, append=TRUE)
-
+    ## model output is on a remote host
+    remoteScript <- paste(settings$outdir, "PEcAn.functions.R", sep = "")
+    
+    ### Make a copy of required functions and place in file PEcAn.functions.R
+    dump(c(paste("model2netcdf", model, sep = "."), "get.run.id", "read.ensemble.output", "read.sa.output", 
+      "read.output", "get.results"), file = remoteScript)
+    
+    ### Add execution of get.results to the end of the PEcAn.functions.R file This will execute all the
+    ### code needed to extract output on remote host
+    cat("get.results()", file = remoteScript, append = TRUE)
+    
     ### Copy required PEcAn.functions.R to remote host
-    rsync('-outi',remoteScript,
-          paste(settings$host$name, ':',settings$host$outdir, sep = '') )
-
+    rsync("-outi", remoteScript, paste(settings$host$name, ":", settings$host$outdir, sep = ""))
+    
     ### Run script on remote host
-    system(paste("ssh -T", settings$host$name, "'",
-             "cd", settings$host$outdir, "; R --vanilla < PEcAn.functions.R'"))
+    system(paste("ssh -T", settings$host$name, "'", "cd", settings$host$outdir, "; R --vanilla < PEcAn.functions.R'"))
     
     ### Get PEcAn output from remote host
-    rsync('-outi', from = paste(settings$host$name, ':', settings$host$outdir, 'output.Rdata', sep=''),
-      to = settings$outdir)
-
-  } ### End of if/else
+    rsync("-outi", from = paste(settings$host$name, ":", settings$host$outdir, "output.Rdata", 
+      sep = ""), to = settings$outdir)
+  }  ### End of if/else
   
-} ### End of function
-#==================================================================================================#
-
-
-####################################################################################################
-### EOF.  End of R script file.              
-####################################################################################################
+} # get.model.output.SIPNET

--- a/models/sipnet/R/met2model.SIPNET.R
+++ b/models/sipnet/R/met2model.SIPNET.R
@@ -6,12 +6,12 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-#
-## R Code to convert NetCDF CF met files into SIPNET met files
 
-##If files already exist in "Outfolder", the default function is NOT to overwrite them and 
-##only gives user the notice that file already exists. If user wants to overwrite the existing files, just change 
-##overwrite statement below to TRUE.
+# R Code to convert NetCDF CF met files into SIPNET met files
+
+## If files already exist in 'Outfolder', the default function is NOT to overwrite them and only
+## gives user the notice that file already exists. If user wants to overwrite the existing files,
+## just change overwrite statement below to TRUE.
 
 ##' met2model wrapper for SIPNET
 ##'
@@ -24,22 +24,26 @@
 ##' @param end_date the end date of the data to be downloaded (will only use the year part of the date)
 ##' @param overwrite should existing files be overwritten
 ##' @param verbose should the function be very verbose
-met2model.SIPNET <- function(in.path, in.prefix, outfolder, start_date, end_date, ..., overwrite=FALSE,verbose=FALSE){
+met2model.SIPNET <- function(in.path, in.prefix, outfolder, start_date, end_date, 
+                             overwrite = FALSE, verbose = FALSE, ...) {
   library(PEcAn.utils)
   
   print("START met2model.SIPNET")
   start_date <- as.POSIXlt(start_date, tz = "GMT")
-  end_date<- as.POSIXlt(end_date, tz = "GMT")
-  out.file <- paste(in.prefix, strptime(start_date, "%Y-%m-%d"),strptime(end_date, "%Y-%m-%d"),"clim", sep=".")
+  end_date <- as.POSIXlt(end_date, tz = "GMT")
+  out.file <- paste(in.prefix, strptime(start_date, "%Y-%m-%d"), 
+                    strptime(end_date, "%Y-%m-%d"), 
+                    "clim", 
+                    sep = ".")
   out.file.full <- file.path(outfolder, out.file)
   
-  results <- data.frame(file = out.file.full,
-                        host = fqdn(),
-                        mimetype ='text/csv',
-                        formatname = 'Sipnet.climna' ,
-                        startdate = start_date ,
-                        enddate = end_date,
-                        dbfile.name = out.file,
+  results <- data.frame(file = out.file.full, 
+                        host = fqdn(), 
+                        mimetype = "text/csv", 
+                        formatname = "Sipnet.climna", 
+                        startdate = start_date, 
+                        enddate = end_date, 
+                        dbfile.name = out.file, 
                         stringsAsFactors = FALSE)
   print("internal results")
   print(results)
@@ -49,13 +53,12 @@ met2model.SIPNET <- function(in.path, in.prefix, outfolder, start_date, end_date
     return(invisible(results))
   }
   
-  require(ncdf4)
-  require(lubridate)
-  require(PEcAn.data.atmosphere)
-  #  require(ncdf)
+  library(ncdf4)
+  library(lubridate)
+  library(PEcAn.data.atmosphere)
   
   ## check to see if the outfolder is defined, if not create directory for output
-  if(!file.exists(outfolder)){
+  if (!file.exists(outfolder)) {
     dir.create(outfolder)
   }
   
@@ -65,64 +68,67 @@ met2model.SIPNET <- function(in.path, in.prefix, outfolder, start_date, end_date
   start_year <- year(start_date)
   end_year <- year(end_date)
   
-  ## loop over files
-  # TODO need to filter out the data that is not inside start_date, end_date
-  for(year in start_year:end_year) {
+  ## loop over files TODO need to filter out the data that is not inside start_date, end_date
+  for (year in start_year:end_year) {
     
     skip <- FALSE
     print(year)
     
-    old.file <- file.path(in.path, paste(in.prefix, year, "nc", sep="."))
+    old.file <- file.path(in.path, paste(in.prefix, year, "nc", sep = "."))
     
-    if(file.exists(old.file)){
+    if (file.exists(old.file)) {
       ## open netcdf
       nc <- nc_open(old.file)
       
       ## convert time to seconds
-      sec   <- nc$dim$time$vals  
-      sec = udunits2::ud.convert(sec,unlist(strsplit(nc$dim$time$units," "))[1],"seconds")
+      sec <- nc$dim$time$vals
+      sec <- udunits2::ud.convert(sec, unlist(strsplit(nc$dim$time$units, " "))[1], "seconds")
       
-      ifelse(leap_year(year)==TRUE,
-             dt <- (366*24*60*60)/length(sec), #leap year
-             dt <- (365*24*60*60)/length(sec)) #non-leap year
-      tstep = round(86400/dt)
-      dt = 86400/tstep
+      dt <- ifelse(leap_year(year) == TRUE, 
+                   366 * 24 * 60 * 60 / length(sec), # leap year
+                   365 * 24 * 60 * 60 / length(sec)) # non-leap year
+      tstep <- round(86400 / dt)
+      dt <- 86400 / tstep
       
       ## extract variables
-      lat  <- ncvar_get(nc,"latitude")
-      lon  <- ncvar_get(nc,"longitude")
-      Tair <- ncvar_get(nc,"air_temperature")  ## in Kelvin
-      Qair <- ncvar_get(nc,"specific_humidity")  #humidity (kg/kg)
-      ws <- try(ncvar_get(nc,"wind_speed"))
-      if(!is.numeric(ws)) {
-        U <- ncvar_get(nc,"eastward_wind")
-        V <- ncvar_get(nc,"northward_wind")
-        ws = sqrt(U^2+V^2)
+      lat <- ncvar_get(nc, "latitude")
+      lon <- ncvar_get(nc, "longitude")
+      Tair <- ncvar_get(nc, "air_temperature")  ## in Kelvin
+      Qair <- ncvar_get(nc, "specific_humidity")  #humidity (kg/kg)
+      ws <- try(ncvar_get(nc, "wind_speed"))
+      if (!is.numeric(ws)) {
+        U <- ncvar_get(nc, "eastward_wind")
+        V <- ncvar_get(nc, "northward_wind")
+        ws <- sqrt(U ^ 2 + V ^ 2)
       }
       
-      Rain <- ncvar_get(nc,"precipitation_flux")
-#      pres <- ncvar_get(nc,"air_pressure") ## in pascal
-      SW   <- ncvar_get(nc,"surface_downwelling_shortwave_flux_in_air") ## in W/m2
+      Rain <- ncvar_get(nc, "precipitation_flux")
+      # pres <- ncvar_get(nc,'air_pressure') ## in pascal
+      SW <- ncvar_get(nc, "surface_downwelling_shortwave_flux_in_air")  ## in W/m2
       
-      PAR  <- try(ncvar_get(nc,"surface_downwelling_photosynthetic_photon_flux_in_air")) ## in mol/m2/s
-      if(!is.numeric(PAR)) PAR = SW*0.45 
-      
-      soilT <- try(ncvar_get(nc,"soil_temperature"))
-      if(!is.numeric(soilT)){
-        #approximation borrowed from SIPNET CRUNCEPpreprocessing's tsoil.py
-        tau = 15.0*tstep
-        filt = exp(-(1:length(Tair))/tau)
-        filt = (filt/sum(filt))
-        soilT = convolve(Tair, filt) - 273.15
-      } else soilT <- soilT - 273.15
-      
-      SVP = ud.convert(get.es(Tair-273.15),"millibar","Pa") ## Saturation vapor pressure
-      VPD <- try(ncvar_get(nc,"water_vapor_saturation_deficit"))  ## in Pa
-      if(!is.numeric(VPD)){
-        VPD = SVP*(1-qair2rh(Qair,Tair-273.15))
+      PAR <- try(ncvar_get(nc, "surface_downwelling_photosynthetic_photon_flux_in_air"))  ## in mol/m2/s
+      if (!is.numeric(PAR)) {
+        PAR <- SW * 0.45
       }
-      e_a = SVP - VPD
-      VPDsoil = ud.convert(get.es(soilT),"millibar","Pa")*(1-qair2rh(Qair,soilT))
+      
+      soilT <- try(ncvar_get(nc, "soil_temperature"))
+      if (!is.numeric(soilT)) {
+        # approximation borrowed from SIPNET CRUNCEPpreprocessing's tsoil.py
+        tau <- 15 * tstep
+        filt <- exp(-(1:length(Tair)) / tau)
+        filt <- (filt / sum(filt))
+        soilT <- convolve(Tair, filt) - 273.15
+      } else {
+        soilT <- soilT - 273.15
+      }
+      
+      SVP <- ud.convert(get.es(Tair - 273.15), "millibar", "Pa")  ## Saturation vapor pressure
+      VPD <- try(ncvar_get(nc, "water_vapor_saturation_deficit"))  ## in Pa
+      if (!is.numeric(VPD)) {
+        VPD <- SVP * (1 - qair2rh(Qair, Tair - 273.15))
+      }
+      e_a <- SVP - VPD
+      VPDsoil <- ud.convert(get.es(soilT), "millibar", "Pa") * (1 - qair2rh(Qair, soilT))
       
       nc_close(nc)
     } else {
@@ -130,91 +136,93 @@ met2model.SIPNET <- function(in.path, in.prefix, outfolder, start_date, end_date
       next
     }
     
-    ##build time variables (year, month, day of year)
-    nyr <- floor(length(sec)/86400/365*dt)
+    ## build time variables (year, month, day of year)
+    nyr <- floor(length(sec) / 86400 / 365 * dt)
     yr <- NULL
     doy <- NULL
     hr <- NULL
     asec <- sec
-    for(y in year+1:nyr-1){
-      ytmp <- rep(y,365*86400/dt)
-      dtmp <- rep(1:365,each=86400/dt)
-      if(y %% 4 == 0){  ## is leap
-        ytmp <- rep(y,366*86400/dt)
-        dtmp <- rep(1:366,each=86400/dt)
+    for (y in year + 1:nyr - 1) {
+      ytmp <- rep(y, 365 * 86400 / dt)
+      dtmp <- rep(1:365, each = 86400 / dt)
+      if (y%%4 == 0) {
+        ## is leap
+        ytmp <- rep(y, 366 * 86400 / dt)
+        dtmp <- rep(1:366, each = 86400 / dt)
       }
-      if(is.null(yr)){
+      if (is.null(yr)) {
         yr <- ytmp
         doy <- dtmp
-        hr <- rep(NA,length(dtmp))
+        hr <- rep(NA, length(dtmp))
       } else {
-        yr <- c(yr,ytmp)
-        doy <- c(doy,dtmp)
-        hr <- c(hr,rep(NA,length(dtmp)))
+        yr <- c(yr, ytmp)
+        doy <- c(doy, dtmp)
+        hr <- c(hr, rep(NA, length(dtmp)))
       }
       rng <- length(doy) - length(ytmp):1 + 1
-      if(!all(rng>=0)){
-        skip = TRUE
-        logger.warn(paste(year,"is not a complete year and will not be included"))
+      if (!all(rng >= 0)) {
+        skip <- TRUE
+        logger.warn(paste(year, "is not a complete year and will not be included"))
         break
       }
       asec[rng] <- asec[rng] - asec[rng[1]]
-      hr[rng] <- (asec[rng] - (dtmp-1)*86400)/86400*24
+      hr[rng] <- (asec[rng] - (dtmp - 1) * 86400) / 86400 * 24
     }
-    if(length(yr) < length(sec)){
-      rng <- (length(yr)+1):length(sec)
-      if(!all(rng>=0)){
-        skip = TRUE
-        logger.warn(paste(year,"is not a complete year and will not be included"))
+    if (length(yr) < length(sec)) {
+      rng <- (length(yr) + 1):length(sec)
+      if (!all(rng >= 0)) {
+        skip <- TRUE
+        logger.warn(paste(year, "is not a complete year and will not be included"))
         break
       }
-      yr[rng] <- rep(y+1,length(rng))
-      doy[rng] <- rep(1:366,each=86400/dt)[1:length(rng)]
-      hr[rng] <- rep(seq(0,length=86400/dt,by=dt/86400*24),366)[1:length(rng)]
+      yr[rng] <- rep(y + 1, length(rng))
+      doy[rng] <- rep(1:366, each = 86400 / dt)[1:length(rng)]
+      hr[rng] <- rep(seq(0, length = 86400 / dt, by = dt/86400 * 24), 366)[1:length(rng)]
     }
-    if(skip){
+    if (skip) {
       print("Skipping to next year")
       next
     }
     
-    ##0 YEAR DAY HOUR TIMESTEP AirT SoilT PAR PRECIP VPD VPD_Soil AirVP(e_a) WIND SoilM   
-    ## build data matrix
-    n = length(Tair)
-    tmp <- cbind(rep(0,n),yr[1:n],doy[1:n],hr[1:n],rep(dt/86400,n),
-                 Tair-273.15,
+    ## 0 YEAR DAY HOUR TIMESTEP AirT SoilT PAR PRECIP VPD VPD_Soil AirVP(e_a) WIND SoilM build data
+    ## matrix
+    n <- length(Tair)
+    tmp <- cbind(rep(0, n), 
+                 yr[1:n],
+                 doy[1:n], 
+                 hr[1:n], 
+                 rep(dt / 86400, n), 
+                 Tair - 273.15, 
                  soilT, 
-                 PAR*dt, #mol/m2/hr
-                 Rain*dt, ## converts from mm/s to mm
-                 VPD,
-                 VPDsoil,
-                 e_a,
-                 ws, ## wind
-                 rep(0.6,n) ## put soil water at a constant. Don't use, set SIPNET to MODEL_WATER = 1
-    )
+                 PAR * dt,  # mol/m2/hr 
+                 Rain * dt, # converts from mm/s to mm
+                 VPD, 
+                 VPDsoil, 
+                 e_a, 
+                 ws, # wind
+                 rep(0.6, n)) # put soil water at a constant. Don't use, set SIPNET to MODEL_WATER = 1
     
     ## quick error check, sometimes get a NA in the last hr
-    hr.na = which(is.na(tmp[,4]))
-    if(length(hr.na)>0) tmp[hr.na,4] = tmp[hr.na-1,4] + dt/86400*24
-    
-    if(is.null(out)){
-      out = tmp
-    } else {
-      out = rbind(out,tmp)
+    hr.na <- which(is.na(tmp[, 4]))
+    if (length(hr.na) > 0) {
+      tmp[hr.na, 4] <- tmp[hr.na - 1, 4] + dt/86400 * 24
     }
     
-  } ## end loop over years
+    if (is.null(out)) {
+      out <- tmp
+    } else {
+      out <- rbind(out, tmp)
+    }
+    
+  }  ## end loop over years
   
-  if(!is.null(out)){
-  
+  if (!is.null(out)) {
+    
     ## write output
-    write.table(out,out.file.full,quote = FALSE,sep="\t",row.names=FALSE,col.names=FALSE)
-  
+    write.table(out, out.file.full, quote = FALSE, sep = "\t", row.names = FALSE, col.names = FALSE)
     invisible(results)
-  
   } else {
     print("NO MET TO OUTPUT")
     invisible(NULL)
-  }  
-  
-  
-} ### end met2model.SIPNET
+  }
+} # met2model.SIPNET

--- a/models/sipnet/R/model2netcdf.SIPNET.R
+++ b/models/sipnet/R/model2netcdf.SIPNET.R
@@ -6,6 +6,7 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
+
 #--------------------------------------------------------------------------------------------------#
 ##' Convert SIPNET output to netCDF
 ##'
@@ -22,13 +23,13 @@
 ##' @author Shawn Serbin, Michael Dietze
 model2netcdf.SIPNET <- function(outdir, sitelat, sitelon, start_date, end_date, delete.raw, revision) {
   
-  require(ncdf4)
-
+  library(ncdf4)
+  
   ### Read in model output in SIPNET format
   sipnet.out.file <- file.path(outdir, "sipnet.out")
-  sipnet.output <- read.table(sipnet.out.file, header=T, skip=1, sep='')
+  sipnet.output <- read.table(sipnet.out.file, header = T, skip = 1, sep = "")
   sipnet.output.dims <- dim(sipnet.output)
-
+  
   
   ### Determine number of years and output timestep
   num.years <- length(unique(sipnet.output$year))
@@ -37,8 +38,8 @@ model2netcdf.SIPNET <- function(outdir, sitelat, sitelon, start_date, end_date, 
   out.day <- length(which(sipnet.output$year == years[1] & sipnet.output$day == 1))
   
   ### Loop over years in SIPNET output to create separate netCDF outputs
-  for (y in years){
-    if (file.exists(file.path(outdir, paste(y,"nc", sep=".")))) {
+  for (y in years) {
+    if (file.exists(file.path(outdir, paste(y, "nc", sep = ".")))) {
       next
     }
     print(paste("---- Processing year: ", y))  # turn on for debugging
@@ -46,36 +47,33 @@ model2netcdf.SIPNET <- function(outdir, sitelat, sitelon, start_date, end_date, 
     ## Subset data for processing
     sub.sipnet.output <- subset(sipnet.output, year == y)
     sub.sipnet.output.dims <- dim(sub.sipnet.output)
-    dayfrac = 1 / out.day
+    dayfrac <- 1 / out.day
     step <- seq(0, 0.99, 1 / out.day)
-
+    
     ## Setup outputs for netCDF file in appropriate units
-    output <- list()
-    output[[1]] <- sub.sipnet.output$year                       # Year
-    output[[2]] <- sub.sipnet.output$day+step                   # Fractional day
-    output[[3]] <- (sub.sipnet.output$gpp*0.001)/timestep.s     # GPP in kgC/m2/s
-    ## output[[4]] <- (sub.sipnet.output$npp*0.001)/timestep.s     # NPP in kgC/m2/s. Internal SIPNET calculation
-    output[[4]] <- (sub.sipnet.output$gpp * 0.001) / timestep.s -
-      ((sub.sipnet.output$rAboveground * 0.001)/timestep.s +
-      (sub.sipnet.output$rRoot * 0.001) / timestep.s)               # NPP in kgC/m2/s. Post SIPNET calculation
-    output[[5]] <- (sub.sipnet.output$rtot * 0.001) / timestep.s    # Total Respiration in kgC/m2/s
-    output[[6]] <- (sub.sipnet.output$rAboveground * 0.001) / timestep.s +
-      (sub.sipnet.output$rRoot * 0.001) / timestep.s                # Autotrophic Respiration in kgC/m2/s
-    output[[7]] <- ((sub.sipnet.output$rSoil - sub.sipnet.output$rRoot) * 0.001) / timestep.s   # Heterotrophic Respiration in kgC/m2/s
-    output[[8]] <- (sub.sipnet.output$rSoil * 0.001) / timestep.s   # Soil Respiration in kgC/m2/s
-    output[[9]] <- (sub.sipnet.output$nee * 0.001) / timestep.s     # NEE in kgC/m2/s
-    #output[[9]] <- rep(-999,sipnet.output.dims[1])             # CarbPools
-    output[[10]] <- (sub.sipnet.output$plantWoodC * 0.001)         # Above ground wood kgC/m2
-    output[[11]] <- (sub.sipnet.output$plantLeafC * 0.001)        # Leaf C kgC/m2
-    output[[12]] <- (sub.sipnet.output$plantWoodC * 0.001)+
-      (sub.sipnet.output$plantLeafC * 0.001)+
-      (sub.sipnet.output$coarseRootC * 0.001)+
-      (sub.sipnet.output$fineRootC * 0.001)                       # Total living C kgC/m2
-    output[[13]] <- (sub.sipnet.output$soil * 0.001)+
-      (sub.sipnet.output$litter * 0.001)                          # Total soil C kgC/m2
-    if(revision=="r136"){
+    output       <- list()
+    output[[1]]  <- sub.sipnet.output$year  # Year
+    output[[2]]  <- sub.sipnet.output$day + step  # Fractional day
+    output[[3]]  <- (sub.sipnet.output$gpp * 0.001) / timestep.s  # GPP in kgC/m2/s
+    ## output[[4]] <- (sub.sipnet.output$npp*0.001) / timestep.s # NPP in kgC/m2/s. Internal SIPNET
+    ## calculation
+    output[[4]]  <- (sub.sipnet.output$gpp * 0.001) / timestep.s - ((sub.sipnet.output$rAboveground * 
+                                                                       0.001) / timestep.s + (sub.sipnet.output$rRoot * 0.001) / timestep.s)  # NPP in kgC/m2/s. Post SIPNET calculation
+    output[[5]]  <- (sub.sipnet.output$rtot * 0.001) / timestep.s  # Total Respiration in kgC/m2/s
+    output[[6]]  <- (sub.sipnet.output$rAboveground * 0.001) / timestep.s + (sub.sipnet.output$rRoot * 
+                                                                               0.001) / timestep.s  # Autotrophic Respiration in kgC/m2/s
+    output[[7]]  <- ((sub.sipnet.output$rSoil - sub.sipnet.output$rRoot) * 0.001) / timestep.s  # Heterotrophic Respiration in kgC/m2/s
+    output[[8]]  <- (sub.sipnet.output$rSoil * 0.001) / timestep.s  # Soil Respiration in kgC/m2/s
+    output[[9]]  <- (sub.sipnet.output$nee * 0.001) / timestep.s  # NEE in kgC/m2/s
+    # output[[9]] <- rep(-999,sipnet.output.dims[1]) # CarbPools
+    output[[10]] <- (sub.sipnet.output$plantWoodC * 0.001)  # Above ground wood kgC/m2
+    output[[11]] <- (sub.sipnet.output$plantLeafC * 0.001)  # Leaf C kgC/m2
+    output[[12]] <- (sub.sipnet.output$plantWoodC * 0.001) + (sub.sipnet.output$plantLeafC * 0.001) + 
+      (sub.sipnet.output$coarseRootC * 0.001) + (sub.sipnet.output$fineRootC * 0.001)  # Total living C kgC/m2
+    output[[13]] <- (sub.sipnet.output$soil * 0.001) + (sub.sipnet.output$litter * 0.001)  # Total soil C kgC/m2
+    if (revision == "r136") {
       output[[14]] <- (sub.sipnet.output$evapotranspiration * 10 * get.lv()) / timestep.s  # Qle W/m2
-    }else{
+    } else {
       ## *** NOTE : npp in the sipnet output file is actually evapotranspiration, this is due to a bug in sipnet.c : ***
       ## *** it says "npp" in the header (written by L774) but the values being written are trackers.evapotranspiration (L806) ***
       ## evapotranspiration in SIPNET is cm^3 water per cm^2 of area, to convert it to latent heat units W/m2 multiply with :
@@ -84,30 +82,28 @@ model2netcdf.SIPNET <- function(outdir, sitelat, sitelon, start_date, end_date, 
       output[[14]] <- (sub.sipnet.output$npp * 10 * get.lv()) / timestep.s  # Qle W/m2
     }
     output[[15]] <- (sub.sipnet.output$fluxestranspiration * 10) / timestep.s  # Transpiration kgW/m2/s
-    output[[16]] <- (sub.sipnet.output$soilWater * 10)            # Soil moisture kgW/m2
-    output[[17]] <- (sub.sipnet.output$soilWetnessFrac)         # Fractional soil wetness
-    output[[18]] <- (sub.sipnet.output$snow * 10)                 # SWE
-    output[[19]] <- sub.sipnet.output$litter * 0.001 ## litter kgC/m2
-
-          
-    #******************** Declare netCDF variables ********************#
-    t <- ncdim_def(name = "time",
-                   units = paste0("days since ", y, "-01-01 00:00:00"),
-                   vals = sub.sipnet.output$day - 1 + (sub.sipnet.output$time / 24),
-                   calendar = "standard", unlim = TRUE)
-    lat <- ncdim_def("lat", "degrees_east",
-                     vals =  as.numeric(sitelat),
-                     longname = "station_latitude") 
-    lon <- ncdim_def("lon", "degrees_north",
-                     vals = as.numeric(sitelon),
-                     longname = "station_longitude")
-
-   ## ***** Need to dynamically update the UTC offset here *****
+    output[[16]] <- (sub.sipnet.output$soilWater * 10)  # Soil moisture kgW/m2
+    output[[17]] <- (sub.sipnet.output$soilWetnessFrac)  # Fractional soil wetness
+    output[[18]] <- (sub.sipnet.output$snow * 10)  # SWE
+    output[[19]] <- sub.sipnet.output$litter * 0.001  ## litter kgC/m2
     
-    for(i in 1:length(output)){
-      if(length(output[[i]])==0) output[[i]] <- rep(-999,length(t$vals))
+    
+    # ******************** Declare netCDF variables ********************#
+    t <- ncdim_def(name = "time", 
+                   units = paste0("days since ", y, "-01-01 00:00:00"), 
+                   vals = sub.sipnet.output$day - 1 + (sub.sipnet.output$time/24),
+                   calendar = "standard", 
+                   unlim = TRUE)
+    lat <- ncdim_def("lat", "degrees_east", vals = as.numeric(sitelat), longname = "station_latitude")
+    lon <- ncdim_def("lon", "degrees_north", vals = as.numeric(sitelon), longname = "station_longitude")
+    
+    ## ***** Need to dynamically update the UTC offset here *****
+    
+    for (i in seq_along(output)) {
+      if (length(output[[i]]) == 0) 
+        output[[i]] <- rep(-999, length(t$vals))
     }
-
+    
     mstmipvar <- PEcAn.utils::mstmipvar
     var <- list()
     var[[1]]  <- mstmipvar("Year", lat, lon, t, NA)
@@ -117,46 +113,38 @@ model2netcdf.SIPNET <- function(outdir, sitelat, sitelon, start_date, end_date, 
     var[[5]]  <- mstmipvar("TotalResp", lat, lon, t, NA)
     var[[6]]  <- mstmipvar("AutoResp", lat, lon, t, NA)
     var[[7]]  <- mstmipvar("HeteroResp", lat, lon, t, NA)
-    var[[8]]  <- ncvar_def("SoilResp", units = "kg C m-2 s-1", dim = list(lon, lat, t), missval = -999, longname = "Soil Respiration")
+    var[[8]]  <- ncvar_def("SoilResp", units = "kg C m-2 s-1", dim = list(lon, lat, t), missval = -999, 
+                          longname = "Soil Respiration")
     var[[9]]  <- mstmipvar("NEE", lat, lon, t, NA)
-    #var[[9]]  <- mstmipvar("CarbPools", lat, lon, t, NA)
-    var[[10]]  <- mstmipvar("AbvGrndWood", lat, lon, t, NA)
-    var[[11]]  <- mstmipvar("LeafC", lat, lon, t, NA)
-    var[[12]]  <- mstmipvar("TotLivBiom", lat, lon, t, NA)
-    var[[13]]  <- mstmipvar("TotSoilCarb", lat, lon, t, NA)
-    var[[14]]  <- mstmipvar("Qle", lat, lon, t, NA)
-    var[[15]]  <- mstmipvar("TVeg", lat, lon, t, NA)
-    var[[16]]  <- mstmipvar("SoilMoist", lat, lon, t, NA)
-    var[[17]]  <- mstmipvar("SoilMoistFrac", lat, lon, t, NA)
-    var[[18]]  <- mstmipvar("SWE", lat, lon, t, NA)
-    var[[19]]  <- mstmipvar("Litter", lat, lon, t, NA)
-
-   
-    #******************** Declar netCDF variables ********************#
+    # var[[9]] <- mstmipvar('CarbPools', lat, lon, t, NA)
+    var[[10]] <- mstmipvar("AbvGrndWood", lat, lon, t, NA)
+    var[[11]] <- mstmipvar("LeafC", lat, lon, t, NA)
+    var[[12]] <- mstmipvar("TotLivBiom", lat, lon, t, NA)
+    var[[13]] <- mstmipvar("TotSoilCarb", lat, lon, t, NA)
+    var[[14]] <- mstmipvar("Qle", lat, lon, t, NA)
+    var[[15]] <- mstmipvar("TVeg", lat, lon, t, NA)
+    var[[16]] <- mstmipvar("SoilMoist", lat, lon, t, NA)
+    var[[17]] <- mstmipvar("SoilMoistFrac", lat, lon, t, NA)
+    var[[18]] <- mstmipvar("SWE", lat, lon, t, NA)
+    var[[19]] <- mstmipvar("Litter", lat, lon, t, NA)
     
+    # ******************** Declare netCDF variables ********************#
     
     ### Output netCDF data
-    nc <- nc_create(file.path(outdir, paste(y,"nc", sep=".")), var)
-    varfile <- file(file.path(outdir, paste(y, "nc", "var", sep=".")), "w")
-    for(i in 1:length(var)){
-      #print(i)
-      ncvar_put(nc,var[[i]],output[[i]])  
-      cat(paste(var[[i]]$name, var[[i]]$longname), file=varfile, sep="\n")
+    nc      <- nc_create(file.path(outdir, paste(y, "nc", sep = ".")), var)
+    varfile <- file(file.path(outdir, paste(y, "nc", "var", sep = ".")), "w")
+    for (i in seq_along(var)) {
+      # print(i)
+      ncvar_put(nc, var[[i]], output[[i]])
+      cat(paste(var[[i]]$name, var[[i]]$longname), file = varfile, sep = "\n")
     }
     close(varfile)
     nc_close(nc)
     
-  } ### End of year loop
-
+  }  ### End of year loop
+  
   ## Delete raw output, if requested
-  if(delete.raw) {
+  if (delete.raw) {
     file.remove(sipnet.out.file)
   }
-  
-} ### End of function
-#==================================================================================================#
-
-
-####################################################################################################
-### EOF.  End of R script file.              
-####################################################################################################
+} # model2netcdf.SIPNET

--- a/models/sipnet/R/read.restart.SIPNET.R
+++ b/models/sipnet/R/read.restart.SIPNET.R
@@ -1,3 +1,12 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2012 University of Illinois, NCSA.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the 
+# University of Illinois/NCSA Open Source License
+# which accompanies this distribution, and is available at
+# http://opensource.ncsa.illinois.edu/license.html
+#-------------------------------------------------------------------------------
+
 ##' @title read.restart.SIPNET
 ##' @name  read.restart.SIPNET
 ##' @author Ann Raiho \email{araiho@@nd.edu}
@@ -12,64 +21,61 @@
 ##' 
 ##' @return X.vec      vector of forecasts
 ##' @export
-##' 
-read.restart.SIPNET <- function(outdir,runid,stop.time,settings,var.names,params){
-
-  prior.sla <- params[[which(names(params)!='soil')[1]]]$SLA
+read.restart.SIPNET <- function(outdir, runid, stop.time, settings, var.names, params) {
+  
+  prior.sla <- params[[which(names(params) != "soil")[1]]]$SLA
   
   forecast <- list()
   
-  #Read ensemble output
-  ens <- read.output(runid = runid,outdir = file.path(outdir, runid),
-                     start.year = year(stop.time),
+  # Read ensemble output
+  ens <- read.output(runid = runid, 
+                     outdir = file.path(outdir, runid), 
+                     start.year = year(stop.time), 
                      end.year = year(stop.time),
                      variables = var.names)
-    
-    last = length(ens$NPP)
-    
-    forecast<-list()
-    
-    #unit.conv <- (10000/1)*(1/1000)*(365.25*24*60*60) ## kgC m-2 s-1 -> MgC/ha/yr
   
-    #### PEcAn Standard Outputs
-    if("NPP" %in% var.names){
-      forecast[[1]] <- ud.convert(mean(ens$NPP),'kg/m^2/s','Mg/ha/yr') #* unit.conv 
-      names(forecast[[1]])<-c("NPP")
-    }
-    
-    if("AbvGrndWood" %in% var.names){
-      forecast[[2]] = ens$AbvGrndWood[last] / (1 - .2 - .2) ## kgC/m2
-      names(forecast[[2]])<-c("AbvGrndWood")
-    }
-    
-    if("LeafC" %in% var.names){
-      forecast[[3]] = ens$LeafC[last]## kgC/m2*m2/kg*2kg/kgC
-      names(forecast[[3]])<-c("LeafC")
-    }
-    
-    if("Litter" %in% var.names){
-      forecast[[4]] = ens$Litter[last]##kgC/m2
-      names(forecast[[4]])<-c("Litter")
-    }
-    
-    if("TotSoilCarb" %in% var.names){
-      forecast[[5]] = ens$TotSoilCarb[last]## kgC/m2
-      names(forecast[[5]])<-c("TotSoilCarb")
-    }
-    
-    if("SoilMoistFrac" %in% var.names){
-      forecast[[6]] = ens$SoilMoistFrac[last]## kgC/m2
-      names(forecast[[6]])<-c("SoilMoistFrac")
-    }
-    
-    if("SWE" %in% var.names){
-      forecast[[7]] = ens$SWE[last]## kgC/m2
-      names(forecast[[7]])<-c("SWE")
-    }
+  last <- length(ens$NPP)
   
-  X.vec = unlist(forecast)
+  forecast <- list()
+  
+  # unit.conv <- (10000/1)*(1/1000)*(365.25*24*60*60) ## kgC m-2 s-1 -> MgC/ha/yr
+  
+  #### PEcAn Standard Outputs
+  if ("NPP" %in% var.names) {
+    forecast[[1]] <- ud.convert(mean(ens$NPP), "kg/m^2/s", "Mg/ha/yr")  #* unit.conv 
+    names(forecast[[1]]) <- c("NPP")
+  }
+  
+  if ("AbvGrndWood" %in% var.names) {
+    forecast[[2]] <- ens$AbvGrndWood[last] / (1 - 0.2 - 0.2)  ## kgC/m2
+    names(forecast[[2]]) <- c("AbvGrndWood")
+  }
+  
+  if ("LeafC" %in% var.names) {
+    forecast[[3]] <- ens$LeafC[last]  ## kgC/m2*m2/kg*2kg/kgC
+    names(forecast[[3]]) <- c("LeafC")
+  }
+  
+  if ("Litter" %in% var.names) {
+    forecast[[4]] <- ens$Litter[last]  ##kgC/m2
+    names(forecast[[4]]) <- c("Litter")
+  }
+  
+  if ("TotSoilCarb" %in% var.names) {
+    forecast[[5]] <- ens$TotSoilCarb[last]  ## kgC/m2
+    names(forecast[[5]]) <- c("TotSoilCarb")
+  }
+  
+  if ("SoilMoistFrac" %in% var.names) {
+    forecast[[6]] <- ens$SoilMoistFrac[last]  ## kgC/m2
+    names(forecast[[6]]) <- c("SoilMoistFrac")
+  }
+  
+  if ("SWE" %in% var.names) {
+    forecast[[7]] <- ens$SWE[last]  ## kgC/m2
+    names(forecast[[7]]) <- c("SWE")
+  }
   
   print(runid)
-
-  return(X.vec)
-}
+  unlist(forecast)
+} # read.restart.SIPNET

--- a/models/sipnet/R/sample.IC.SIPNET.R
+++ b/models/sipnet/R/sample.IC.SIPNET.R
@@ -1,3 +1,12 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2012 University of Illinois, NCSA.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the 
+# University of Illinois/NCSA Open Source License
+# which accompanies this distribution, and is available at
+# http://opensource.ncsa.illinois.edu/license.html
+#-------------------------------------------------------------------------------
+
 ## samples intial conditions for SIPNET
 ##' @title sample.IC.SIPNET
 ##' @name  sample.IC.SIPNET
@@ -10,43 +19,52 @@
 ##' @return IC matrix of initial conditions
 ##' @export
 ##' 
-sample.IC.SIPNET <- function(ne,state,year=1){
-  ## Mg C / ha / yr NPP
-  NPP = ifelse(rep("NPP" %in% names(state),ne),
-                     state$NPP[1,sample.int(ncol(state$NPP),ne),year],#*.48, ## unit MgC/ha/yr
-                     runif(ne,0,10)) ## prior
-  ## g C * m-2 ground area in wood (above-ground + roots)
-  plantWood = ifelse(rep("AGB" %in% names(state),ne),
-                     state$AGB[1,sample.int(ncol(state$AGB),ne),year]*(1/1000)*(1000000/1), ## unit KgC/ha -> g C /m^2
-                     runif(ne,0,14000)) ## prior
-  ## initial leaf area, m2 leaves * m-2 ground area (multiply by leafCSpWt to get initial plant leaf C)
-  lai = ifelse(rep("LAI" %in% names(state),ne),
-               state$LAI[1,sample.int(ncol(state$LAI),ne),year],
-               runif(ne,0,7)) ## prior
-  ## g C * m-2 ground area
-  litter = ifelse(rep("litter" %in% names(state),ne),
-                  state$litter[1,sample.int(ncol(state$litter),ne),year],
-                  runif(ne,0,1200)) ## prior
-  ## g C * m-2 ground area
-  soil   = ifelse(rep("soil" %in% names(state),ne),
-                  state$soil[1,sample.int(ncol(state$soil),ne),year],
-                  runif(ne,0,19000)) ## prior
-  ## unitless: fraction of litterWHC
-  litterWFrac = ifelse(rep("litterW" %in% names(state),ne),
-                       state$litterW[1,sample.int(ncol(state$litterW),ne),year],
-                       runif(ne)) ## prior
-  ## unitless: fraction of soilWHC
-  soilWFrac = ifelse(rep("soilW" %in% names(state),ne),
-                     state$soilW[1,sample.int(ncol(state$soilW),ne),year],
-                     runif(ne)) ## prior
-  ## cm water equiv
-  snow = ifelse(rep("snow" %in% names(state),ne),
-                state$snow[1,sample.int(ncol(state$snow),ne),year],
-                runif(ne,0,1)) ## prior
-  microbe = ifelse(rep("microbe" %in% names(state),ne),
-                   state$microbe[1,sample.int(ncol(state$microbe),ne),year],
-                   runif(ne,0,1)) ## prior                  
-  IC = data.frame(NPP,plantWood,lai,litter,soil,litterWFrac,soilWFrac,snow,microbe) 
-  return(IC)
+sample.IC.SIPNET <- function(ne, state, year = 1) {
   
-}
+  ## Mg C / ha / yr NPP
+  NPP <- ifelse(rep("NPP" %in% names(state), ne), 
+                state$NPP[1, sample.int(ncol(state$NPP), ne), year], # *.48, ## unit MgC/ha/yr
+                runif(ne, 0, 10))  ## prior
+  
+  # g C * m-2 ground area in wood (above-ground + roots)
+  plantWood <- ifelse(rep("AGB" %in% names(state), ne), 
+                      state$AGB[1, sample.int(ncol(state$AGB), ne), year] * (1/1000) * (1e+06/1), ## unit KgC/ha -> g C /m^2 
+                      runif(ne, 0, 14000))  ## prior
+  
+  # initial leaf area, m2 leaves * m-2 ground area (multiply by leafCSpWt to
+  ## get initial plant leaf C)
+  lai <- ifelse(rep("LAI" %in% names(state), ne), 
+                state$LAI[1, sample.int(ncol(state$LAI), ne), year], 
+                runif(ne, 0, 7))  ## prior
+  
+  ## g C * m-2 ground area
+  litter <- ifelse(rep("litter" %in% names(state), ne), 
+                   state$litter[1, sample.int(ncol(state$litter), ne), year], 
+                   runif(ne, 0, 1200))  ## prior
+  
+  ## g C * m-2 ground area
+  soil <- ifelse(rep("soil" %in% names(state), ne), 
+                 state$soil[1, sample.int(ncol(state$soil), ne), year], 
+                 runif(ne, 0, 19000))  ## prior
+  
+  ## unitless: fraction of litterWHC
+  litterWFrac <- ifelse(rep("litterW" %in% names(state), ne), 
+                        state$litterW[1, sample.int(ncol(state$litterW), ne), year], 
+                        runif(ne))  ## prior
+  
+  ## unitless: fraction of soilWHC
+  soilWFrac <- ifelse(rep("soilW" %in% names(state), ne), 
+                      state$soilW[1, sample.int(ncol(state$soilW), ne), year],
+                      runif(ne))  ## prior
+  
+  ## cm water equiv
+  snow <- ifelse(rep("snow" %in% names(state), ne), 
+                 state$snow[1, sample.int(ncol(state$snow), ne), year], 
+                 runif(ne, 0, 1))  ## prior
+  
+  microbe <- ifelse(rep("microbe" %in% names(state), ne), 
+                    state$microbe[1, sample.int(ncol(state$microbe), ne), year], 
+                    runif(ne, 0, 1))  ## prior 
+  
+  data.frame(NPP, plantWood, lai, litter, soil, litterWFrac, soilWFrac, snow, microbe)
+} # sample.IC.SIPNET

--- a/models/sipnet/R/split.inputs.SIPNET.R
+++ b/models/sipnet/R/split.inputs.SIPNET.R
@@ -1,3 +1,12 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2012 University of Illinois, NCSA.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the 
+# University of Illinois/NCSA Open Source License
+# which accompanies this distribution, and is available at
+# http://opensource.ncsa.illinois.edu/license.html
+#-------------------------------------------------------------------------------
+
 ## split clim file into smaller time units to use in KF
 ##' @title split.inputs.SIPNET
 ##' @name  split.inputs.SIPNET
@@ -10,34 +19,31 @@
 ##' 
 ##' @return file split up climate file
 ##' @export
-##' 
-split.inputs.SIPNET <- function(settings,start.time,stop.time){
+split.inputs.SIPNET <- function(settings, start.time, stop.time) {
   
+  start.day <- day(start.time)
+  start.year <- year(start.time)
   
-  start.day<-day(start.time)
-  start.year<-year(start.time)
-  
-  end.day<-day(stop.time)
-  end.year<-year(stop.time)
+  end.day <- day(stop.time)
+  end.year <- year(stop.time)
   
   met <- c(settings$run$inputs$met$path)
   
   path <- dirname(met)
-  prefix <- sub(".clim","",basename(met),fixed=TRUE)
-  dat <- read.table(met,header=FALSE)
+  prefix <- sub(".clim", "", basename(met), fixed = TRUE)
+  dat <- read.table(met, header = FALSE)
   file <- NA
-  names(file) <- paste(start.time,"-",stop.time)
+  names(file) <- paste(start.time, "-", stop.time)
   
-  sel1 <- which(dat[,2] == as.numeric(start.year) & dat[,3] == as.numeric(start.day))[1]
-  sel2 <- which(dat[,2] == as.numeric(end.year) & dat[,3] == as.numeric(end.day))[length(which(dat[,2] == as.numeric(end.year) & dat[,3] == as.numeric(end.day)))]
+  sel1 <- which(dat[, 2] == as.numeric(start.year) & dat[, 3] == as.numeric(start.day))[1]
+  sel2 <- which(dat[, 2] == as.numeric(end.year) & 
+                  dat[, 3] == as.numeric(end.day))[length(which(dat[, 2] == as.numeric(end.year) & 
+                                                                  dat[, 3] == as.numeric(end.day)))]
   
-  file<- paste(path,"/",prefix,".",paste0(as.Date(start.time),"-",as.Date(stop.time)),".clim",sep="") 
+  file <- paste0(path, "/", prefix, ".", paste0(as.Date(start.time), "-", as.Date(stop.time)), ".clim")
   
-  write.table(dat[sel1:sel2,],file,row.names=FALSE,col.names=FALSE)
+  write.table(dat[sel1:sel2, ], file, row.names = FALSE, col.names = FALSE)
   
-  settings$run$inputs$met$path<-file
-  inputs<-settings$run$inputs
-  
-  return(inputs)
-  
-}
+  settings$run$inputs$met$path <- file
+  settings$run$inputs
+} # split.inputs.SIPNET

--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -13,17 +13,18 @@
 ##' @title Writes a configuration files for SIPNET model
 ##' @export
 ##' @author Michael Dietze
-#--------------------------------------------------------------------------------------------------#
-write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs=NULL, IC=NULL, restart=NULL, spinup=NULL){
+write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs = NULL, IC = NULL, 
+                                restart = NULL, spinup = NULL) {
   ### WRITE sipnet.in
-  template.in <- system.file("sipnet.in", package="PEcAn.SIPNET")
-  config.text <- readLines(con=template.in, n=-1)
+  template.in <- system.file("sipnet.in", package = "PEcAn.SIPNET")
+  config.text <- readLines(con = template.in, n = -1)
   writeLines(config.text, con = file.path(settings$rundir, run.id, "sipnet.in"))
   
   ### WRITE *.clim
-  template.clim <- settings$run$input$met$path      ## read from settings
-  if(!is.null(inputs)){                       ## override if specified in inputs
-    if('met' %in% names(inputs)){
+  template.clim <- settings$run$input$met$path  ## read from settings
+  if (!is.null(inputs)) {
+    ## override if specified in inputs
+    if ("met" %in% names(inputs)) {
       template.clim <- inputs$met$path
     }
   }
@@ -38,332 +39,328 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
   
   # create launch script (which will create symlink)
   if (!is.null(settings$model$jobtemplate) && file.exists(settings$model$jobtemplate)) {
-    jobsh <- readLines(con=settings$model$jobtemplate, n=-1)
+    jobsh <- readLines(con = settings$model$jobtemplate, n = -1)
   } else {
-    jobsh <- readLines(con=system.file("template.job", package = "PEcAn.SIPNET"), n=-1)
+    jobsh <- readLines(con = system.file("template.job", package = "PEcAn.SIPNET"), n = -1)
   }
   
   # create host specific setttings
   hostsetup <- ""
   if (!is.null(settings$model$prerun)) {
-    hostsetup <- paste(hostsetup, sep="\n", paste(settings$model$prerun, collapse="\n"))
+    hostsetup <- paste(hostsetup, sep = "\n", paste(settings$model$prerun, collapse = "\n"))
   }
   if (!is.null(settings$host$prerun)) {
-    hostsetup <- paste(hostsetup, sep="\n", paste(settings$host$prerun, collapse="\n"))
+    hostsetup <- paste(hostsetup, sep = "\n", paste(settings$host$prerun, collapse = "\n"))
   }
-
+  
   hostteardown <- ""
   if (!is.null(settings$model$postrun)) {
-    hostteardown <- paste(hostteardown, sep="\n", paste(settings$model$postrun, collapse="\n"))
+    hostteardown <- paste(hostteardown, sep = "\n", paste(settings$model$postrun, collapse = "\n"))
   }
   if (!is.null(settings$host$postrun)) {
-    hostteardown <- paste(hostteardown, sep="\n", paste(settings$host$postrun, collapse="\n"))
+    hostteardown <- paste(hostteardown, sep = "\n", paste(settings$host$postrun, collapse = "\n"))
   }
-
+  
   # create job.sh
-  jobsh <- gsub('@HOST_SETUP@', hostsetup, jobsh)
-  jobsh <- gsub('@HOST_TEARDOWN@', hostteardown, jobsh)
-
-  jobsh <- gsub('@SITE_LAT@', settings$run$site$lat, jobsh)
-  jobsh <- gsub('@SITE_LON@', settings$run$site$lon, jobsh)
-  jobsh <- gsub('@SITE_MET@', template.clim, jobsh)
+  jobsh <- gsub("@HOST_SETUP@", hostsetup, jobsh)
+  jobsh <- gsub("@HOST_TEARDOWN@", hostteardown, jobsh)
   
-  jobsh <- gsub('@OUTDIR@', outdir, jobsh)
-  jobsh <- gsub('@RUNDIR@', rundir, jobsh)
+  jobsh <- gsub("@SITE_LAT@", settings$run$site$lat, jobsh)
+  jobsh <- gsub("@SITE_LON@", settings$run$site$lon, jobsh)
+  jobsh <- gsub("@SITE_MET@", template.clim, jobsh)
   
-  jobsh <- gsub('@START_DATE@', settings$run$start.date, jobsh)
-  jobsh <- gsub('@END_DATE@', settings$run$end.date, jobsh)
+  jobsh <- gsub("@OUTDIR@", outdir, jobsh)
+  jobsh <- gsub("@RUNDIR@", rundir, jobsh)
   
-  jobsh <- gsub('@BINARY@', settings$model$binary, jobsh)
-  jobsh <- gsub('@REVISION@', settings$model$revision, jobsh)
+  jobsh <- gsub("@START_DATE@", settings$run$start.date, jobsh)
+  jobsh <- gsub("@END_DATE@", settings$run$end.date, jobsh)
   
-  if(is.null(settings$model$delete.raw)) settings$model$delete.raw <- FALSE
-  jobsh <- gsub('@DELETE.RAW@', settings$model$delete.raw, jobsh)
-
-  writeLines(jobsh, con=file.path(settings$rundir, run.id, "job.sh"))
+  jobsh <- gsub("@BINARY@", settings$model$binary, jobsh)
+  jobsh <- gsub("@REVISION@", settings$model$revision, jobsh)
+  
+  if (is.null(settings$model$delete.raw)) {
+    settings$model$delete.raw <- FALSE
+  }
+  jobsh <- gsub("@DELETE.RAW@", settings$model$delete.raw, jobsh)
+  
+  writeLines(jobsh, con = file.path(settings$rundir, run.id, "job.sh"))
   Sys.chmod(file.path(settings$rundir, run.id, "job.sh"))
   
   ### WRITE *.param-spatial
-  template.paramSpatial <- system.file("template.param-spatial",package="PEcAn.SIPNET")
+  template.paramSpatial <- system.file("template.param-spatial", package = "PEcAn.SIPNET")
   file.copy(template.paramSpatial, file.path(settings$rundir, run.id, "sipnet.param-spatial"))
   
   ### WRITE *.param
-  template.param <- system.file("template.param",package="PEcAn.SIPNET")
-  if("default.param" %in% names(settings$model)){template.param <- settings$model$default.param}
+  template.param <- system.file("template.param", package = "PEcAn.SIPNET")
+  if ("default.param" %in% names(settings$model)) {
+    template.param <- settings$model$default.param
+  }
   
   param <- read.table(template.param)
   
   #### write INITAL CONDITIONS here ####
-  if(!is.null(IC)){
-    ic.names = names(IC)
-    ##plantWoodInit gC/m2
-    if("plantWood" %in% ic.names){
-      param[which(param[,1] == 'plantWoodInit'),2] = IC$plantWood
-    } 
-    ##laiInit m2/m2
-    if("lai" %in% ic.names){
-      param[which(param[,1] == 'laiInit'),2] = IC$lai
+  if (!is.null(IC)) {
+    ic.names <- names(IC)
+    ## plantWoodInit gC/m2
+    if ("plantWood" %in% ic.names) {
+      param[which(param[, 1] == "plantWoodInit"), 2] <- IC$plantWood
     }
-    ##litterInit gC/m2
-    if("litter" %in% ic.names){
-      param[which(param[,1] == 'litterInit'),2] = IC$litter
+    ## laiInit m2/m2
+    if ("lai" %in% ic.names) {
+      param[which(param[, 1] == "laiInit"), 2] <- IC$lai
     }
-    ##soilInit gC/m2
-    if("soil" %in% ic.names){
-      param[which(param[,1] == 'soilInit'),2] = IC$soil
+    ## litterInit gC/m2
+    if ("litter" %in% ic.names) {
+      param[which(param[, 1] == "litterInit"), 2] <- IC$litter
     }
-    ##litterWFracInit fraction
-    if("litterWFrac" %in% ic.names){
-      param[which(param[,1] == 'litterWFracInit'),2] = IC$litterWFrac
+    ## soilInit gC/m2
+    if ("soil" %in% ic.names) {
+      param[which(param[, 1] == "soilInit"), 2] <- IC$soil
     }
-    ##soilWFracInit fraction
-    if("soilWFrac" %in% ic.names){
-      param[which(param[,1] == 'soilWFracInit'),2] = IC$soilWFrac
+    ## litterWFracInit fraction
+    if ("litterWFrac" %in% ic.names) {
+      param[which(param[, 1] == "litterWFracInit"), 2] <- IC$litterWFrac
     }
-    ##snowInit cm water equivalent
-    if("snow" %in% ic.names){
-      param[which(param[,1] == 'snowInit'),2] = IC$snow
+    ## soilWFracInit fraction
+    if ("soilWFrac" %in% ic.names) {
+      param[which(param[, 1] == "soilWFracInit"), 2] <- IC$soilWFrac
     }
-    ##microbeInit mgC/g soil
-    if("microbe" %in% ic.names){
-      param[which(param[,1] == 'microbeInit'),2] = IC$microbe
+    ## snowInit cm water equivalent
+    if ("snow" %in% ic.names) {
+      param[which(param[, 1] == "snowInit"), 2] <- IC$snow
+    }
+    ## microbeInit mgC/g soil
+    if ("microbe" %in% ic.names) {
+      param[which(param[, 1] == "microbeInit"), 2] <- IC$microbe
     }
   }
   
-  #### write run-specific PFT parameters here ####
-  ## Get parameters being handled by PEcAn
-for(pft in seq_along(trait.values)){
-  pft.traits <- unlist(trait.values[[pft]])
-  pft.names  <- names(pft.traits)
-
-  ## Append/replace params specified as constants
-  constant.traits <- unlist(defaults[[1]]$constants)
-  constant.names  <- names(constant.traits)
-  
-  # Replace matches
-
-    for(i in seq_along(constant.traits)) {
-      ind = match(constant.names[i], pft.names)
-      if(is.na(ind)) { # Add to list
+  #### write run-specific PFT parameters here #### Get parameters being handled by PEcAn
+  for (pft in seq_along(trait.values)) {
+    pft.traits <- unlist(trait.values[[pft]])
+    pft.names <- names(pft.traits)
+    
+    ## Append/replace params specified as constants
+    constant.traits <- unlist(defaults[[1]]$constants)
+    constant.names <- names(constant.traits)
+    
+    # Replace matches
+    for (i in seq_along(constant.traits)) {
+      ind <- match(constant.names[i], pft.names)
+      if (is.na(ind)) {
+        # Add to list
         pft.names <- c(pft.names, constant.names[i])
         pft.traits <- c(pft.traits, constant.traits[i])
-      } else {  # Replace existing value
+      } else {
+        # Replace existing value
         pft.traits[ind] <- constant.traits[i]
       }
     }
-
     
-  # Remove NAs. Constants may be specified as NA to request template defaults. Note that it is "NA" (character) not actual NA due to being read in as XML
-  pft.names  <- pft.names [ pft.traits != "NA" & !is.na(pft.traits) ]
-  pft.traits <- pft.traits[ pft.traits != "NA" & !is.na(pft.traits) ]
-  pft.traits <- as.numeric(pft.traits)
-  
-  # Leaf carbon concentration
-  leafC = 0.48  #0.5
-  if("leafC" %in% pft.names){
-    leafC = pft.traits[which(pft.names == 'leafC')]
-    id = which(param[,1] == 'cFracLeaf')
-    param[id,2] = leafC*0.01 # convert to percentage from 0 to 1
-  }
-
-  # Specific leaf area converted to SLW
-  SLA = NA
-  id = which(param[,1] == 'leafCSpWt')
-  if("SLA" %in% pft.names){
-    SLA = pft.traits[which(pft.names == 'SLA')]
-    param[id,2] = 1000*leafC*0.01/SLA
-  } else {
-    SLA = 1000*leafC/param[id,2]
-  }
-  
-  # Maximum photosynthesis
-  Amax = NA
-  id = which(param[,1] == 'aMax')
-  if("Amax" %in% pft.names){
-    Amax = pft.traits[which(pft.names == 'Amax')]
-    param[id,2] = Amax*SLA
-  } else {
-    Amax = param[id,2]*SLA
-  }
-  
-  # Daily fraction of maximum photosynthesis
-  if("AmaxFrac" %in% pft.names){
-    param[which(param[,1] == 'aMaxFrac'),2] = pft.traits[which(pft.names == 'AmaxFrac')]
-  }  
-  
-  ### Canopy extinction coefficiet (k)
-  if("extinction_coefficient" %in% pft.names){
-    param[which(param[,1] == 'attenuation'),2] = pft.traits[which(pft.names == 'extinction_coefficient')]
-  }
-  
-  # Leaf respiration rate converted to baseFolRespFrac
-  if("leaf_respiration_rate_m2" %in% pft.names){
-    Rd = pft.traits[which(pft.names == 'leaf_respiration_rate_m2')]
-    id = which(param[,1] == 'baseFolRespFrac')
-    param[id,2] = max(min(Rd/Amax,1),0)
-  }
-  
-  # Low temp threshold for photosynethsis
-  if("Vm_low_temp" %in% pft.names){
-    param[which(param[,1] == 'psnTMin'),2] = pft.traits[which(pft.names == 'Vm_low_temp')]
-  }
-  
-  # Opt. temp for photosynthesis
-  if("psnTOpt" %in% pft.names){
-    param[which(param[,1] == 'psnTOpt'),2] = pft.traits[which(pft.names == 'psnTOpt')]
-  }
-  
-  # Growth respiration factor (fraction of GPP)
-  if("growth_resp_factor" %in% pft.names){
-    param[which(param[,1] == 'growthRespFrac'),2] =
-      pft.traits[which(pft.names == 'growth_resp_factor')]
-  }
-  
-  ### !!! NOT YET USED
-  #Jmax = NA
-  #if("Jmax" %in% pft.names){
-  #  Jmax = pft.traits[which(pft.names == 'Jmax')]
-  ### Using Jmax scaled to 25 degC. Maybe not be the best approach
-  #}
-  
-  #alpha = NA
-  #if("quantum_efficiency" %in% pft.names){
-  #  alpha = pft.traits[which(pft.names == 'quantum_efficiency')]
-  #}
-  
-  # Half saturation of PAR.  PAR at which photosynthesis occurs at 1/2 theoretical maximum (Einsteins * m^-2 ground area * day^-1).
-  #if(!is.na(Jmax) & !is.na(alpha)){
-  # param[which(param[,1] == "halfSatPar"),2] = Jmax/(2*alpha)
-  ### WARNING: this is a very coarse linear approximation and needs improvement *****
-  ### Yes, we also need to work on doing a paired query where we have both data together.
-  ### Once halfSatPar is calculated, need to remove Jmax and quantum_efficiency from param list so they are not included in SA
-  #}
-  ### !!!
-  
-  # Half saturation of PAR.  PAR at which photosynthesis occurs at 1/2 theoretical maximum (Einsteins * m^-2 ground area * day^-1).
-  # Temporary implementation until above is working.
-  if("half_saturation_PAR" %in% pft.names){ 
-    param[which(param[,1] == 'halfSatPar'),2] = pft.traits[which(pft.names == 'half_saturation_PAR')]
-  }
-  
-  # Ball-berry slomatal slope parameter m
-  if("stomatal_slope.BB" %in% pft.names){
-    id = which(param[,1] == 'm_ballBerry')
-    param[id,2] = pft.traits[which(pft.names == 'stomatal_slope.BB')]
-  }
-  
-  # Slope of VPD–photosynthesis relationship. dVpd = 1 - dVpdSlope * vpd^dVpdExp  
-  if('dVPDSlope' %in% pft.names){
-    param[which(param[,1] == 'dVpdSlope'),2] = pft.traits[which(pft.names == 'dVPDSlope')]
-  }
-  
-  # VPD–water use efficiency relationship.  dVpd = 1 - dVpdSlope * vpd^dVpdExp
-  if('dVpdExp' %in% pft.names){
-    param[which(param[,1] == 'dVpdExp'),2] = pft.traits[which(pft.names == 'dVpdExp')]
-  }
-  
-  # Leaf turnover rate average turnover rate of leaves, in fraction per day NOTE: read in as per-year rate!
-  if("leaf_turnover_rate" %in% pft.names){
-    param[which(param[,1] == 'leafTurnoverRate'),2] =
-      pft.traits[which(pft.names == 'leaf_turnover_rate')]
-  }
-  
-  # vegetation respiration Q10.
-  if('veg_respiration_Q10' %in% pft.names){
-    param[which(param[,1] == 'vegRespQ10'),2] = 
-      pft.traits[which(pft.names == 'veg_respiration_Q10')]
-  }
-  
-  # Base vegetation respiration. vegetation maintenance respiration at 0 degrees C (g C respired * g^-1 plant C * day^-1) 
-  # NOTE: only counts plant wood C - leaves handled elsewhere (both above and below-ground: assumed for now to have same resp. rate)
-  # NOTE: read in as per-year rate!
-  if("stem_respiration_rate" %in% pft.names){
-    vegRespQ10 = param[which(param[,1] == "vegRespQ10"),2]
-    id = which(param[,1] == 'baseVegResp')
-    ## Convert from umols CO2 kg s-1 to gC g day-1
-    stem_resp_g <- (((pft.traits[which(pft.names=='stem_respiration_rate')])*(44.0096/1000000)*(12.01/44.0096))/1000)*86400
-    ## use Q10 to convert stem resp from reference of 25C to 0C
-    #param[id,2] = pft.traits[which(pft.names=='stem_respiration_rate')]*vegRespQ10^(-25/10)
-    param[id,2] = stem_resp_g*vegRespQ10^(-25/10)
-  }
-  
-  # turnover of fine roots (per year rate)
-  if("root_turnover_rate" %in% pft.names){
-    id = which(param[,1] == 'fineRootTurnoverRate')
-    param[id,2] = pft.traits[which(pft.names == 'root_turnover_rate')]
-  }
-  
-  # fine root respiration Q10
-  if('fine_root_respiration_Q10' %in% pft.names){
-    param[which(param[,1] == 'fineRootQ10'),2] =
-      pft.traits[which(pft.names == 'fine_root_respiration_Q10')]
-  }
-  
-  # base respiration rate of fine roots  (per year rate)
-  if("root_respiration_rate" %in% pft.names){
-    fineRootQ10 = param[which(param[,1] == "fineRootQ10"),2]
-    id = which(param[,1] == 'baseFineRootResp')
-    ## Convert from umols CO2 kg s-1 to gC g day-1
-    root_resp_rate_g <- (((pft.traits[which(pft.names=='root_respiration_rate')])*(44.0096/1000000)*(12.01/44.0096))/1000)*86400
-    ## use Q10 to convert stem resp from reference of 25C to 0C
-    #param[id,2] = pft.traits[which(pft.names=='root_respiration_rate')]*fineRootQ10^(-25/10)
-    param[id,2] = root_resp_rate_g*fineRootQ10^(-25/10)
-  }
-  
-  # coarse root respiration Q10
-  if('coarse_root_respiration_Q10' %in% pft.names){
-    param[which(param[,1] == 'coarseRootQ10'),2] =
-      pft.traits[which(pft.names == 'coarse_root_respiration_Q10')]
-  } 
-  
-  ### ----- Soil parameters
-  # soil respiration Q10.
-  if('soil_respiration_Q10' %in% pft.names){
-    param[which(param[,1] == 'soilRespQ10'),2] = 
-      pft.traits[which(pft.names == 'soil_respiration_Q10')]
-  }
-  # soil respiration rate -- units = 1/year, reference = 0C
-  if('som_respiration_rate' %in% pft.names){
-    param[which(param[,1] == 'baseSoilResp'),2] = 
-      pft.traits[which(pft.names == 'som_respiration_rate')]
-  }
-  # litterBreakdownRate
-  if("turn_over_time" %in% pft.names){
-    id = which(param[,1] == 'litterBreakdownRate')
-    param[id,2] = pft.traits[which(pft.names == 'turn_over_time')]
-  }
-  # frozenSoilEff
-  if('frozenSoilEff' %in% pft.names){
-    param[which(param[,1] == 'frozenSoilEff'),2] = 
-      pft.traits[which(pft.names == 'frozenSoilEff')]
-  }
-  # soilWHC
-  if('soilWHC' %in% pft.names){
-    param[which(param[,1] == 'soilWHC'),2] = 
-      pft.traits[which(pft.names == 'soilWHC')]
-  }
-  
-  ### ----- Phenology parameters
-  # GDD leaf on
-  if("GDD" %in% pft.names){
-    param[which(param[,1] == 'gddLeafOn'),2] = pft.traits[which(pft.names == 'GDD')]
-  }
-  
-  # Fraction of leaf fall per year (should be 1 for decid)
-  if('fracLeafFall' %in% pft.names){
-    param[which(param[,1] == 'fracLeafFall'),2] = pft.traits[which(pft.names == 'fracLeafFall')]
-  }
-  
-  # Leaf growth.  Amount of C added to the leaf during the greenup period
-  if('leafGrowth' %in% pft.names){
-    param[which(param[,1] == 'leafGrowth'),2] = pft.traits[which(pft.names == 'leafGrowth')]
-  }
-}    ## end loop over PFTS
-####### end parameter update
+    # Remove NAs. Constants may be specified as NA to request template defaults. Note that it is 'NA'
+    # (character) not actual NA due to being read in as XML
+    pft.names <- pft.names[pft.traits != "NA" & !is.na(pft.traits)]
+    pft.traits <- pft.traits[pft.traits != "NA" & !is.na(pft.traits)]
+    pft.traits <- as.numeric(pft.traits)
     
-  write.table(param,file.path(settings$rundir, run.id,"sipnet.param"),row.names=FALSE,col.names=FALSE,quote=FALSE)
-}
-#==================================================================================================#
+    # Leaf carbon concentration
+    leafC <- 0.48  #0.5
+    if ("leafC" %in% pft.names) {
+      leafC <- pft.traits[which(pft.names == "leafC")]
+      id <- which(param[, 1] == "cFracLeaf")
+      param[id, 2] <- leafC * 0.01  # convert to percentage from 0 to 1
+    }
+    
+    # Specific leaf area converted to SLW
+    SLA <- NA
+    id <- which(param[, 1] == "leafCSpWt")
+    if ("SLA" %in% pft.names) {
+      SLA <- pft.traits[which(pft.names == "SLA")]
+      param[id, 2] <- 1000 * leafC * 0.01 / SLA
+    } else {
+      SLA <- 1000 * leafC / param[id, 2]
+    }
+    
+    # Maximum photosynthesis
+    Amax <- NA
+    id <- which(param[, 1] == "aMax")
+    if ("Amax" %in% pft.names) {
+      Amax <- pft.traits[which(pft.names == "Amax")]
+      param[id, 2] <- Amax * SLA
+    } else {
+      Amax <- param[id, 2] * SLA
+    }
+    
+    # Daily fraction of maximum photosynthesis
+    if ("AmaxFrac" %in% pft.names) {
+      param[which(param[, 1] == "aMaxFrac"), 2] <- pft.traits[which(pft.names == "AmaxFrac")]
+    }
+    
+    ### Canopy extinction coefficiet (k)
+    if ("extinction_coefficient" %in% pft.names) {
+      param[which(param[, 1] == "attenuation"), 2] <- pft.traits[which(pft.names == "extinction_coefficient")]
+    }
+    
+    # Leaf respiration rate converted to baseFolRespFrac
+    if ("leaf_respiration_rate_m2" %in% pft.names) {
+      Rd <- pft.traits[which(pft.names == "leaf_respiration_rate_m2")]
+      id <- which(param[, 1] == "baseFolRespFrac")
+      param[id, 2] <- max(min(Rd/Amax, 1), 0)
+    }
+    
+    # Low temp threshold for photosynethsis
+    if ("Vm_low_temp" %in% pft.names) {
+      param[which(param[, 1] == "psnTMin"), 2] <- pft.traits[which(pft.names == "Vm_low_temp")]
+    }
+    
+    # Opt. temp for photosynthesis
+    if ("psnTOpt" %in% pft.names) {
+      param[which(param[, 1] == "psnTOpt"), 2] <- pft.traits[which(pft.names == "psnTOpt")]
+    }
+    
+    # Growth respiration factor (fraction of GPP)
+    if ("growth_resp_factor" %in% pft.names) {
+      param[which(param[, 1] == "growthRespFrac"), 2] <- pft.traits[which(pft.names == "growth_resp_factor")]
+    }
+    
+    ### !!! NOT YET USED
+    #Jmax = NA
+    #if("Jmax" %in% pft.names){
+    #  Jmax = pft.traits[which(pft.names == 'Jmax')]
+    ### Using Jmax scaled to 25 degC. Maybe not be the best approach
+    #}
+    
+    #alpha = NA
+    #if("quantum_efficiency" %in% pft.names){
+    #  alpha = pft.traits[which(pft.names == 'quantum_efficiency')]
+    #}
+    
+    # Half saturation of PAR.  PAR at which photosynthesis occurs at 1/2 theoretical maximum (Einsteins * m^-2 ground area * day^-1).
+    #if(!is.na(Jmax) & !is.na(alpha)){
+    # param[which(param[,1] == "halfSatPar"),2] = Jmax/(2*alpha)
+    ### WARNING: this is a very coarse linear approximation and needs improvement *****
+    ### Yes, we also need to work on doing a paired query where we have both data together.
+    ### Once halfSatPar is calculated, need to remove Jmax and quantum_efficiency from param list so they are not included in SA
+    #}
+    ### !!!
+    
+    # Half saturation of PAR.  PAR at which photosynthesis occurs at 1/2 theoretical maximum (Einsteins * m^-2 ground area * day^-1).
+    # Temporary implementation until above is working.
+    if ("half_saturation_PAR" %in% pft.names) {
+      param[which(param[, 1] == "halfSatPar"), 2] <- pft.traits[which(pft.names == "half_saturation_PAR")]
+    }
+    
+    # Ball-berry slomatal slope parameter m
+    if ("stomatal_slope.BB" %in% pft.names) {
+      id <- which(param[, 1] == "m_ballBerry")
+      param[id, 2] <- pft.traits[which(pft.names == "stomatal_slope.BB")]
+    }
+    
+    # Slope of VPD–photosynthesis relationship. dVpd = 1 - dVpdSlope * vpd^dVpdExp
+    if ("dVPDSlope" %in% pft.names) {
+      param[which(param[, 1] == "dVpdSlope"), 2] <- pft.traits[which(pft.names == "dVPDSlope")]
+    }
+    
+    # VPD–water use efficiency relationship.  dVpd = 1 - dVpdSlope * vpd^dVpdExp
+    if ("dVpdExp" %in% pft.names) {
+      param[which(param[, 1] == "dVpdExp"), 2] <- pft.traits[which(pft.names == "dVpdExp")]
+    }
+    
+    # Leaf turnover rate average turnover rate of leaves, in fraction per day NOTE: read in as
+    # per-year rate!
+    if ("leaf_turnover_rate" %in% pft.names) {
+      param[which(param[, 1] == "leafTurnoverRate"), 2] <- pft.traits[which(pft.names == "leaf_turnover_rate")]
+    }
+    
+    # vegetation respiration Q10.
+    if ("veg_respiration_Q10" %in% pft.names) {
+      param[which(param[, 1] == "vegRespQ10"), 2] <- pft.traits[which(pft.names == "veg_respiration_Q10")]
+    }
+    
+    # Base vegetation respiration. vegetation maintenance respiration at 0 degrees C (g C respired * g^-1 plant C * day^-1) 
+    # NOTE: only counts plant wood C - leaves handled elsewhere (both above and below-ground: assumed for now to have same resp. rate)
+    # NOTE: read in as per-year rate!
+    if ("stem_respiration_rate" %in% pft.names) {
+      vegRespQ10 <- param[which(param[, 1] == "vegRespQ10"), 2]
+      id <- which(param[, 1] == "baseVegResp")
+      ## Convert from umols CO2 kg s-1 to gC g day-1
+      stem_resp_g <- (((pft.traits[which(pft.names == "stem_respiration_rate")]) * 
+                         (44.0096 / 1e+06) * (12.01 / 44.0096)) / 1000) * 86400
+      ## use Q10 to convert stem resp from reference of 25C to 0C param[id,2] =
+      ## pft.traits[which(pft.names=='stem_respiration_rate')]*vegRespQ10^(-25/10)
+      param[id, 2] <- stem_resp_g * vegRespQ10^(-25/10)
+    }
+    
+    # turnover of fine roots (per year rate)
+    if ("root_turnover_rate" %in% pft.names) {
+      id <- which(param[, 1] == "fineRootTurnoverRate")
+      param[id, 2] <- pft.traits[which(pft.names == "root_turnover_rate")]
+    }
+    
+    # fine root respiration Q10
+    if ("fine_root_respiration_Q10" %in% pft.names) {
+      param[which(param[, 1] == "fineRootQ10"), 2] <- pft.traits[which(pft.names == "fine_root_respiration_Q10")]
+    }
+    
+    # base respiration rate of fine roots (per year rate)
+    if ("root_respiration_rate" %in% pft.names) {
+      fineRootQ10 <- param[which(param[, 1] == "fineRootQ10"), 2]
+      id <- which(param[, 1] == "baseFineRootResp")
+      ## Convert from umols CO2 kg s-1 to gC g day-1
+      root_resp_rate_g <- (((pft.traits[which(pft.names == "root_respiration_rate")]) *
+                              (44.0096/1e+06) * (12.01 / 44.0096)) / 1000) * 86400
+      ## use Q10 to convert stem resp from reference of 25C to 0C param[id,2] =
+      ## pft.traits[which(pft.names=='root_respiration_rate')]*fineRootQ10^(-25/10)
+      param[id, 2] <- root_resp_rate_g * fineRootQ10 ^ (-25 / 10)
+    }
+    
+    # coarse root respiration Q10
+    if ("coarse_root_respiration_Q10" %in% pft.names) {
+      param[which(param[, 1] == "coarseRootQ10"), 2] <- pft.traits[which(pft.names == "coarse_root_respiration_Q10")]
+    }
+    
+    ### ----- Soil parameters soil respiration Q10.
+    if ("soil_respiration_Q10" %in% pft.names) {
+      param[which(param[, 1] == "soilRespQ10"), 2] <- pft.traits[which(pft.names == "soil_respiration_Q10")]
+    }
+    # soil respiration rate -- units = 1/year, reference = 0C
+    if ("som_respiration_rate" %in% pft.names) {
+      param[which(param[, 1] == "baseSoilResp"), 2] <- pft.traits[which(pft.names == "som_respiration_rate")]
+    }
+    # litterBreakdownRate
+    if ("turn_over_time" %in% pft.names) {
+      id <- which(param[, 1] == "litterBreakdownRate")
+      param[id, 2] <- pft.traits[which(pft.names == "turn_over_time")]
+    }
+    # frozenSoilEff
+    if ("frozenSoilEff" %in% pft.names) {
+      param[which(param[, 1] == "frozenSoilEff"), 2] <- pft.traits[which(pft.names == "frozenSoilEff")]
+    }
+    # soilWHC
+    if ("soilWHC" %in% pft.names) {
+      param[which(param[, 1] == "soilWHC"), 2] <- pft.traits[which(pft.names == "soilWHC")]
+    }
+    
+    ### ----- Phenology parameters GDD leaf on
+    if ("GDD" %in% pft.names) {
+      param[which(param[, 1] == "gddLeafOn"), 2] <- pft.traits[which(pft.names == "GDD")]
+    }
+    
+    # Fraction of leaf fall per year (should be 1 for decid)
+    if ("fracLeafFall" %in% pft.names) {
+      param[which(param[, 1] == "fracLeafFall"), 2] <- pft.traits[which(pft.names == "fracLeafFall")]
+    }
+    
+    # Leaf growth.  Amount of C added to the leaf during the greenup period
+    if ("leafGrowth" %in% pft.names) {
+      param[which(param[, 1] == "leafGrowth"), 2] <- pft.traits[which(pft.names == "leafGrowth")]
+    }
+  }  ## end loop over PFTS
+  ####### end parameter update
+  
+  write.table(param, file.path(settings$rundir, run.id, "sipnet.param"), row.names = FALSE, col.names = FALSE, 
+              quote = FALSE)
+} # write.config.SIPNET
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -372,23 +369,24 @@ for(pft in seq_along(trait.values)){
 ##' @title Function to generate generic model run script files
 ##' @author <unknown>
 ##' @import PEcAn.utils
-#--------------------------------------------------------------------------------------------------#
-write.run.generic <- function(settings){
-  run.script.template = system.file("data", "run.template.generic", package="PEcAn.generic")
+write.run.generic <- function(settings) {
+  run.script.template <- system.file("data", "run.template.generic", package = "PEcAn.generic")
   run.text <- scan(file = run.script.template, 
-                   what="character",sep='@', quote=NULL, quiet=TRUE)
-  run.text  <- gsub('TMP', paste("/scratch/",Sys.getenv("USER"),sep=""), run.text)
-  run.text  <- gsub('BINARY', settings$host$ed$binary, run.text)
-  run.text <- gsub('OUTDIR', settings$host$outdir, run.text)
-  runfile <- paste(settings$outdir, 'run', sep='')
+                   what = "character", 
+                   sep = "@", 
+                   quote = NULL,
+                   quiet = TRUE)
+  run.text <- gsub("TMP", paste0("/scratch/", Sys.getenv("USER")), run.text)
+  run.text <- gsub("BINARY", settings$host$ed$binary, run.text)
+  run.text <- gsub("OUTDIR", settings$host$outdir, run.text)
+  runfile <- paste0(settings$outdir, "run")
   writeLines(run.text, con = runfile)
-  if(settings$host$name == 'localhost') {
-    system(paste('cp ', runfile, settings$host$rundir))
-  }else{
-    system(paste("rsync -outi ", runfile , ' ', settings$host$name, ":", settings$host$rundir, sep = ''))
+  if (settings$host$name == "localhost") {
+    system(paste("cp ", runfile, settings$host$rundir))
+  } else {
+    system(paste0("rsync -outi ", runfile, " ", settings$host$name, ":", settings$host$rundir))
   }
-}
-#==================================================================================================#
+} # write.run.generic
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -403,28 +401,21 @@ write.run.generic <- function(settings){
 ##' @export
 ##'
 ##' @author Shawn Serbin, David LeBauer
-remove.config.SIPNET <- function(main.outdir,settings) {
+remove.config.SIPNET <- function(main.outdir, settings) {
   
   ### Remove files on localhost
-  if(settings$host$name == 'localhost'){
-    files <- paste(settings$outdir,
-                   list.files(path=settings$outdir, recursive=FALSE),sep="") # Need to change this to the run folder when implemented
-    files <- files[-grep('*.xml',files)] # Keep pecan.xml file
-    pft.dir <- strsplit(settings$pfts$pft$outdir,"/")[[1]]
+  if (settings$host$name == "localhost") {
+    files <- paste0(settings$outdir, list.files(path = settings$outdir, recursive = FALSE))  # Need to change this to the run folder when implemented
+    files <- files[-grep("*.xml", files)]  # Keep pecan.xml file
+    pft.dir <- strsplit(settings$pfts$pft$outdir, "/")[[1]]
     ln <- length(pft.dir)
     pft.dir <- pft.dir[ln]
-    files <- files[-grep(pft.dir,files)] # Keep pft folder
-    #file.remove(files,recursive=TRUE)
-    system(paste("rm -r ",files,sep="",collapse=" "),ignore.stderr = TRUE) # remove files/dirs
+    files <- files[-grep(pft.dir, files)]  # Keep pft folder
+    # file.remove(files,recursive=TRUE)
+    system(paste("rm -r ", files, sep = "", collapse = " "), ignore.stderr = TRUE)  # remove files/dirs
     
     ### On remote host
   } else {
     print("*** WARNING: Removal of files on remote host not yet implemented ***")
   }
-}
-#==================================================================================================#
-
-
-####################################################################################################
-### EOF.  End of R script file.            	
-####################################################################################################
+} # remove.config.SIPNET

--- a/models/sipnet/R/write.restart.SIPNET.R
+++ b/models/sipnet/R/write.restart.SIPNET.R
@@ -1,3 +1,12 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2012 University of Illinois, NCSA.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the 
+# University of Illinois/NCSA Open Source License
+# which accompanies this distribution, and is available at
+# http://opensource.ncsa.illinois.edu/license.html
+#-------------------------------------------------------------------------------
+
 ##' @title write.restart.SIPNET
 ##' @name  write.restart.SIPNET
 ##' @author Ann Raiho \email{araiho@@nd.edu}
@@ -17,83 +26,85 @@
 ##' 
 ##' @return NONE
 ##' @export
-##' 
-write.restart.SIPNET<- function(outdir, runid, start.time, stop.time,
-                                settings, new.state,
-                                RENAME = TRUE,
-                                new.params = FALSE,
-                                inputs){
+write.restart.SIPNET <- function(outdir, runid, start.time, stop.time, settings, new.state, 
+                                 RENAME = TRUE, new.params = FALSE, inputs) {
   
-  rundir<-settings$host$rundir
+  rundir <- settings$host$rundir
   variables <- colnames(new.state)
- 
-  if(RENAME == TRUE) {
-    file.rename(file.path(outdir,runid,"sipnet.out"),
-                file.path(outdir,runid,paste0("sipnet.",as.Date(start.time),".out")))
-    system(paste("rm",file.path(rundir,runid,"sipnet.clim")))
-  }else{
-    print(paste("Files not renamed -- Need to rerun year",start.time,"before next time step"))
+  
+  if (RENAME) {
+    file.rename(file.path(outdir, runid, "sipnet.out"), 
+                file.path(outdir, runid, paste0("sipnet.", as.Date(start.time), ".out")))
+    system(paste("rm", file.path(rundir, runid, "sipnet.clim")))
+  } else {
+    print(paste("Files not renamed -- Need to rerun year", start.time, "before next time step"))
   }
   
   settings$run$start.date <- start.time
   settings$run$end.date <- stop.time
   
   ## Converting to sipnet units
-  prior.sla <- new.params[[which(names(new.params)!='soil')[1]]]$SLA[1]
-  unit.conv <- 2*(10000/1)*(1/1000)*(3.154*10^7) # kgC/m2/s -> Mg/ha/yr
+  prior.sla <- new.params[[which(names(new.params) != "soil")[1]]]$SLA[1]
+  unit.conv <- 2 * (10000 / 1) * (1 / 1000) * (3.154 * 10^7)  # kgC/m2/s -> Mg/ha/yr
   
   analysis.save <- list()
   
-  if('NPP' %in% variables){
-    analysis.save[[1]] <- new.state$NPP#*unit.conv -> Mg/ha/yr
-    names(analysis.save[[1]])<-c('NPP')
+  if ("NPP" %in% variables) {
+    analysis.save[[1]] <- new.state$NPP  #*unit.conv -> Mg/ha/yr
+    names(analysis.save[[1]]) <- c("NPP")
   }
   
-  if('AbvGrndWood' %in% variables){
-    analysis.save[[2]] <- new.state$AbvGrndWood*1000 #kgC/m2 -> g/m2 #no (1-.2-.2) because that's on sipnet side
-    names(analysis.save[[2]])<-c('plantWood')
+  if ("AbvGrndWood" %in% variables) {
+    analysis.save[[2]] <- new.state$AbvGrndWood * 1000  #kgC/m2 -> g/m2 #no (1-.2-.2) because that's on sipnet side
+    names(analysis.save[[2]]) <- c("plantWood")
   }
   
-  if('LeafC' %in% variables){
-    analysis.save[[3]] <- new.state$LeafC*prior.sla*2 ## kgC/m2*m2/kg*2kg/kgC -> m2/m2
-    if(new.state$LeafC<0) analysis.save[[3]] <- 0
-    names(analysis.save[[3]])<-c('lai')
+  if ("LeafC" %in% variables) {
+    analysis.save[[3]] <- new.state$LeafC * prior.sla * 2  ## kgC/m2*m2/kg*2kg/kgC -> m2/m2
+    if (new.state$LeafC < 0) 
+      analysis.save[[3]] <- 0
+    names(analysis.save[[3]]) <- c("lai")
   }
   
-  if('Litter' %in% variables){
-    analysis.save[[4]] <- new.state$Litter*1000 ##kgC/m2 -> gC/m2
-    if(new.state$Litter<0) analysis.save[[4]] <- 0
-    names(analysis.save[[4]])<-c('litter')
+  if ("Litter" %in% variables) {
+    analysis.save[[4]] <- new.state$Litter * 1000  ##kgC/m2 -> gC/m2
+    if (new.state$Litter < 0) 
+      analysis.save[[4]] <- 0
+    names(analysis.save[[4]]) <- c("litter")
   }
   
-  if('TotSoilCarb' %in% variables){
-    analysis.save[[5]] <- new.state$TotSoilCarb*1000 ##kgC/m2 -> gC/m2
-    names(analysis.save[[5]])<-c('soil')
+  if ("TotSoilCarb" %in% variables) {
+    analysis.save[[5]] <- new.state$TotSoilCarb * 1000  ##kgC/m2 -> gC/m2
+    names(analysis.save[[5]]) <- c("soil")
   }
   
-  if('SoilMoistFrac' %in% variables){
-    analysis.save[[6]] <- new.state$SoilMoistFrac ## unitless
-    if(new.state$SoilMoistFrac < 0 | new.state$SoilMoistFrac > 1) analysis.save[[6]] <- .5
-    names(analysis.save[[6]])<-c('litterWFrac')
+  if ("SoilMoistFrac" %in% variables) {
+    analysis.save[[6]] <- new.state$SoilMoistFrac  ## unitless
+    if (new.state$SoilMoistFrac < 0 | new.state$SoilMoistFrac > 1) 
+      analysis.save[[6]] <- 0.5
+    names(analysis.save[[6]]) <- c("litterWFrac")
     
-    analysis.save[[7]] <- new.state$SoilMoistFrac ## unitless
-    if(new.state$SoilMoistFrac < 0 | new.state$SoilMoistFrac > 1) analysis.save[[7]] <- .5
-    names(analysis.save[[7]])<-c('soilWFrac')
+    analysis.save[[7]] <- new.state$SoilMoistFrac  ## unitless
+    if (new.state$SoilMoistFrac < 0 | new.state$SoilMoistFrac > 1) 
+      analysis.save[[7]] <- 0.5
+    names(analysis.save[[7]]) <- c("soilWFrac")
   }
   
-  if('SWE' %in% variables){
-    analysis.save[[8]] <- new.state$SWE## unitless
-    if(new.state$SWE<0) new.state$SWE <- 0
-    names(analysis.save[[8]])<-c('snow')
+  if ("SWE" %in% variables) {
+    analysis.save[[8]] <- new.state$SWE  ## unitless
+    if (new.state$SWE < 0) 
+      new.state$SWE <- 0
+    names(analysis.save[[8]]) <- c("snow")
   }
   
- analysis.save.mat <- data.frame(matrix(unlist(analysis.save,use.names=TRUE),nrow=1))
- colnames(analysis.save.mat)<-names(unlist(analysis.save))
-
- do.call(write.config.SIPNET, args = list(defaults = NULL, trait.values = new.params,
-                                         settings = settings, run.id = runid,
-                                         inputs = inputs,IC = analysis.save.mat))
-
- print(runid)
+  analysis.save.mat <- data.frame(matrix(unlist(analysis.save, use.names = TRUE), nrow = 1))
+  colnames(analysis.save.mat) <- names(unlist(analysis.save))
   
-}
+  do.call(write.config.SIPNET, args = list(defaults = NULL, 
+                                           trait.values = new.params, 
+                                           settings = settings, 
+                                           run.id = runid, 
+                                           inputs = inputs,
+                                           IC = analysis.save.mat))
+  print(runid)
+} # write.restart.SIPNET


### PR DESCRIPTION
Ran through formatR::tidy_dir with arrow=TRUE and indent=2; made sure all if blocks have braces. Tried to make sure formatR didn’t make things too jaggy. Moved ellipses to end of `met2model.MAESPA.R` declaration. Substituted `seq_len`, `seq_along`, and `paste0`.
