### PR TITLE
ED verbose path matching

### DIFF
--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -173,8 +173,9 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
     ed2in.text <- gsub("@INIT_MODEL@", 0, ed2in.text)
     ed2in.text <- gsub("@SITE_PSSCSS@", "", ed2in.text)
   } else {
-    prefix.pss <- sub(".lat.*", "", settings$run$inputs$css$path)
-    prefix.css <- sub(".lat.*", "", settings$run$inputs$pss$path)
+    lat_rxp <- "\\.lat\\.*"
+    prefix.pss <- sub(lat_rxp, "", settings$run$inputs$css$path)
+    prefix.css <- sub(lat_rxp, "", settings$run$inputs$pss$path)
     # pss and css prefix is not the same, kill
     if (!identical(prefix.pss, prefix.css)) {
       print(paste("pss prefix:", prefix.pss))
@@ -185,7 +186,7 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
       value <- 2
       # site exists
       if (!is.null(settings$run$inputs$site$path)) {
-        prefix.site <- sub(".lat.*", "", settings$run$inputs$site$path)
+        prefix.site <- sub(lat_rxp, "", settings$run$inputs$site$path)
         # sites and pss have different prefix name, kill
         if (!identical(prefix.site, prefix.pss)) {
           print(paste("site prefix:", prefix.site))

--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -177,6 +177,8 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
     prefix.css <- sub(".lat.*", "", settings$run$inputs$pss$path)
     # pss and css prefix is not the same, kill
     if (!identical(prefix.pss, prefix.css)) {
+      print(paste("pss prefix:", prefix.pss))
+      print(paste("css prefix:", prefix.css))
       logger.severe("ED2 css/pss/ files have different prefix")
     } else {
       # pss and css are both present
@@ -186,6 +188,8 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
         prefix.sites <- sub(".lat.*", "", settings$run$inputs$site$path)
         # sites and pss have different prefix name, kill
         if (!identical(prefix.sites, prefix.pss)) {
+          print(paste("site prefix:", prefix.site))
+          print(paste("pss prefix:", prefix.pss))
           logger.severe("ED2 sites/pss/ files have different prefix")
         } else {
           # sites and pass same prefix name, case 3

--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -173,13 +173,13 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
     ed2in.text <- gsub("@INIT_MODEL@", 0, ed2in.text)
     ed2in.text <- gsub("@SITE_PSSCSS@", "", ed2in.text)
   } else {
-    lat_rxp <- "\\.lat\\.*"
+    lat_rxp <- "(\\.lat\\.*)?\\.(css|pss|site)"
     prefix.pss <- sub(lat_rxp, "", settings$run$inputs$css$path)
     prefix.css <- sub(lat_rxp, "", settings$run$inputs$pss$path)
     # pss and css prefix is not the same, kill
     if (!identical(prefix.pss, prefix.css)) {
-      print(paste("pss prefix:", prefix.pss))
-      print(paste("css prefix:", prefix.css))
+      logger.info(paste("pss prefix:", prefix.pss))
+      logger.info(paste("css prefix:", prefix.css))
       logger.severe("ED2 css/pss/ files have different prefix")
     } else {
       # pss and css are both present
@@ -189,8 +189,8 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
         prefix.site <- sub(lat_rxp, "", settings$run$inputs$site$path)
         # sites and pss have different prefix name, kill
         if (!identical(prefix.site, prefix.pss)) {
-          print(paste("site prefix:", prefix.site))
-          print(paste("pss prefix:", prefix.pss))
+          logger.info(paste("site prefix:", prefix.site))
+          logger.info(paste("pss prefix:", prefix.pss))
           logger.severe("ED2 sites/pss/ files have different prefix")
         } else {
           # sites and pass same prefix name, case 3

--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -185,9 +185,9 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
       value <- 2
       # site exists
       if (!is.null(settings$run$inputs$site$path)) {
-        prefix.sites <- sub(".lat.*", "", settings$run$inputs$site$path)
+        prefix.site <- sub(".lat.*", "", settings$run$inputs$site$path)
         # sites and pss have different prefix name, kill
-        if (!identical(prefix.sites, prefix.pss)) {
+        if (!identical(prefix.site, prefix.pss)) {
           print(paste("site prefix:", prefix.site))
           print(paste("pss prefix:", prefix.pss))
           logger.severe("ED2 sites/pss/ files have different prefix")


### PR DESCRIPTION
`write.configs.ed` checks that the paths for the ED css, pss, and site files match, and throws an error if they don't.

To make it easier to diagnose errors related to this, I added `print` statements so that the paths are visible on exit.