### PR TITLE
Fix buggy regular expression in write.configs.ed

### DIFF
--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -173,7 +173,7 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
     ed2in.text <- gsub("@INIT_MODEL@", 0, ed2in.text)
     ed2in.text <- gsub("@SITE_PSSCSS@", "", ed2in.text)
   } else {
-    lat_rxp <- "(\\.lat\\.*)?\\.(css|pss|site)"
+    lat_rxp <- "\\.lat.*lon.*\\.(css|pss|site)"
     prefix.pss <- sub(lat_rxp, "", settings$run$inputs$css$path)
     prefix.css <- sub(lat_rxp, "", settings$run$inputs$pss$path)
     # pss and css prefix is not the same, kill


### PR DESCRIPTION
Latitude and longitude should be in every prefix, and therefore *not* optional. Also, `lat` is not followed by a literal period. New regular expression should correctly match `.lat<coord>lon<coord>.css/pss/site`.