### PR TITLE
make sure there are no spaces at beginning/end of params

### DIFF
--- a/web/04-runpecan.php
+++ b/web/04-runpecan.php
@@ -155,7 +155,7 @@ $q->bindParam(':notes', $notes_db, PDO::PARAM_STR);
 $q->bindParam(':hostname', $hostname, PDO::PARAM_STR);
 $q->bindParam(':startdate', $startdate, PDO::PARAM_STR);
 $q->bindParam(':enddate', $enddate, PDO::PARAM_STR);
-$q->bindParam(':params', $params, PDO::PARAM_STR);
+$q->bindParam(':params', trim($params), PDO::PARAM_STR);
 if ($userid != -1) {
   $q->bindParam(':userid', $userid, PDO::PARAM_INT);
 }


### PR DESCRIPTION
make sure there are no spaces around the params which can trigger an error in insert workflow.

https://gitter.im/PecanProject/pecan?at=57fce8724fde72031429acfa