### PR TITLE
Style cleanup for `utils/R/*.R` scripts 

### DIFF
--- a/utils/R/SafeList.R
+++ b/utils/R/SafeList.R
@@ -1,11 +1,12 @@
-#----------------------------------------------------------------------------
-## Copyright (c) 2012 University of Illinois, NCSA.
-## All rights reserved. This program and the accompanying materials
-## are made available under the terms of the 
-## University of Illinois/NCSA Open Source License
-## which accompanies this distribution, and is available at
-## http://opensource.ncsa.illinois.edu/license.html
-## #-------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+# Copyright (c) 2012 University of Illinois, NCSA.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the 
+# University of Illinois/NCSA Open Source License
+# which accompanies this distribution, and is available at
+# http://opensource.ncsa.illinois.edu/license.html
+#-------------------------------------------------------------------------------
+
 ##' Create a SafeList object
 ##'
 ##' SafeList is a wrapper class for the normal R list. It should behave identically, except for 
@@ -14,7 +15,7 @@
 ##' The constructor works identical to list(...) unless:
 ##' 
 ##' 1) The only argument is a list, in which case the result is the same list, with its class
-##' attribute updated to include "SafeList", or
+##' attribute updated to include 'SafeList', or
 ##' 2) The only argument is a SafeList, in which case that argument is returned unchanged
 ##' 
 ##' @title Constrct SafeList Object
@@ -24,8 +25,8 @@
 ##' @author Ryan Kelly
 SafeList <- function(...) {
   result <- list(...)
-  if(length(result)==1) {
-    if(is(result[[1]], "SafeList")) {
+  if (length(result) == 1) {
+    if (is(result[[1]], "SafeList")) {
       return(result[[1]])
     } else if (is.list(result[[1]])) {
       result <- result[[1]]
@@ -33,18 +34,20 @@ SafeList <- function(...) {
   }
   class(result) <- c("SafeList", class(result))
   return(result)
-}
+} # SafeList
+
 
 ##' @export
 ##' @describeIn SafeList Coerce an object to SafeList. 
 as.SafeList <- function(x) {
   return(SafeList(x))
-}
+} # as.SafeList
+
 
 ##' @export
 is.SafeList <- function(x) {
   return(is(x, "SafeList"))
-}
+} # is.SafeList
 
 
 ##' Extract SafeList component by name
@@ -59,7 +62,5 @@ is.SafeList <- function(x) {
 ##' @export
 ##' @author Ryan Kelly
 "$.SafeList" <- function(x, name) {
-  return(x[[name, exact=TRUE]])
-}
-
-
+  return(x[[name, exact = TRUE]])
+} # "$.SafeList"

--- a/utils/R/clear.scratch.R
+++ b/utils/R/clear.scratch.R
@@ -6,7 +6,7 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-#--------------------------------------------------------------------------------------------------#
+
 ##' Removes previous model run output from worker node local scratch directories on EBI-CLUSTER 
 ##'
 ##' @title Clear EBI-CLUSTER worker node local scratch directories of old PEcAn output
@@ -18,31 +18,22 @@
 ##' \dontrun{
 ##' clear.scratch(settings)
 ##' }
-clear.scratch <- function(settings){
+clear.scratch <- function(settings) {
   
   ### Setup script
-  clear.scratch <- system.file("clear.scratch.sh", package="PEcAn.utils")
-  host <-  settings$host
-  nodes <- paste("all.q@compute-0-",seq(0,24,1),".local",sep="")
+  clear.scratch <- system.file("clear.scratch.sh", package = "PEcAn.utils")
+  host  <- settings$host
+  nodes <- paste0("all.q@compute-0-", seq(0, 24, 1), ".local")
   
-  if(any(grep('cluster',host$name))) {
-    for (i in nodes){
+  if (any(grep("cluster", host$name))) {
+    for (i in nodes) {
       print(" ")
-      print(paste("----- Removing output on node: ",i,sep=""))
-      system(paste("ssh -T ", settings$host$name," qlogin -q ",
-                   i," < ",clear.scratch,sep=""))
+      print(paste("----- Removing output on node: ", i, sep = ""))
+      system(paste0("ssh -T ", settings$host$name, " qlogin -q ", i, " < ", clear.scratch))
       print(" ")
-    } ### End of for loop
+    }  ### End of for loop
     
   } else {
     print("---- No output to delete.  Output host is not EBI-CLUSTER ----")
-    
-  } ### End of if/else
-  
-} ### End of function
-#==================================================================================================#
-
-
-####################################################################################################
-### EOF.  End of R script file.          		
-####################################################################################################
+  }  ### End of if/else
+} # clear.scratch

--- a/utils/R/convert.input.R
+++ b/utils/R/convert.input.R
@@ -5,228 +5,245 @@
 ##' @title convert.input
 ##' @export
 ##' @author Betsy Cowdery, Michael Dietze, Ankur Desai
-convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, start_date, end_date, 
-                          pkg, fcn, con=con, host, browndog, write=TRUE,  
-                          format.vars, overwrite=FALSE, ...) {
+convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, start_date, 
+                          end_date, pkg, fcn, con = con, host, browndog, write = TRUE, 
+                          format.vars, overwrite = FALSE, ...) {
   input.args <- list(...)
-
-  logger.debug(paste(
-    "Convert.Inputs", fcn, input.id, host$name, outfolder, formatname, mimetype, 
-    site.id, start_date, end_date))
-
+  
+  logger.debug(paste("Convert.Inputs", fcn, input.id, host$name, outfolder, formatname, 
+                     mimetype, site.id, start_date, end_date))
+  
   n <- nchar(outfolder)
-  if(substr(outfolder,n,n) != "/") {
-    outfolder = paste0(outfolder,"/")
+  if (substr(outfolder, n, n) != "/") {
+    outfolder <- paste0(outfolder, "/")
   }
   
-  outname = tail(unlist(strsplit(outfolder,'/')), n=1)
-
-  print(paste(
-    "start CHECK Convert.Inputs", fcn, input.id, host$name, outfolder, formatname, mimetype, 
-    site.id, start_date, end_date))
-  existing.dbfile <- dbfile.input.check(
-    siteid=site.id, mimetype=mimetype, formatname=formatname, parentid=input.id, 
-    con=con, hostname=host$name, ignore.dates=TRUE)
-  print(existing.dbfile, digits=10)
+  outname <- tail(unlist(strsplit(outfolder, "/")), n = 1)
+  
+  print(paste("start CHECK Convert.Inputs", fcn, input.id, host$name, outfolder, 
+              formatname, mimetype, site.id, start_date, end_date))
+  existing.dbfile <- dbfile.input.check(siteid = site.id,
+                                        mimetype = mimetype, 
+                                        formatname = formatname, 
+                                        parentid = input.id, 
+                                        con = con, 
+                                        hostname = host$name, 
+                                        ignore.dates = TRUE)
+  print(existing.dbfile, digits = 10)
   print("end CHECK")
-
-  if(nrow(existing.dbfile) > 0) {
-    existing.input <- db.query(paste0("SELECT * FROM inputs WHERE id=", existing.dbfile[['container_id']]), con)    
-    # Convert dates to Date objects and strip all time zones (DB values are timezone-free)
-    start_date <- force_tz(as_date(start_date), 'GMT')
-    end_date <- force_tz(as_date(end_date), 'GMT')
-    existing.input$start_date <- force_tz(as_date(existing.input$start_date), 'GMT')
-    existing.input$end_date <- force_tz(as_date(existing.input$end_date), 'GMT')
-
-    if(overwrite) {
+  
+  if (nrow(existing.dbfile) > 0) {
+    existing.input <- db.query(paste0("SELECT * FROM inputs WHERE id=", existing.dbfile[["container_id"]]), 
+                               con)
+    # Convert dates to Date objects and strip all time zones 
+    # (DB values are timezone-free)
+    start_date <- force_tz(as_date(start_date), "UTC")
+    end_date   <- force_tz(as_date(end_date), "UTC")
+    existing.input$start_date <- force_tz(as_date(existing.input$start_date), 
+                                          "UTC")
+    existing.input$end_date <- force_tz(as_date(existing.input$end_date), "UTC")
+    
+    if (overwrite) {
       # collect files to flag for deletion
-      files.to.delete <- remote.execute.R(paste0(
-        "list.files('", existing.dbfile[['file_path']], "', full.names=TRUE)"), 
-        host, user=NA, verbose=TRUE, R="R")
-
+      files.to.delete <- remote.execute.R(paste0("list.files('", 
+                                                 existing.dbfile[["file_path"]], 
+                                                 "', full.names=TRUE)"), 
+                                          host, user = NA, verbose = TRUE, R = "R")
+      
       file.deletion.commands <- .get.file.deletion.commands(files.to.delete)
       
-      remote.execute.R(file.deletion.commands$move.to.tmp, host, user=NA, verbose=TRUE, R="R")
+      remote.execute.R(file.deletion.commands$move.to.tmp, host, user = NA, 
+                       verbose = TRUE, R = "R")
       
       # Schedule files to be replaced or deleted on exiting the function
       succesful <- FALSE
-      on.exit(
-        if(exists("successful") && successful) {
-          logger.info("Conversion successful, with overwrite=TRUE. Deleting old files.")
-          remote.execute.R(file.deletion.commands$delete.tmp, host, user=NA, verbose=TRUE, R="R")
-        } else {
-          logger.info("Conversion failed. Replacing old files.")
-          remote.execute.R(file.deletion.commands$replace.from.tmp, host, user=NA, verbose=TRUE, R="R")
-        }
-      )
-    } else if((start_date >= existing.input$start_date) && (end_date <= existing.input$end_date)) {
-      # There's an existing input that spans desired start/end dates. Use that one. 
+      on.exit(if (exists("successful") && successful) {
+        logger.info("Conversion successful, with overwrite=TRUE. Deleting old files.")
+        remote.execute.R(file.deletion.commands$delete.tmp, host, user = NA, 
+                         verbose = TRUE, R = "R")
+      } else {
+        logger.info("Conversion failed. Replacing old files.")
+        remote.execute.R(file.deletion.commands$replace.from.tmp, host, user = NA, 
+                         verbose = TRUE, R = "R")
+      })
+    } else if ((start_date >= existing.input$start_date) && (end_date <= existing.input$end_date)) {
+      # There's an existing input that spans desired start/end dates. Use that one.
       logger.info("Skipping this input conversion because files are already available.")
-      return(list(input.id=existing.input$id, dbfile.id=existing.dbfile$id))
+      return(list(input.id = existing.input$id, dbfile.id = existing.dbfile$id))
     } else {
-      # Start/end dates need to be updated so that the input spans a continuous timeframe
+      # Start/end dates need to be updated so that the input spans a continuous
+      # timeframe
       start_date <- min(start_date, existing.input$start_date)
       end_date <- max(end_date, existing.input$end_date)
-      logger.info(paste0("Changed start/end dates to '", start_date, "'/'", end_date, "' ",
-                  "so that existing input can be updated while maintaining continuous time span."))
+      logger.info(paste0("Changed start/end dates to '", 
+                         start_date, "'/'", end_date, "' ", 
+                         "so that existing input can be updated while maintaining continuous time span."))
       
       # There might be existing files for some years (but not all; checked that above)
-      # fcn should be smart enough not overwrite the existing ones, 
-      # and hopefully won't waste time working on them either
-      # At the end, if convert.inputs was successful we'll need to update its start/end dates
-      # We don't know the dbfile path/prefix until after fcn runs, so unfortunately can't check 
-      # that the new dbfile record won't conflict with existing ones. 
+      # fcn should be smart enough not overwrite the existing ones, and hopefully won't
+      # waste time working on them either At the end, if convert.inputs was successful
+      # we'll need to update its start/end dates We don't know the dbfile path/prefix
+      # until after fcn runs, so unfortunately can't check that the new dbfile record
+      # won't conflict with existing ones.
     }
   } else {
     # No existing record found. Should be good to go.
   }
   
-  
-  
   machine.host <- ifelse(host$name == "localhost", fqdn(), host$name)
-  machine = db.query(paste0("SELECT * from machines where hostname = '", machine.host, "'"), con)
+  machine <- db.query(paste0("SELECT * from machines where hostname = '", 
+                             machine.host, "'"), con)
   
-  if(nrow(machine)==0){
+  if (nrow(machine) == 0) {
     logger.error("machine not found", host$name)
     return(NULL)
   }
-
-  if(missing(input.id) || is.na(input.id) || is.null(input.id)) {
+  
+  if (missing(input.id) || is.na(input.id) || is.null(input.id)) {
     input <- dbfile <- NULL
   } else {
-    input = db.query(paste("SELECT * from inputs where id =", input.id), con)
-    if(nrow(input)==0){
+    input <- db.query(paste("SELECT * from inputs where id =", input.id), con)
+    if (nrow(input) == 0) {
       logger.error("input not found", input.id)
       return(NULL)
     }
     
-    dbfile = db.query(paste(
-      "SELECT * from dbfiles where container_id =", input.id, 
-      " and container_type = 'Input' and machine_id =", machine$id), con)
-    if(nrow(dbfile)==0) {
-      logger.error("dbfile not found",input.id);return(NULL)
+    dbfile <- db.query(paste("SELECT * from dbfiles where container_id =", input.id, 
+                             " and container_type = 'Input' and machine_id =", machine$id), con)
+    if (nrow(dbfile) == 0) {
+      logger.error("dbfile not found", input.id)
+      return(NULL)
     }
-    if(nrow(dbfile)>1) {
-      logger.warning("multiple dbfile records, using last",dbfile);
-      dbfile = dbfile[nrow(dbfile),]
+    if (nrow(dbfile) > 1) {
+      logger.warning("multiple dbfile records, using last", dbfile)
+      dbfile <- dbfile[nrow(dbfile), ]
     }
-  } 
-
-  #--------------------------------------------------------------------------------------------------#
-  # Perform Conversion 
-  conversion = "local.remote" #default
+  }
   
-  if(!is.null(browndog) && host$name == 'localhost'){ 
+  #--------------------------------------------------------------------------------------------------#
+  # Perform Conversion
+  conversion <- "local.remote"  #default
+  
+  if (!is.null(browndog) && host$name == "localhost") {
     # perform conversions with Brown Dog - only works locally right now
-    library(RCurl) 
+    library(RCurl)
     
-    # Determine outputtype using formatname and mimetype of output file
-    # Add issue to github that extension of formats table to include outputtype 
-    if(mimetype ==  'application/x-netcdf') { # Convert to netcdf - only using localhost
-      outputtype <- 'pecan.zip'
-    } else { # Convert to model specific format
-      if(formatname == 'ed.met_driver_header_files_format' ||
-         formatname == 'ed.met_driver_header files format') {
-        outputtype <- 'ed.zip'
-      } else if(formatname == 'Sipnet.climna') {
-        outputtype <- 'clim'
-      } else if(formatname == 'DALEC meteorology') {
-        outputtype <- 'dalec.dat'
-      } else if(formatname == 'LINKAGES met') {
-        outputtype <- 'linkages.dat'
+    # Determine outputtype using formatname and mimetype of output file Add issue to
+    # github that extension of formats table to include outputtype Convert to netcdf
+    # - only using localhost
+    if (mimetype == "application/x-netcdf") {
+      outputtype <- "pecan.zip"
+    } else {
+      # Convert to model specific format
+      if (formatname == "ed.met_driver_header_files_format" || formatname == 
+          "ed.met_driver_header files format") {
+        outputtype <- "ed.zip"
+      } else if (formatname == "Sipnet.climna") {
+        outputtype <- "clim"
+      } else if (formatname == "DALEC meteorology") {
+        outputtype <- "dalec.dat"
+      } else if (formatname == "LINKAGES met") {
+        outputtype <- "linkages.dat"
+      } else {
+        logger.severe(paste("Unknown formatname", formatname))
       }
     }
     
     # create curl options
     if (!is.null(browndog$username) && !is.null(browndog$password)) {
-      userpwd <- paste(browndog$username, browndog$password, sep=":")
+      userpwd <- paste(browndog$username, browndog$password, sep = ":")
       curloptions <- list(userpwd = userpwd, httpauth = 1L)
     }
-    curloptions <- c(curloptions, followlocation=TRUE)
+    curloptions <- c(curloptions, followlocation = TRUE)
     
-    # check if we can do conversion 
-    out.html <- getURL(paste0(
-      "http://dap-dev.ncsa.illinois.edu:8184/inputs/", browndog$inputtype), .opts = curloptions)
-    if(outputtype %in% unlist(strsplit(out.html, '\n'))){
-      logger.info(paste("Conversion from", browndog$inputtype, "to", outputtype, "through Brown Dog"))
+    # check if we can do conversion
+    out.html <- getURL(paste0("http://dap-dev.ncsa.illinois.edu:8184/inputs/", 
+                              browndog$inputtype), .opts = curloptions)
+    if (outputtype %in% unlist(strsplit(out.html, "\n"))) {
+      logger.info(paste("Conversion from", browndog$inputtype, "to", outputtype, 
+                        "through Brown Dog"))
       conversion <- "browndog"
     }
   }
   
-  if(conversion == "browndog"){
-    url <- file.path(browndog$url,outputtype) 
+  if (conversion == "browndog") {
+    url <- file.path(browndog$url, outputtype)
     
-    # loop over files in localhost and zip to send to Brown Dog 
-    files <- list.files(dbfile$file_path, pattern=dbfile$file_name)
-    files <- grep(dbfile$file_name, files,value=T)
-    zipfile <- paste0(dbfile$file_name,".", browndog$inputtype)
-    system(paste("cd", dbfile$file_path, "; zip", zipfile,  paste(files, collapse = " ")))
-    zipfile <- file.path(dbfile$file_path, zipfile) 
+    # loop over files in localhost and zip to send to Brown Dog
+    files <- list.files(dbfile$file_path, pattern = dbfile$file_name)
+    files <- grep(dbfile$file_name, files, value = TRUE)
+    zipfile <- paste0(dbfile$file_name, ".", browndog$inputtype)
+    system(paste("cd", dbfile$file_path, "; zip", zipfile, paste(files, collapse = " ")))
+    zipfile <- file.path(dbfile$file_path, zipfile)
     
     # check for and create output folder
-    if(!file.exists(outfolder)){
-      dir.create(outfolder, showWarnings=FALSE, recursive=TRUE)
+    if (!file.exists(outfolder)) {
+      dir.create(outfolder, showWarnings = FALSE, recursive = TRUE)
     }
     
     # post zipped file to Brown Dog
-    html <- postForm(url,"fileData" = fileUpload(zipfile), .opts = curloptions)
+    html <- postForm(url, fileData = fileUpload(zipfile), .opts = curloptions)
     link <- getHTMLLinks(html)
     file.remove(zipfile)
     
     # download converted file
-    outfile <- file.path(outfolder,unlist(strsplit(basename(link),"_"))[2])
-    download.url(url = link, file = outfile, timeout = 600, .opts = curloptions, retry404 = TRUE)  
+    outfile <- file.path(outfolder, unlist(strsplit(basename(link), "_"))[2])
+    download.url(url = link, file = outfile, timeout = 600, .opts = curloptions, retry404 = TRUE)
     
     # unzip downloaded file if necessary
-    if(file.exists(outfile)) {
-      if(tail(unlist(strsplit(outfile, "[.]")), 1)=="zip"){
-        fname <- unzip(outfile, list=TRUE)$Name
-        unzip(outfile, files=fname, exdir=outfolder, overwrite=TRUE)
+    if (file.exists(outfile)) {
+      if (tail(unlist(strsplit(outfile, "[.]")), 1) == "zip") {
+        fname <- unzip(outfile, list = TRUE)$Name
+        unzip(outfile, files = fname, exdir = outfolder, overwrite = TRUE)
         file.remove(outfile)
       } else {
         fname <- list.files(outfolder)
       }
     }
     
-    # settings$run$inputs$path <- outputfile what if there is more than 1 output file?
+    # settings$run$inputs$path <- outputfile 
+    # what if there is more than 1 output file?
     rows <- length(fname)
-    result <- data.frame(file=character(rows), host=character(rows),
-                         mimetype=character(rows), formatname=character(rows),
-                         startdate=character(rows), enddate=character(rows),
+    result <- data.frame(file = character(rows), 
+                         host = character(rows), 
+                         mimetype = character(rows), 
+                         formatname = character(rows), 
+                         startdate = character(rows), 
+                         enddate = character(rows), 
                          stringsAsFactors = FALSE)
-    for(i in 1:rows){
-      old.file <- file.path(dbfile$file_path,files[i])
-      new.file <- file.path(outfolder,fname[i])
+    for (i in seq_len(rows)) {
+      old.file <- file.path(dbfile$file_path, files[i])
+      new.file <- file.path(outfolder, fname[i])
       
       # create array with results
-      result$file[i] <- new.file
-      result$host[i] <- fqdn()
-      result$startdate[i] <- paste(input$start_date, "00:00:00")
-      result$enddate[i] <- paste(input$end_date, "23:59:59")
-      result$mimetype[i] <- mimetype
-      result$formatname[i] <- formatname    
+      result$file[i]       <- new.file
+      result$host[i]       <- fqdn()
+      result$startdate[i]  <- paste(input$start_date, "00:00:00")
+      result$enddate[i]    <- paste(input$end_date, "23:59:59")
+      result$mimetype[i]   <- mimetype
+      result$formatname[i] <- formatname
     }
-  } else if (conversion == "local.remote") { 
+  } else if (conversion == "local.remote") {
     # perform conversion on local or remote host
-
+    
     fcn.args <- input.args
-    fcn.args$overwrite <- overwrite
-    fcn.args$in.path <- dbfile$file_path
-    fcn.args$in.prefix <- dbfile$file_name
-    fcn.args$outfolder <- outfolder
+    fcn.args$overwrite  <- overwrite
+    fcn.args$in.path    <- dbfile$file_path
+    fcn.args$in.prefix  <- dbfile$file_name
+    fcn.args$outfolder  <- outfolder
     fcn.args$start_date <- start_date
-    fcn.args$end_date <- end_date 
-
+    fcn.args$end_date   <- end_date
+    
     arg.string <- listToArgString(fcn.args)
     
-    if(!missing(format.vars)) {
+    if (!missing(format.vars)) {
       arg.string <- paste0(arg.string, ", format=", paste0(list(format.vars)))
     }
     
-    cmdFcn = paste0(pkg, "::", fcn, "(", arg.string, ")")
+    cmdFcn <- paste0(pkg, "::", fcn, "(", arg.string, ")")
     logger.debug(paste0("convert.input executing the following function:\n", cmdFcn))
-
-    result <- remote.execute.R(script=cmdFcn, host, user=NA, verbose=TRUE, R="R")
+    
+    result <- remote.execute.R(script = cmdFcn, host, user = NA, verbose = TRUE, R = "R")
   }
   
   print("RESULTS: Convert.Input")
@@ -235,58 +252,56 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
   
   #--------------------------------------------------------------------------------------------------#
   # Insert into Database
-  outlist <- unlist(strsplit(outname,"_")) 
-
+  outlist <- unlist(strsplit(outname, "_"))
+  
   ## insert new record into database
-  if(write==TRUE) {
-    if(exists("existing.input") && nrow(existing.input) > 0 &&
-       (existing.input$start_date != start_date || existing.input$end_date != end_date)) {
-      db.query(paste0(
-        "UPDATE inputs SET start_date='", start_date, "', end_date='", end_date, "', ", 
-        "updated_at=NOW() WHERE id=", existing.input$id), con)
+  if (write == TRUE) {
+    if (exists("existing.input") && nrow(existing.input) > 0 && 
+        (existing.input$start_date != start_date || existing.input$end_date != end_date)) {
+      db.query(paste0("UPDATE inputs SET start_date='", start_date, "', end_date='", 
+                      end_date, "', ", "updated_at=NOW() WHERE id=", existing.input$id), 
+               con)
     }
     
-    if(overwrite) {
-      # A bit hacky, but need to make sure that all fields are updated to expected values 
-      # (i.e., what they'd be if convert.input was creating a new record)
-      if(exists("existing.input") && nrow(existing.input) > 0) {
-        db.query(paste0(
-          "UPDATE inputs SET name='", basename(dirname(result$file[1])), "', ", 
-          "updated_at=NOW() WHERE id=", existing.input$id), con)
-      } 
-      if(exists("existing.dbfile") && nrow(existing.dbfile) > 0) {
-        db.query(paste0(
-          "UPDATE dbfiles SET file_path='", dirname(result$file[1]), "', ",
-          "file_name='", result$dbfile.name[1], "', ", 
-          "updated_at=NOW() WHERE id=", existing.dbfile$id), con)
+    if (overwrite) {
+      # A bit hacky, but need to make sure that all fields are updated to expected
+      # values (i.e., what they'd be if convert.input was creating a new record)
+      if (exists("existing.input") && nrow(existing.input) > 0) {
+        db.query(paste0("UPDATE inputs SET name='", basename(dirname(result$file[1])), 
+                        "', ", "updated_at=NOW() WHERE id=", existing.input$id), con)
+      }
+      if (exists("existing.dbfile") && nrow(existing.dbfile) > 0) {
+        db.query(paste0("UPDATE dbfiles SET file_path='", dirname(result$file[1]), 
+                        "', ", "file_name='", result$dbfile.name[1], "', ", 
+                        "updated_at=NOW() WHERE id=", existing.dbfile$id), con)
       }
     }
-
+    
     parent.id <- ifelse(is.null(input), NA, input$id)
     
-    if("newsite" %in% names(input.args) && !is.null(input.args[["newsite"]])){
+    if ("newsite" %in% names(input.args) && !is.null(input.args[["newsite"]])) {
       site.id <- input.args$newsite
-    } 
+    }
     
-    newinput <- dbfile.input.insert(in.path=dirname(result$file[1]),
-                                    in.prefix=result$dbfile.name[1],
+    newinput <- dbfile.input.insert(in.path = dirname(result$file[1]), 
+                                    in.prefix = result$dbfile.name[1], 
                                     siteid = site.id, 
-                                    startdate = start_date, 
+                                    startdate = start_date,
                                     enddate = end_date, 
                                     mimetype, 
-                                    formatname,
+                                    formatname, 
                                     parentid = parent.id,
-                                    con = con,
-                                    hostname = machine$hostname) 
-
+                                    con = con, 
+                                    hostname = machine$hostname)
+    
     successful <- TRUE
     return(newinput)
   } else {
-    logger.warn('Input was not added to the database')
+    logger.warn("Input was not added to the database")
     successful <- TRUE
     return(NULL)
   }
-}
+} # convert.input
 
 
 .get.file.deletion.commands <- function(files.to.delete) {
@@ -297,7 +312,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
     tmp.dirs.string <- paste0("c(", paste(paste0("'", tmp.dirs, "'"), collapse=', '), ")")
     tmp.path.string <- paste0("c(", paste(paste0("'", tmp.paths, "'"), collapse=', '), ")")
     original.path.string <- paste0("c(", paste(paste0("'", files.to.delete, "'"), collapse=', '), ")")
-
+    
     move.to.tmp <- paste0(
       "dir.create(", tmp.dirs.string, ", recursive=TRUE, showWarnings=FALSE); ",
       "file.rename(from=", original.path.string, ", to=", tmp.path.string, ")"
@@ -315,4 +330,4 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
   } else {
     return(NULL)
   }
-}
+} # .get.file.deletion.commands

--- a/utils/R/distn.stats.R
+++ b/utils/R/distn.stats.R
@@ -2,63 +2,63 @@
 ##' named distributions different
 ##' 
 ##' @title Distribution Stats
-##' @param distn named distribution, one of "beta", "exp", "f", "gamma", "lnorm", "norm", "t", 
+##' @param distn named distribution, one of 'beta', 'exp', 'f', 'gamma', 'lnorm', 'norm', 't', 
 ##' @param a numeric; first parameter of \code{distn} 
 ##' @param b numeric; second parameter of \code{distn}
 ##' @return vector with mean and standard deviation
 ##' @export
 ##' @author David LeBauer
 ##' @examples
-##' distn.stats("norm", 0, 1)
-distn.stats <- function(distn,a,b){
+##' distn.stats('norm', 0, 1)
+distn.stats <- function(distn, a, b) {
   mean <- sd <- NULL
-  if(distn == "beta"){
-    mean <- a/(a+b)
-    sd   <- sqrt(a*b/((a+b)^2 * (a+b+1)))
-  } else if(distn == "exp"){
-    mean <- 1/a
-    sd <- 1/a
-  } else if(distn == "f"){
-    mean <- b/(b-2)
-    sd   <- sqrt(2*b*b*(a + b -2)/(a*(b-2)^2*(b-4)))
-  } else if(distn == "gamma"){
+  if (distn == "beta") {
+    mean <- a / (a + b)
+    sd   <- sqrt(a * b / ((a + b) ^ 2 * (a + b + 1)))
+  } else if (distn == "exp") {
+    mean <- 1 / a
+    sd   <- 1 / a
+  } else if (distn == "f") {
+    mean <- b / (b - 2)
+    sd   <- sqrt(2 * b * b * (a + b - 2) / (a * (b - 2) ^ 2 * (b - 4)))
+  } else if (distn == "gamma") {
     mean <- a/b
-    sd   <- sqrt(a/b^2)
-  } else if (distn == "lnorm"){
-    mean <- exp(a + 0.5*b^2)
-    sd   <- sqrt(exp(2*a + b^2)*(exp(b^2)-1))
-  } else if (distn == "norm"){
+    sd   <- sqrt(a / b ^ 2)
+  } else if (distn == "lnorm") {
+    mean <- exp(a + 0.5 * b ^ 2)
+    sd   <- sqrt(exp(2 * a + b ^ 2) * (exp(b ^ 2) - 1))
+  } else if (distn == "norm") {
     mean <- a
     sd   <- b
-  } else if (distn == "t"){
+  } else if (distn == "t") {
     mean <- 0
-    sd   <- sqrt(a/(a-2))
-  } else if (distn == "unif"){
-    mean <- 0.5*(a+b)
-    sd <- (b-a)/sqrt(12)
-  } else if (distn == "weibull"){
-    mean <- b * gamma(1+1/a)
-    sd   <- b^2 * (gamma(1 + 2/a) - (gamma(1 + 1/a))^2)
+    sd   <- sqrt(a / (a - 2))
+  } else if (distn == "unif") {
+    mean <- 0.5 * (a + b)
+    sd   <- (b - a) / sqrt(12)
+  } else if (distn == "weibull") {
+    mean <- b * gamma(1 + 1 / a)
+    sd   <- b ^ 2 * (gamma(1 + 2 / a) - (gamma(1 + 1 / a)) ^ 2)
   }
   return(c(mean, sd))
-}
+} # distn.stats
+
 
 ##' a helper function for computing summary statistics of a parametric distribution
 ##' 
-##' @title return mean and standard deviation of a distribution for each distribution in a table with \code{colnames = c("distn", "a", "b")},
+##' @title return mean and standard deviation of a distribution for each distribution in a table with \code{colnames = c('distn', 'a', 'b')},
 ##'  e.g. in a table of priors
 ##' @param distns table of distributions; see examples 
 ##' @return named vector of mean and SD
 ##' @export
 ##' @author David LeBauer
-distn.table.stats <- function(distns){
-  y = as.data.frame(matrix(NA,nrow(distns),2))
-  for(i in 1:nrow(distns)){
-    x = distns[i,]
-    y[i,] = distn.stats(x[1],as.numeric(x[2]),as.numeric(x[3]))
+distn.table.stats <- function(distns) {
+  y <- as.data.frame(matrix(NA, nrow(distns), 2))
+  for (i in seq_len(nrow(distns))) {
+    x <- distns[i, ]
+    y[i, ] <- distn.stats(x[1], as.numeric(x[2]), as.numeric(x[3]))
   }
-  rownames(y) = rownames(distns)
-  colnames(y) = c('mean', 'sd')
+  rownames(y) <- rownames(distns)
+  colnames(y) <- c("mean", "sd")
   return(y)
-}
-
+} # distn.table.stats

--- a/utils/R/do.conversions.R
+++ b/utils/R/do.conversions.R
@@ -4,20 +4,24 @@
 ##' @description Input conversion workflow
 ##' @author Ryan Kelly, Rob Kooper, Betsy Cowdery
 do.conversions <- function(settings) {
-  if(is.MultiSettings(settings)) {
+  if (is.MultiSettings(settings)) {
     return(papply(settings, do.conversions))
   }
   
   needsave <- FALSE
-  if(is.character(settings$run$inputs)) settings$run$inputs <- NULL  ## check for empty set
-  for(i in seq_along(settings$run$inputs)) {
+  if (is.character(settings$run$inputs)) {
+    settings$run$inputs <- NULL  ## check for empty set
+  }
+  for (i in seq_along(settings$run$inputs)) {
     input <- settings$run$inputs[[i]]
-    if (is.null(input)) next
+    if (is.null(input)) {
+      next
+    }
     
     input.tag <- names(settings$run$input)[i]
     
     # fia database
-    if ((input['input'] == 'fia') && (status.check("FIA2ED") == 0)) {
+    if ((input["input"] == "fia") && (status.check("FIA2ED") == 0)) {
       status.start("FIA2ED")
       fia.to.psscss(settings)
       status.end()
@@ -25,30 +29,29 @@ do.conversions <- function(settings) {
     }
     
     # met conversion
-    if(input.tag == 'met') {
+    if (input.tag == "met") {
       name <- ifelse(is.null(settings$browndog), "MET Process", "BrownDog")
       if (is.null(input$path) && (status.check(name) == 0)) {
         status.start(name)
-        result <- PEcAn.data.atmosphere::met.process(
-          site       = settings$run$site, 
-          input_met  = settings$run$inputs$met,
-          start_date = settings$run$start.date,
-          end_date   = settings$run$end.date,
-          model      = settings$model$type,
-          host       = settings$host,
-          dbparms    = settings$database$bety, 
-          dir        = settings$database$dbfiles,
-          browndog   = settings$browndog)
-        settings$run$inputs[[i]][['path']] <- result
+        result <- PEcAn.data.atmosphere::met.process(site = settings$run$site, 
+                                                     input_met = settings$run$inputs$met, 
+                                                     start_date = settings$run$start.date, 
+                                                     end_date = settings$run$end.date, 
+                                                     model = settings$model$type, 
+                                                     host = settings$host, 
+                                                     dbparms = settings$database$bety,
+                                                     dir = settings$database$dbfiles, 
+                                                     browndog = settings$browndog)
+        settings$run$inputs[[i]][["path"]] <- result
         status.end()
         needsave <- TRUE
       }
     }
   }
   if (needsave) {
-    saveXML(listToXml(settings, "pecan"), file=file.path(settings$outdir, 'pecan.METProcess.xml'))  
-  } else if (file.exists(file.path(settings$outdir, 'pecan.METProcess.xml'))) {
-    settings <- read.settings(file.path(settings$outdir, 'pecan.METProcess.xml'))
+    saveXML(listToXml(settings, "pecan"), file = file.path(settings$outdir, "pecan.METProcess.xml"))
+  } else if (file.exists(file.path(settings$outdir, "pecan.METProcess.xml"))) {
+    settings <- read.settings(file.path(settings$outdir, "pecan.METProcess.xml"))
   }
   return(settings)
-}
+} # do.conversions

--- a/utils/R/download.url.R
+++ b/utils/R/download.url.R
@@ -20,19 +20,19 @@
 ##' \dontrun{
 ##' download.url('http://localhost/', index.html)
 ##' }
-download.url = function(url, file, timeout=600, .opts=list(), retry404=TRUE) {
-  dir.create(basename(file), recursive=TRUE)
+download.url <- function(url, file, timeout = 600, .opts = list(), retry404 = TRUE) {
+  dir.create(basename(file), recursive = TRUE)
   count <- 0
-  while (!url.exists(url, .opts=.opts) && count < timeout) {
+  while (!url.exists(url, .opts = .opts) && count < timeout) {
     count <- count + 1
     Sys.sleep(1)
   }
   if (count >= timeout) {
     return(NA)
   }
-  f <- CFILE(file, mode="wb")
-  curlPerform(url=url, writedata=f@ref, .opts=.opts)
-	RCurl::close(f)
+  f <- CFILE(file, mode = "wb")
+  curlPerform(url = url, writedata = f@ref, .opts = .opts)
+  RCurl::close(f)
   
   return(file)
-}
+} # download.url

--- a/utils/R/ensemble.R
+++ b/utils/R/ensemble.R
@@ -6,7 +6,6 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-#-------------------------------------------------------------------------------
 
 ##' Reads output from model ensemble
 ##'
@@ -23,29 +22,29 @@
 ##' @export
 ##' @author Ryan Kelly, David LeBauer, Rob Kooper
 #--------------------------------------------------------------------------------------------------#
-read.ensemble.output <- function(ensemble.size, pecandir, outdir, 
-                                 start.year, end.year, variable, ens.run.ids=NULL){
+read.ensemble.output <- function(ensemble.size, pecandir, outdir, start.year, end.year, 
+                                 variable, ens.run.ids = NULL) {
   if (is.null(ens.run.ids)) {
-    samples.file <- file.path(pecandir, 'samples.Rdata')
-    if(file.exists(samples.file)){
+    samples.file <- file.path(pecandir, "samples.Rdata")
+    if (file.exists(samples.file)) {
       load(samples.file)
       ens.run.ids <- runs.samples$ensemble
     } else {
-      stop(samples.file, "not found required by read.ensemble.output")      
+      stop(samples.file, "not found required by read.ensemble.output")
     }
   }
-
+  
   ensemble.output <- list()
-  for(row in rownames(ens.run.ids)) {
-    run.id <- ens.run.ids[row, 'id']
+  for (row in rownames(ens.run.ids)) {
+    run.id <- ens.run.ids[row, "id"]
     logger.info("reading ensemble output from run id: ", run.id)
-    ensemble.output[[row]] <- sapply(read.output(run.id, file.path(outdir, run.id),
-                                                 start.year, end.year, variable),
-                                     mean,na.rm=TRUE)
+    ensemble.output[[row]] <- sapply(read.output(run.id, file.path(outdir, run.id), 
+                                                 start.year, end.year, variable), mean, na.rm = TRUE)
   }
   return(ensemble.output)
-}
-#==================================================================================================#
+} # read.ensemble.output
+
+
 ##' Get parameter values used in ensemble
 ##'
 ##' Returns a matrix of randomly or quasi-randomly sampled trait values 
@@ -63,80 +62,83 @@ read.ensemble.output <- function(ensemble.size, pecandir, outdir,
 ##' @export
 ##' @import randtoolbox
 ##' @author David LeBauer
-get.ensemble.samples <- function(ensemble.size, pft.samples, env.samples, method="uniform", ...) {
+get.ensemble.samples <- function(ensemble.size, pft.samples, env.samples, 
+                                 method = "uniform", ...) {
   
-  if(is.null(method)) {
+  if (is.null(method)) {
     logger.info("No sampling method supplied, defaulting to uniform random sampling")
-    method="uniform"
+    method <- "uniform"
   }
   
-  ##force as numeric for compatibility with Fortran code in halton()
+  ## force as numeric for compatibility with Fortran code in halton()
   ensemble.size <- as.numeric(ensemble.size)
-  if(ensemble.size <= 0){
+  if (ensemble.size <= 0) {
     ans <- NULL
   } else if (ensemble.size == 1) {
-    ans <- get.sa.sample.list(pft.samples,env.samples,0.50)
+    ans <- get.sa.sample.list(pft.samples, env.samples, 0.5)
   } else {
-    pft.samples[[length(pft.samples)+1]] = env.samples
-    names(pft.samples)[length(pft.samples)] <- 'env'
+    pft.samples[[length(pft.samples) + 1]] <- env.samples
+    names(pft.samples)[length(pft.samples)] <- "env"
     pft2col <- NULL
-    for(i in 1:length(pft.samples)){
-      pft2col <- c(pft2col,rep(i,length(pft.samples[[i]])))
+    for (i in seq_along(pft.samples)) {
+      pft2col <- c(pft2col, rep(i, length(pft.samples[[i]])))
     }
-        
+    
     total.sample.num <- sum(sapply(pft.samples, length))
     random.samples <- NULL
-
-      if(method == "halton"){
-        logger.info("Using ", method, "method for sampling")
-        random.samples <- halton(n = ensemble.size, dim=total.sample.num, ...)
-        ##force as a matrix in case length(samples)=1
-        random.samples <- as.matrix(random.samples)
-      } else if(method == "sobol"){
-        logger.info("Using ", method, "method for sampling")
-        random.samples <- sobol(n = ensemble.size, dim=total.sample.num, ...)
-        ##force as a matrix in case length(samples)=1
-        random.samples <- as.matrix(random.samples)
-      } else if(method == "torus"){
-        logger.info("Using ", method, "method for sampling")
-        random.samples <- torus(n = ensemble.size, dim=total.sample.num, ...)
-        ##force as a matrix in case length(samples)=1
-        random.samples <- as.matrix(random.samples)
-      } else if(method == "lhc"){
-        logger.info("Using ", method, "method for sampling")
-        random.samples <- lhc(t(matrix(0:1, ncol=total.sample.num, nrow=2)),ensemble.size)
-      } else if(method == "uniform"){
-        logger.info("Using ", method, "random sampling")
-        #uniform random
-        random.samples <- matrix(runif(ensemble.size*total.sample.num), ensemble.size, total.sample.num)
-      } else {
-        logger.info("Method ", method, " has not been implemented yet, using uniform random sampling")
-        #uniform random
-        random.samples <- matrix(runif(ensemble.size*total.sample.num), ensemble.size, total.sample.num)
-      }
     
+    if (method == "halton") {
+      logger.info("Using ", method, "method for sampling")
+      random.samples <- halton(n = ensemble.size, dim = total.sample.num, ...)
+      ## force as a matrix in case length(samples)=1
+      random.samples <- as.matrix(random.samples)
+    } else if (method == "sobol") {
+      logger.info("Using ", method, "method for sampling")
+      random.samples <- sobol(n = ensemble.size, dim = total.sample.num, ...)
+      ## force as a matrix in case length(samples)=1
+      random.samples <- as.matrix(random.samples)
+    } else if (method == "torus") {
+      logger.info("Using ", method, "method for sampling")
+      random.samples <- torus(n = ensemble.size, dim = total.sample.num, ...)
+      ## force as a matrix in case length(samples)=1
+      random.samples <- as.matrix(random.samples)
+    } else if (method == "lhc") {
+      logger.info("Using ", method, "method for sampling")
+      random.samples <- lhc(t(matrix(0:1, ncol = total.sample.num, nrow = 2)), ensemble.size)
+    } else if (method == "uniform") {
+      logger.info("Using ", method, "random sampling")
+      # uniform random
+      random.samples <- matrix(runif(ensemble.size * total.sample.num),
+                               ensemble.size, 
+                               total.sample.num)
+    } else {
+      logger.info("Method ", method, " has not been implemented yet, using uniform random sampling")
+      # uniform random
+      random.samples <- matrix(runif(ensemble.size * total.sample.num), 
+                               ensemble.size, 
+                               total.sample.num)
+    }
     
     ensemble.samples <- list()
     
     col.i <- 0
-    for(pft.i in seq(pft.samples)){
-      ensemble.samples[[pft.i]] <-
-        matrix(nrow=ensemble.size,ncol=length(pft.samples[[pft.i]]))
-      for(trait.i in seq(pft.samples[[pft.i]])) {
-        col.i<-col.i+1
-        ensemble.samples[[pft.i]][, trait.i] <- 
-          quantile(pft.samples[[pft.i]][[trait.i]],
-                   random.samples[, col.i])
-      } # end trait
+    for (pft.i in seq(pft.samples)) {
+      ensemble.samples[[pft.i]] <- matrix(nrow = ensemble.size, ncol = length(pft.samples[[pft.i]]))
+      for (trait.i in seq(pft.samples[[pft.i]])) {
+        col.i <- col.i + 1
+        ensemble.samples[[pft.i]][, trait.i] <- quantile(pft.samples[[pft.i]][[trait.i]], 
+                                                         random.samples[, col.i])
+      }  # end trait
       ensemble.samples[[pft.i]] <- as.data.frame(ensemble.samples[[pft.i]])
       colnames(ensemble.samples[[pft.i]]) <- names(pft.samples[[pft.i]])
-    } #end pft
+    }  #end pft
     names(ensemble.samples) <- names(pft.samples)
     ans <- ensemble.samples
   }
   return(ans)
-}  ### End of function: get.ensemble.samples
-#==================================================================================================#
+} # get.ensemble.samples
+
+
 ##' Write ensemble config files
 ##'
 ##' Writes config files for use in meta-analysis and returns a list of run ids.
@@ -151,17 +153,19 @@ get.ensemble.samples <- function(ensemble.size, pft.samples, env.samples, method
 ##' @return list, containing $runs = data frame of runids, and $ensemble.id = the ensemble ID for these runs. Also writes sensitivity analysis configuration files as a side effect
 ##' @export
 ##' @author David LeBauer, Carl Davidson
-write.ensemble.configs <- function(defaults, ensemble.samples, settings,
-                                   model, clean=FALSE, write.to.db = TRUE){
+write.ensemble.configs <- function(defaults, ensemble.samples, settings, model, 
+                                   clean = FALSE, write.to.db = TRUE) {
   
-  my.write.config <- paste("write.config.", model, sep="")
-
-  if(is.null(ensemble.samples)) return(list(runs=NULL, ensemble.id=NULL))
+  my.write.config <- paste("write.config.", model, sep = "")
+  
+  if (is.null(ensemble.samples)) {
+    return(list(runs = NULL, ensemble.id = NULL))
+  }
   
   # Open connection to database so we can store all run/ensemble information
-  if(write.to.db){
-    con <- try(db.open(settings$database$bety), silent=TRUE)
-    if(is.character(con)){
+  if (write.to.db) {
+    con <- try(db.open(settings$database$bety), silent = TRUE)
+    if (is.character(con)) {
       con <- NULL
     }
   } else {
@@ -177,56 +181,66 @@ write.ensemble.configs <- function(defaults, ensemble.samples, settings,
   
   # create an ensemble id
   if (!is.null(con)) {
-    # write enseblem first
+    # write ensemble first
     now <- format(Sys.time(), "%Y-%m-%d %H:%M:%S")
     db.query(paste0("INSERT INTO ensembles (created_at, runtype, workflow_id) values ('", 
-                     now, "', 'ensemble', ", workflow.id, ")"), con=con)
-    ensemble.id <- db.query(paste0("SELECT id FROM ensembles WHERE created_at='", now, "' AND runtype='ensemble'"), con=con)[['id']]
+                    now, "', 'ensemble', ", workflow.id, ")"), con = con)
+    ensemble.id <- db.query(paste0("SELECT id FROM ensembles WHERE created_at='", 
+                                   now, "' AND runtype='ensemble'"), con = con)[["id"]]
     for (pft in defaults) {
-      db.query(paste0("INSERT INTO posteriors_ensembles (posterior_id, ensemble_id, created_at, updated_at) values (",
-                      pft$posteriorid, ", ", ensemble.id, ", '", now, "', '", now, "');"), con=con)
+      db.query(paste0("INSERT INTO posteriors_ensembles (posterior_id, ensemble_id, created_at, updated_at) values (", 
+                      pft$posteriorid, ", ", 
+                      ensemble.id, ", '", now, "', '", now, "');"), 
+               con = con)
     }
   } else {
     ensemble.id <- NA
   }
-
+  
   # find all inputs that have an id
   inputs <- names(settings$run$inputs)
-  inputs <- inputs[grepl('.id$', inputs)]
+  inputs <- inputs[grepl(".id$", inputs)]
   
   # write configuration for each run of the ensemble
   runs <- data.frame()
-  for(counter in 1:settings$ensemble$size) {
+  for (counter in seq_len(settings$ensemble$size)) {
     if (!is.null(con)) {
       now <- format(Sys.time(), "%Y-%m-%d %H:%M:%S")
-      paramlist <- paste("ensemble=", counter, sep='')
-      db.query(paste0("INSERT INTO runs (model_id, site_id, start_time, finish_time, outdir, created_at, ensemble_id,",
-                       " parameter_list) values ('", 
-                       settings$model$id, "', '", settings$run$site$id, "', '", settings$run$start.date, "', '", 
-                       settings$run$end.date, "', '", settings$run$outdir , "', '", now, "', ", ensemble.id, ", '", 
-                       paramlist, "')"), con=con)
-      run.id <- db.query(paste0("SELECT id FROM runs WHERE created_at='", now, "' AND parameter_list='", paramlist, "'"), con=con)[['id']]
-
+      paramlist <- paste("ensemble=", counter, sep = "")
+      db.query(paste0("INSERT INTO runs (model_id, site_id, start_time, finish_time, outdir, created_at, ensemble_id,", 
+                      " parameter_list) values ('", settings$model$id,
+                      "', '", settings$run$site$id, 
+                      "', '", settings$run$start.date, 
+                      "', '", settings$run$end.date,
+                      "', '", settings$run$outdir,
+                      "', '", now, 
+                      "', ", ensemble.id, 
+                      ", '", paramlist, 
+                      "')"), con = con)
+      run.id <- db.query(paste0("SELECT id FROM runs WHERE created_at='", now, 
+                                "' AND parameter_list='", paramlist, "'"), con = con)[["id"]]
+      
       # associate inputs with runs
       if (!is.null(inputs)) {
-        for(x in inputs) {
-          db.query(paste0("INSERT INTO inputs_runs (input_id, run_id, created_at) ",
-                          "values (", settings$run$inputs[[x]], ", ", run.id, ", NOW());"), con=con)
+        for (x in inputs) {
+          db.query(paste0("INSERT INTO inputs_runs (input_id, run_id, created_at) ", 
+                          "values (", settings$run$inputs[[x]], ", ", run.id, ", NOW());"), 
+                   con = con)
         }
       }
-
+      
     } else {
-      run.id <- get.run.id('ENS', left.pad.zeros(counter, 5))
+      run.id <- get.run.id("ENS", left.pad.zeros(counter, 5))
     }
-    runs[counter, 'id'] <- run.id
+    runs[counter, "id"] <- run.id
     
     # create folders (cleaning up old ones if needed)
-    if(clean) {
+    if (clean) {
       unlink(file.path(settings$rundir, run.id))
       unlink(file.path(settings$modeloutdir, run.id))
     }
-    dir.create(file.path(settings$rundir, run.id), recursive=TRUE)
-    dir.create(file.path(settings$modeloutdir, run.id), recursive=TRUE)
+    dir.create(file.path(settings$rundir, run.id), recursive = TRUE)
+    dir.create(file.path(settings$modeloutdir, run.id), recursive = TRUE)
     
     # write run information to disk
     cat("runtype     : ensemble\n",
@@ -245,17 +259,18 @@ write.ensemble.configs <- function(defaults, ensemble.samples, settings,
         "hostname    : ", settings$host$name, "\n",
         "rundir      : ", file.path(settings$host$rundir, run.id), "\n",
         "outdir      : ", file.path(settings$host$outdir, run.id), "\n",
-        file=file.path(settings$rundir, run.id, "README.txt"), sep='')
+        file = file.path(settings$rundir, run.id, "README.txt"))
     
-    do.call(my.write.config, args = list(defaults = defaults,
-                                         trait.values = lapply(ensemble.samples, function(x, n){x[n, ]},n = counter),
+    do.call(my.write.config, args = list(defaults = defaults, 
+                                         trait.values = lapply(ensemble.samples, 
+                                                               function(x, n) { x[n, ] },
+                                                               n = counter), 
                                          settings = settings, run.id = run.id))
-    cat(run.id, file=file.path(settings$rundir, "runs.txt"), sep="\n", append=TRUE)
+    cat(run.id, file = file.path(settings$rundir, "runs.txt"), sep = "\n", append = TRUE)
   }
   if (!is.null(con)) {
     db.close(con)
   }
   
-  invisible(list(runs=runs, ensemble.id=ensemble.id))
-} ### End of function: write.ensemble.configs
-#==================================================================================================#
+  invisible(list(runs = runs, ensemble.id = ensemble.id))
+} # write.ensemble.configs

--- a/utils/R/fqdn.R
+++ b/utils/R/fqdn.R
@@ -6,7 +6,7 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-#--------------------------------------------------------------------------------------------------#
+
 ##' Returns the fully qualified hostname. This is potentially different from Sys.info()['nodename']
 ##' which can return just the hostname part and not the domain as well. For example the machine
 ##' pecan.ncsa.illinois.edu will return just that as fqdn but only pecan for hostname.
@@ -19,5 +19,5 @@
 ##' @examples
 ##' fqdn()
 fqdn <- function() {
-	system2('hostname', '-f', stdout=TRUE)
-}
+  system2("hostname", "-f", stdout = TRUE)
+} # fqdn

--- a/utils/R/full.path.R
+++ b/utils/R/full.path.R
@@ -6,7 +6,7 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-#--------------------------------------------------------------------------------------------------#
+
 ##' Creates an absolute path to a folder.
 ##'
 ##' This will take a folder and make it into an absolute folder name. It
@@ -19,21 +19,16 @@
 ##' @return absolute path
 ##' @export
 ##' @examples
-##' full.path("pecan")
-full.path <- function(folder){
+##' full.path('pecan')
+full.path <- function(folder) {
   # normalize pathname
-  folder <- normalizePath(folder, mustWork=FALSE)
-
+  folder <- normalizePath(folder, mustWork = FALSE)
+  
   # add cwd if needed
-  if (substr(folder, 1, 1) != '/') {
-  	folder <- file.path(getwd(), folder)
-  	folder <- normalizePath(folder, mustWork=FALSE)
+  if (substr(folder, 1, 1) != "/") {
+    folder <- file.path(getwd(), folder)
+    folder <- normalizePath(folder, mustWork = FALSE)
   }
-
-  invisible(folder)
-} 
-
-
-####################################################################################################
-### EOF.  End of R script file.          		
-####################################################################################################
+  
+  return(invisible(folder))
+} # full.path

--- a/utils/R/get.analysis.filenames.r
+++ b/utils/R/get.analysis.filenames.r
@@ -8,34 +8,35 @@
 ##'
 ##' @details Generally uses values in settings, but can be overwritten for manual uses
 ##' @author Ryan Kelly
-ensemble.filename <- function(settings, 
-                              prefix = "ensemble.samples", suffix = "Rdata", 
-                              all.var.yr = TRUE,
-                              ensemble.id = settings$ensemble$ensemble.id,
-                              variable    = settings$ensemble$variable,
-                              start.year  = settings$ensemble$start.year,
-                              end.year    = settings$ensemble$end.year) {
-
-  if(is.null(ensemble.id) || is.na(ensemble.id)) {
-    # This shouldn't generally arise, as run.write.configs() appends ensemble.id to settings. However,it will come up if running run.write.configs(..., write=F), because then no ensemble ID is created in the database. A simple workflow will still work in that case, but provenance will be lost if multiple ensembles are run.
+ensemble.filename <- function(settings, prefix = "ensemble.samples", suffix = "Rdata", 
+                              all.var.yr = TRUE, ensemble.id = settings$ensemble$ensemble.id, 
+                              variable = settings$ensemble$variable, 
+                              start.year = settings$ensemble$start.year, 
+                              end.year = settings$ensemble$end.year) {
+  
+  if (is.null(ensemble.id) || is.na(ensemble.id)) {
+    # This shouldn't generally arise, as run.write.configs() appends ensemble.id to
+    # settings. However,it will come up if running run.write.configs(..., write=F),
+    # because then no ensemble ID is created in the database. A simple workflow will
+    # still work in that case, but provenance will be lost if multiple ensembles are
+    # run.
     ensemble.id <- "NOENSEMBLEID"
   }
   
   ensemble.dir <- settings$outdir
   
-  dir.create(ensemble.dir, showWarnings=FALSE, recursive=TRUE)
+  dir.create(ensemble.dir, showWarnings = FALSE, recursive = TRUE)
   
-  if(all.var.yr) {
+  if (all.var.yr) {
     # All variables and years will be included; omit those from filename
-    ensemble.file <- file.path(ensemble.dir, 
-      paste(prefix, ensemble.id, suffix, sep='.'))
+    ensemble.file <- file.path(ensemble.dir, paste(prefix, ensemble.id, suffix, sep = "."))
   } else {
-    ensemble.file <- file.path(ensemble.dir, 
-      paste(prefix, ensemble.id, variable, start.year, end.year, suffix, sep='.'))
+    ensemble.file <- file.path(ensemble.dir, paste(prefix, ensemble.id, variable, 
+                                                   start.year, end.year, suffix, sep = "."))
   }
   
   return(ensemble.file)
-}
+} # ensemble.filename
 
 
 ##' Generate sensitivity analysis filenames
@@ -48,64 +49,77 @@ ensemble.filename <- function(settings,
 ##'
 ##' @details  Generally uses values in settings, but can be overwritten for manual uses
 ##' @author Ryan Kelly
-sensitivity.filename <- function(settings, 
-                              prefix = "sensitivity.samples", suffix = "Rdata", 
-                              all.var.yr = TRUE,
-                              pft        = NULL,
-                              ensemble.id = settings$sensitivity.analysis$ensemble.id,
-                              variable    = settings$sensitivity.analysis$variable,
-                              start.year  = settings$sensitivity.analysis$start.year,
-                              end.year    = settings$sensitivity.analysis$end.year) {
-
-  if(is.null(ensemble.id) || is.na(ensemble.id)) {
-    # This shouldn't generally arise, as run.write.configs() appends ensemble.id to settings. However,it will come up if running run.write.configs(..., write=F), because then no ensemble ID is created in the database. A simple workflow will still work in that case, but provenance will be lost if multiple ensembles are run.
+sensitivity.filename <- function(settings, prefix = "sensitivity.samples", suffix = "Rdata", 
+                                 all.var.yr = TRUE, pft = NULL, 
+                                 ensemble.id = settings$sensitivity.analysis$ensemble.id, 
+                                 variable = settings$sensitivity.analysis$variable, 
+                                 start.year = settings$sensitivity.analysis$start.year, 
+                                 end.year = settings$sensitivity.analysis$end.year) {
+  
+  if (is.null(ensemble.id) || is.na(ensemble.id)) {
+    # This shouldn't generally arise, as run.write.configs() appends ensemble.id to
+    # settings. However,it will come up if running run.write.configs(..., write=F),
+    # because then no ensemble ID is created in the database. A simple workflow will
+    # still work in that case, but provenance will be lost if multiple ensembles are
+    # run.
     ensemble.id <- "NOENSEMBLEID"
   }
-  ## for other variables, these are just included in the filename so just need to make sure they don't crash
-  if(is.null(variable))   variable = "NA"
-  if(is.null(start.year)) start.year = "NA"
-  if(is.null(end.year))   end.year = "NA"
+  ## for other variables, these are just included in the filename so just need to
+  ## make sure they don't crash
+  if (is.null(variable)) {
+    variable <- "NA"
+  }
+  if (is.null(start.year)) {
+    start.year <- "NA"
+  }
+  if (is.null(end.year)) {
+    end.year <- "NA"
+  }
   
-
-  if(is.null(pft)) {
-    # Goes in main output directory. 
+  if (is.null(pft)) {
+    # Goes in main output directory.
     sensitivity.dir <- settings$outdir
   } else {
     ind <- which(sapply(settings$pfts, function(x) x$name) == pft)
-    if(length(ind) == 0){ ## no match
-      logger.warn("sensitivity.filename: unmatched PFT = ",pft," not among ", sapply(settings$pfts, function(x) x$name))
-      sensitivity.dir <- file.path(settings$outdir,"pfts",pft)
+    if (length(ind) == 0) {
+      ## no match
+      logger.warn("sensitivity.filename: unmatched PFT = ", pft, " not among ", 
+                  sapply(settings$pfts, function(x) x$name))
+      sensitivity.dir <- file.path(settings$outdir, "pfts", pft)
     } else {
-       if (length(ind) > 1){  ## multiple matches
-         logger.warn("sensitivity.filename: multiple matchs of PFT = ",pft," among ", sapply(settings$pfts, function(x) x$name)," USING")
-         ind = ind[1]
-       }
-       if(is.null(settings$pfts[[ind]]$outdir) | is.na(settings$pfts[[ind]]$outdir)){ ## no outdir
-         settings$pfts[[ind]]$outdir <- file.path(settings$outdir,"pfts",pft)
-       }
-       sensitivity.dir <- settings$pfts[[ind]]$outdir
+      if (length(ind) > 1) {
+        ## multiple matches
+        logger.warn("sensitivity.filename: multiple matchs of PFT = ", pft, 
+                    " among ", sapply(settings$pfts, function(x) x$name), " USING")
+        ind <- ind[1]
+      }
+      if (is.null(settings$pfts[[ind]]$outdir) | is.na(settings$pfts[[ind]]$outdir)) {
+        ## no outdir
+        settings$pfts[[ind]]$outdir <- file.path(settings$outdir, "pfts", pft)
+      }
+      sensitivity.dir <- settings$pfts[[ind]]$outdir
     }
   }
   
-  dir.create(sensitivity.dir, showWarnings=FALSE, recursive=TRUE)
-  if(!dir.exists(sensitivity.dir)){
-    logger.error("sensitivity.filename: could not create directory, please check permissions ", sensitivity.dir,
-                 " will try ",settings$outdir)
-    if(dir.exists(settings$outdir)){
-      sensitivity.dir = settings$outdir
+  dir.create(sensitivity.dir, showWarnings = FALSE, recursive = TRUE)
+  if (!dir.exists(sensitivity.dir)) {
+    logger.error("sensitivity.filename: could not create directory, please check permissions ", 
+                 sensitivity.dir, " will try ", settings$outdir)
+    if (dir.exists(settings$outdir)) {
+      sensitivity.dir <- settings$outdir
     } else {
-      logger.error("sensitivity.filename: no OUTDIR ",settings$outdir)
+      logger.error("sensitivity.filename: no OUTDIR ", settings$outdir)
     }
   }
   
-  if(all.var.yr) {
+  if (all.var.yr) {
     # All variables and years will be included; omit those from filename
-    sensitivity.file <- file.path(sensitivity.dir, 
-      paste(prefix, ensemble.id, suffix, sep='.'))
+    sensitivity.file <- file.path(sensitivity.dir,
+                                  paste(prefix, ensemble.id, suffix, sep = "."))
   } else {
     sensitivity.file <- file.path(sensitivity.dir, 
-      paste(prefix, ensemble.id, variable, start.year, end.year, suffix, sep='.'))
+                                  paste(prefix, ensemble.id, variable, start.year, end.year, suffix, sep = "."))
   }
   
   return(sensitivity.file)
-}
+} # sensitivity.filename

--- a/utils/R/get.model.output.R
+++ b/utils/R/get.model.output.R
@@ -6,7 +6,7 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-#--------------------------------------------------------------------------------------------------#
+
 ##'
 ##' This function retrieves model output for further analyses
 ##' @name get.model.output
@@ -19,13 +19,10 @@
 ##' @examples
 ##' \dontrun{
 ##' get.model.output(model)
-##' get.model.output("ED2")
+##' get.model.output('ED2')
 ##' }
 ##'
 ##' @author Michael Dietze, Shawn Serbin, David LeBauer
-get.model.output <- function(model, settings){
+get.model.output <- function(model, settings) {
   logger.severe("Same as get.results(settings), please update your workflow")
-}
-####################################################################################################
-### EOF.  End of R script file.            	
-####################################################################################################
+} # get.model.output

--- a/utils/R/get.results.R
+++ b/utils/R/get.results.R
@@ -6,7 +6,7 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-#--------------------------------------------------------------------------------------------------#
+
 ##' Reads model output and runs sensitivity and ensemble analyses
 ##'
 ##' Output is placed in model output directory (settings$modeloutdir).
@@ -15,159 +15,207 @@
 ##' @export
 ##' @param settings list, read from settings file (xml) using \code{\link{read.settings}}
 ##' @author David LeBauer, Shawn Serbin, Mike Dietze, Ryan Kelly
-get.results <- function(settings, sa.ensemble.id=NULL, ens.ensemble.id=NULL,
-                        variable=NULL, start.year=NULL, end.year=NULL) {
-
+get.results <- function(settings, sa.ensemble.id = NULL, ens.ensemble.id = NULL, 
+                        variable = NULL, start.year = NULL, end.year = NULL) {
+  
   outdir <- settings$outdir
   
-  sensitivity.output <- list()   
-  if('sensitivity.analysis' %in% names(settings)) {
+  sensitivity.output <- list()
+  if ("sensitivity.analysis" %in% names(settings)) {
     ### Load PEcAn sa info
     # Can specify ensemble ids manually. If not, look in settings. 
     # if no ensemble ids in settings look in samples.Rdata, 
     # which for backwards compatibility still contains the sample info for (the most recent)
     # sensitivity and ensemble analysis combined.
-    if(!is.null(sa.ensemble.id)) {
+    if (!is.null(sa.ensemble.id)) {
       fname <- sensitivity.filename(settings, "sensitivity.samples", "Rdata", 
-                 ensemble.id=sa.ensemble.id, all.var.yr=TRUE, pft=NULL)
-    } else if(!is.null(settings$sensitivity.analysis$ensemble.id)) {
+                                    ensemble.id = sa.ensemble.id,
+                                    all.var.yr = TRUE, 
+                                    pft = NULL)
+    } else if (!is.null(settings$sensitivity.analysis$ensemble.id)) {
       sa.ensemble.id <- settings$sensitivity.analysis$ensemble.id
       fname <- sensitivity.filename(settings, "sensitivity.samples", "Rdata", 
-                 ensemble.id=sa.ensemble.id, all.var.yr=TRUE, pft=NULL)
+                                    ensemble.id = sa.ensemble.id,
+                                    all.var.yr = TRUE, 
+                                    pft = NULL)
     } else {
-      fname <- file.path(outdir, 'samples.Rdata')
+      fname <- file.path(outdir, "samples.Rdata")
       sa.ensemble.id <- NULL
     }
-    if(!file.exists(fname)) logger.severe("No sensitivity analysis samples file found!")
+    
+    if (!file.exists(fname)) {
+      logger.severe("No sensitivity analysis samples file found!")
+    }
     load(fname)
-
+    
     # For backwards compatibility, define some variables if not just loaded
-    if(!exists("pft.names"))    pft.names <- names(trait.samples)
-    if(!exists("trait.names"))  trait.names <- lapply(trait.samples, names)
-    if(!exists("sa.run.ids"))   sa.run.ids <- runs.samples$sa
-  
+    if (!exists("pft.names")) {
+      pft.names <- names(trait.samples)
+    }
+    if (!exists("trait.names")) {
+      trait.names <- lapply(trait.samples, names)
+    }
+    if (!exists("sa.run.ids")) {
+      sa.run.ids <- runs.samples$sa
+    }
+    
     # Set variable and years. Use args first, then settings, then defaults/error
     start.year.sa <- start.year
-    if(is.null(start.year.sa)) start.year.sa <- settings$sensitivity.analysis$start.year
-    if(is.null(start.year.sa)) start.year.sa <- NA
-
+    if (is.null(start.year.sa)) {
+      start.year.sa <- settings$sensitivity.analysis$start.year
+    }
+    if (is.null(start.year.sa)) {
+      start.year.sa <- NA
+    }
+    
     end.year.sa <- end.year
-    if(is.null(end.year.sa)) end.year.sa <- settings$sensitivity.analysis$end.year
-    if(is.null(end.year.sa)) end.year.sa <- NA
-
+    if (is.null(end.year.sa)) {
+      end.year.sa <- settings$sensitivity.analysis$end.year
+    }
+    if (is.null(end.year.sa)) {
+      end.year.sa <- NA
+    }
+    
     variable.sa <- variable
-    if(is.null(variable.sa)) {
-      if("variable" %in% names(settings$sensitivity.analysis)){
+    if (is.null(variable.sa)) {
+      if ("variable" %in% names(settings$sensitivity.analysis)) {
         variable.sa <- settings$sensitivity.analysis[names(settings$sensitivity.analysis) == "variable"]
       } else {
         logger.severe("no variable defined for sensitivity analysis")
       }
     }
-
+    
     # Only handling one variable at a time for now
-    if(length(variable.sa) > 1) {
+    if (length(variable.sa) > 1) {
       variable.sa <- variable.sa[1]
-      logger.warn(paste0("Currently performs sensitivity analysis on only one variable at a time. Using first (", variable.sa, ")"))
+      logger.warn(paste0("Currently performs sensitivity analysis on only one variable at a time. Using first (", 
+                         variable.sa, ")"))
     }
-
-    for(pft.name in pft.names){
-      quantiles <- rownames(sa.samples[[pft.name]])    
+    
+    for (pft.name in pft.names) {
+      quantiles <- rownames(sa.samples[[pft.name]])
       traits <- trait.names[[pft.name]]
       
-      sensitivity.output[[pft.name]] <- read.sa.output(traits = traits,
-                                                       quantiles = quantiles,
-                                                       pecandir = outdir,
-                                                       outdir = settings$modeloutdir, 
-                                                       pft.name = pft.name,
-                                                       start.year = start.year.sa,
-                                                       end.year = end.year.sa,
-                                                       variable = variable.sa,
+      sensitivity.output[[pft.name]] <- read.sa.output(traits = traits, 
+                                                       quantiles = quantiles, 
+                                                       pecandir = outdir, 
+                                                       outdir = settings$modeloutdir, pft.name = pft.name, 
+                                                       start.year = start.year.sa, 
+                                                       end.year = end.year.sa, 
+                                                       variable = variable.sa, 
                                                        sa.run.ids = sa.run.ids)
     }
-
+    
     # Save sensitivity output
-    fname <- sensitivity.filename(
-      settings, "sensitivity.output", "Rdata", all.var.yr=FALSE, pft=NULL,
-      ensemble.id=sa.ensemble.id, variable=variable.sa, start.year=start.year.sa, end.year=end.year.sa)
+    fname <- sensitivity.filename(settings, "sensitivity.output", "Rdata", 
+                                  all.var.yr = FALSE, 
+                                  pft = NULL, 
+                                  ensemble.id = sa.ensemble.id, 
+                                  variable = variable.sa, 
+                                  start.year = start.year.sa, 
+                                  end.year = end.year.sa)
     save(sensitivity.output, file = fname)
     
   }
   
-  ensemble.output    <- list()
-  if('ensemble' %in% names(settings)) {
-    ### Load PEcAn ensemble info
-    # Can specify ensemble ids manually. If not, look in settings. If none there, just look in samples.Rdata, which for backwards compatibility still contains the sample info for (the most recent)  sensitivity and ensemble analysis combined.
-    if(!is.null(ens.ensemble.id)) {
+  ensemble.output <- list()
+  if ("ensemble" %in% names(settings)) {
+    ### Load PEcAn ensemble info Can specify ensemble ids manually. If not, look in
+    ### settings. If none there, just look in samples.Rdata, which for backwards
+    ### compatibility still contains the sample info for (the most recent) sensitivity
+    ### and ensemble analysis combined.
+    if (!is.null(ens.ensemble.id)) {
       fname <- ensemble.filename(settings, "ensemble.samples", "Rdata", 
-                 ensemble.id=ens.ensemble.id, all.var.yr=TRUE)
-    } else if(!is.null(settings$ensemble$ensemble.id)) {
+                                 ensemble.id = ens.ensemble.id, 
+                                 all.var.yr = TRUE)
+    } else if (!is.null(settings$ensemble$ensemble.id)) {
       ens.ensemble.id <- settings$ensemble$ensemble.id
-      fname <- ensemble.filename(settings, "ensemble.samples", "Rdata", 
-                 ensemble.id=ens.ensemble.id, all.var.yr=TRUE)
+      fname <- ensemble.filename(settings, "ensemble.samples", "Rdata",
+                                 ensemble.id = ens.ensemble.id, 
+                                 all.var.yr = TRUE)
     } else {
-      fname <- file.path(outdir, 'samples.Rdata')
+      fname <- file.path(outdir, "samples.Rdata")
     }
-    if(!file.exists(fname)) logger.severe("No ensemble samples file found!")
+    if (!file.exists(fname)) {
+      logger.severe("No ensemble samples file found!")
+    }
     load(fname)
     
     # For backwards compatibility, define some variables if not just loaded
-    if(!exists("pft.names"))    pft.names <- names(trait.samples)
-    if(!exists("trait.names"))  trait.names <- lapply(trait.samples, names)
-    if(!exists("ens.run.ids"))   ens.run.ids <- runs.samples$ens
-
+    if (!exists("pft.names")) {
+      pft.names <- names(trait.samples)
+    }
+    if (!exists("trait.names")) {
+      trait.names <- lapply(trait.samples, names)
+    }
+    if (!exists("ens.run.ids")) {
+      ens.run.ids <- runs.samples$ens
+    }
+    
     # Set variable and years. Use args first, then settings, then defaults/error
     start.year.ens <- start.year
-    if(is.null(start.year.ens)) start.year.ens <- settings$ensemble$start.year
-    if(is.null(start.year.ens)) start.year.ens <- NA
-
+    if (is.null(start.year.ens)) {
+      start.year.ens <- settings$ensemble$start.year
+    }
+    if (is.null(start.year.ens)) {
+      start.year.ens <- NA
+    }
+    
     end.year.ens <- end.year
-    if(is.null(end.year.ens)) end.year.ens <- settings$ensemble$end.year
-    if(is.null(end.year.ens)) end.year.ens <- NA
-
+    if (is.null(end.year.ens)) {
+      end.year.ens <- settings$ensemble$end.year
+    }
+    if (is.null(end.year.ens)) {
+      end.year.ens <- NA
+    }
+    
     variable.ens <- variable
-    if(is.null(variable.ens)) {
-      if("variable" %in% names(settings$ensemble)){
-        var <- which(names(settings$ensemble) == 'variable')
-        for(i in 1:length(var)){
-          variable.ens[i] = settings$ensemble[[var[i]]]
+    if (is.null(variable.ens)) {
+      if ("variable" %in% names(settings$ensemble)) {
+        var <- which(names(settings$ensemble) == "variable")
+        for (i in seq_along(var)) {
+          variable.ens[i] <- settings$ensemble[[var[i]]]
         }
       }
     }
-
-    if(is.null(variable.ens)) logger.sever("No variables for ensemble analysis!")
-  
+    
+    if (is.null(variable.ens)) 
+      logger.sever("No variables for ensemble analysis!")
+    
     # Only handling one variable at a time for now
-    if(length(variable.ens) > 1) {
+    if (length(variable.ens) > 1) {
       variable.ens <- variable.ens[1]
-      logger.warn(paste0("Currently performs ensemble analysis on only one variable at a time. Using first (", variable.ens, ")"))
+      logger.warn(paste0("Currently performs ensemble analysis on only one variable at a time. Using first (", 
+                         variable.ens, ")"))
     }
-
+    
     ensemble.output <- read.ensemble.output(settings$ensemble$size,
-                                            pecandir    = outdir,
-                                            outdir      = settings$modeloutdir, 
-                                            start.year  = start.year.ens,
-                                            end.year    = end.year.ens,
-                                            variable    = variable.ens,
+                                            pecandir = outdir, 
+                                            outdir = settings$modeloutdir,
+                                            start.year = start.year.ens, 
+                                            end.year = end.year.ens, 
+                                            variable = variable.ens,
                                             ens.run.ids = ens.run.ids)
-
-
+    
     # Save ensemble output
-    fname <- ensemble.filename(settings, "ensemble.output", "Rdata", all.var.yr=FALSE,
-      ensemble.id=ens.ensemble.id, variable=variable.ens, 
-      start.year=start.year.ens, end.year=end.year.ens)
+    fname <- ensemble.filename(settings, "ensemble.output", "Rdata", 
+                               all.var.yr = FALSE, 
+                               ensemble.id = ens.ensemble.id, 
+                               variable = variable.ens, 
+                               start.year = start.year.ens, 
+                               end.year = end.year.ens)
     save(ensemble.output, file = fname)
   }
+} # get.results
 
-}
-#==================================================================================================#
 
 ##' @export
 runModule.get.results <- function(settings) {
-  if(is.MultiSettings(settings)) {
+  if (is.MultiSettings(settings)) {
     return(papply(settings, runModule.get.results))
   } else if (is.Settings(settings)) {
-    get.results(settings) 
+    get.results(settings)
   } else {
     stop("runModule.get.results only works with Settings or MultiSettings")
   }
-}
+} # runModule.get.results

--- a/utils/R/help.R
+++ b/utils/R/help.R
@@ -6,6 +6,7 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
+
 ##' R package to support PEcAn, the Predictive Ecosystem Analyzer
 ##'
 ##' Instructions for the use of this package are provided in the project documentation \url{https://pecan.gitbooks.io/pecan-documentation/content/}.

--- a/utils/R/kill.tunnel.R
+++ b/utils/R/kill.tunnel.R
@@ -4,11 +4,11 @@
 ##' @description kill tunnel to remote machine
 ##' @author Rob Kooper
 kill.tunnel <- function() {
-  if (exists("settings") && !is.null(settings$host$tunnel)) {
-    pidfile <- file.path(dirname(settings$host$tunnel), "pid")
-    pid <- readLines(pidfile)
-    print(paste("Killing tunnel with PID", pid))
-    tools::pskill(pid)
-    file.remove(pidfile)
-  }
-}
+    if (exists("settings") && !is.null(settings$host$tunnel)) {
+        pidfile <- file.path(dirname(settings$host$tunnel), "pid")
+        pid <- readLines(pidfile)
+        print(paste("Killing tunnel with PID", pid))
+        tools::pskill(pid)
+        file.remove(pidfile)
+    }
+} # kill.tunnel

--- a/utils/R/mail.R
+++ b/utils/R/mail.R
@@ -7,7 +7,6 @@
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
 
-#--------------------------------------------------------------------------------------------------#
 ##' Sends email. This assumes the program sendmail is installed. 
 ##'
 ##' @title Clear EBI-CLUSTER worker node local scratch directories of old PEcAn output
@@ -21,7 +20,7 @@
 ##' @export
 ##' @examples
 ##' \dontrun{
-##' sendmail("bob@@example.com", "joe@@example.com", "Hi", "This is R.")
+##' sendmail('bob@@example.com', 'joe@@example.com', 'Hi', 'This is R.')
 ##' }
 sendmail <- function(from, to, subject, body) {
   if (is.null(to)) {
@@ -30,18 +29,15 @@ sendmail <- function(from, to, subject, body) {
     if (is.null(from)) {
       from <- to
     }
-    sendmail <- "sendmail"
-    if (file.exists("/usr/sbin/sendmail")) {
-      sendmail <- "/usr/sbin/sendmail"
-    }
+    sendmail <- Sys.which("sendmail")
     mailfile <- tempfile("mail")
-    cat(paste0("From: ", from, "\n",
-               "Subject: ", subject, "\n",
-               "To: ", to, "\n",
-               "\n",
-               body), file=mailfile)
-    system2(sendmail, c("-f", paste0('"', from, '"'), paste0('"', to, '"'), "<", mailfile))
+    cat(paste0("From: ", from, "\n", 
+               "Subject: ", subject, "\n", 
+               "To: ", to, "\n", "\n", 
+               body), file = mailfile)
+    system2(sendmail, c("-f", paste0("\"", from, "\""), 
+                        paste0("\"", to, "\""), "<", mailfile))
     unlink(mailfile)
   }
-}
+} # sendmail
 

--- a/utils/R/n_leap_day.R
+++ b/utils/R/n_leap_day.R
@@ -5,7 +5,7 @@
 ##' @param start_date
 ##' @param end_date
 ##' @export
-n_leap_day <- function(start_date,end_date){
+n_leap_day <- function(start_date, end_date) {
   library(lubridate)
   
   ## make sure dates are formatted correctly
@@ -13,12 +13,16 @@ n_leap_day <- function(start_date,end_date){
   end_date   <- as.Date(end_date)
   
   ## which years are leap years?
-  l_years    <- leap_year(year(start_date):year(end_date))
+  l_years <- leap_year(year(start_date):year(end_date))
   
   ## check for mid-year conditions in start/end
-  if(start_date >= as.Date(paste0(year(start_date),"-03-01"))) l_years[1] = FALSE
-  if(end_date <= as.Date(paste0(year(end_date),"-02-28"))) l_years[length(l_years)] = FALSE
+  if (start_date >= as.Date(paste0(year(start_date), "-03-01"))) {
+    l_years[1] <- FALSE
+  }
+  if (end_date <= as.Date(paste0(year(end_date), "-02-28"))) {
+    l_years[length(l_years)] <- FALSE
+  }
   
   ## count up total number of leap days
   return(sum(l_years))
-}
+} # n_leap_day

--- a/utils/R/plots.R
+++ b/utils/R/plots.R
@@ -6,7 +6,7 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-##--------------------------------------------------------------------------------------------------#
+
 ##' Variable-width (dagonally cut) histogram
 ##'
 ##' 
@@ -27,143 +27,145 @@
 ##' @return list with two elements, heights of length n and breaks of length n+1 indicating the heights and break points of the histogram bars. 
 ##' @author Lorraine Denby, Colin Mallows
 ##' @references Lorraine Denby, Colin Mallows. Journal of Computational and Graphical Statistics. March 1, 2009, 18(1): 21-31. doi:10.1198/jcgs.2009.0002.
-dhist <- function(x, a=5*iqr(x),
-                nbins=nclass.Sturges(x), rx = range(x,na.rm = TRUE),
-                eps=.15, xlab = "x", plot = TRUE,lab.spikes = TRUE)
-{
-
-  if(is.character(nbins))
-    nbins <- switch(casefold(nbins),
+dhist <- function(x, a = 5 * iqr(x), nbins = nclass.Sturges(x), rx = range(x, na.rm = TRUE), 
+                  eps = 0.15, xlab = "x", plot = TRUE, lab.spikes = TRUE) {
+  
+  if (is.character(nbins)) {
+    nbins <- switch(casefold(nbins), 
                     sturges = nclass.Sturges(x),
-                    fd = nclass.FD(x),
-                    scott = nclass.scott(x),
+                    fd = nclass.FD(x), 
+                    scott = nclass.scott(x), 
                     stop("Nclass method not recognized"))
-  else if(is.function(nbins))
-    nbins <- nbins(x)
-
+  } else {
+    if (is.function(nbins)) {
+      nbins <- nbins(x)
+    }
+  }
+  
   x <- sort(x[!is.na(x)])
-  if(a == 0)
-    a <- diff(range(x))/100000000
-  if(a != 0 & a != Inf) {
-    n <- length(x)
-    h <- (rx[2] + a - rx[1])/nbins
-    ybr <- rx[1] + h * (0:nbins)
-    yupper <- x + (a * (1:n))/n
-                                        # upper and lower corners in the ecdf
-    ylower <- yupper - a/n
-                                        #
-    cmtx <- cbind(cut(yupper, breaks = ybr), cut(yupper, breaks = 
-                                ybr, left.include = TRUE), cut(ylower, breaks = ybr),
+  if (a == 0) {
+    a <- diff(range(x)) / 1e+08
+  }
+  if (a != 0 & a != Inf) {
+    n      <- length(x)
+    h      <- (rx[2] + a - rx[1]) / nbins
+    ybr    <- rx[1] + h * (0:nbins)
+    yupper <- x + (a * seq_len(n)) / n
+    # upper and lower corners in the ecdf
+    ylower <- yupper - a / n
+    # 
+    cmtx <- cbind(cut(yupper, breaks = ybr), 
+                  cut(yupper, breaks = ybr, left.include = TRUE), 
+                  cut(ylower, breaks = ybr),
                   cut(ylower, breaks = ybr, left.include = TRUE))
     cmtx[1, 3] <- cmtx[1, 4] <- 1
-                                        # to replace NAs when default r is used
+    # to replace NAs when default r is used
     cmtx[n, 1] <- cmtx[n, 2] <- nbins
-                                        #
-                                        #checksum <- apply(cmtx, 1, sum) %% 4
-    checksum <- (cmtx[, 1] + cmtx[, 2] + cmtx[, 3] + cmtx[, 4]) %%
-    4
-                                        # will be 2 for obs. that straddle two bins
+    # checksum <- apply(cmtx, 1, sum) %% 4
+    checksum <- (cmtx[, 1] + cmtx[, 2] + cmtx[, 3] + cmtx[, 4]) %% 4
+    # will be 2 for obs. that straddle two bins
     straddlers <- (1:n)[checksum == 2]
-                                        # to allow for zero counts
-    if(length(straddlers) > 0) {
-      counts <- table(c(1:nbins, cmtx[ - straddlers, 1]))
+    # to allow for zero counts
+    if (length(straddlers) > 0) {
+      counts <- table(c(1:nbins, cmtx[-straddlers, 1]))
     } else {
       counts <- table(c(1:nbins, cmtx[, 1]))
     }
     counts <- counts - 1
-                                        #
-    if(length(straddlers) > 0) {
-      for(i in straddlers) {
+    # 
+    if (length(straddlers) > 0) {
+      for (i in straddlers) {
         binno <- cmtx[i, 1]
-        theta <- ((yupper[i] - ybr[binno]) * n)/a
-        counts[binno - 1] <- counts[binno - 1] + (
-                                                  1 - theta)
+        theta <- ((yupper[i] - ybr[binno]) * n) / a
+        counts[binno - 1] <- counts[binno - 1] + (1 - theta)
         counts[binno] <- counts[binno] + theta
       }
     }
     xbr <- ybr
-    xbr[-1] <- ybr[-1] - (a * cumsum(counts))/n
-    spike<-eps*diff(rx)/nbins
-    flag.vec<-c(diff(xbr)<spike,F)
-    if ( sum(abs(diff(xbr))<=spike) >1) {
-      xbr.new<-xbr
-      counts.new<-counts
-      diff.xbr<-abs(diff(xbr))
-      amt.spike<-diff.xbr[length(diff.xbr)]
+    xbr[-1] <- ybr[-1] - (a * cumsum(counts)) / n
+    spike <- eps * diff(rx)/nbins
+    flag.vec <- c(diff(xbr) < spike, FALSE)
+    if (sum(abs(diff(xbr)) <= spike) > 1) {
+      xbr.new    <- xbr
+      counts.new <- counts
+      diff.xbr   <- abs(diff(xbr))
+      amt.spike  <- diff.xbr[length(diff.xbr)]
       for (i in rev(2:length(diff.xbr))) {
-        if (diff.xbr[i-1] <= spike&diff.xbr[i] <= spike &
-            !is.na(diff.xbr[i])) {
-          amt.spike <- amt.spike+diff.xbr[i-1]
-          counts.new[i-1] <- counts.new[i-1]+counts.new[i]
-          xbr.new[i] <- NA
-          counts.new[i] <- NA
-          flag.vec[i-1] <- T
-        }
-        else amt.spike<-diff.xbr[i-1]
+        if (diff.xbr[i - 1] <= spike & diff.xbr[i] <= spike & !is.na(diff.xbr[i])) {
+          amt.spike         <- amt.spike + diff.xbr[i - 1]
+          counts.new[i - 1] <- counts.new[i - 1] + counts.new[i]
+          xbr.new[i]        <- NA
+          counts.new[i]     <- NA
+          flag.vec[i - 1]   <- TRUE
+        } else {
+          amt.spike <- diff.xbr[i - 1]
+        } 
       }
-      flag.vec<-flag.vec[!is.na(xbr.new)]
-      flag.vec<-flag.vec[-length(flag.vec)]
-      counts<-counts.new[!is.na(counts.new)]
-      xbr<-xbr.new[!is.na(xbr.new)]
-
+      flag.vec <- flag.vec[!is.na(xbr.new)]
+      flag.vec <- flag.vec[-length(flag.vec)]
+      counts   <- counts.new[!is.na(counts.new)]
+      xbr      <- xbr.new[!is.na(xbr.new)]
+      
+    } else {
+      flag.vec <- flag.vec[-length(flag.vec)]
     }
-    else flag.vec<-flag.vec[-length(flag.vec)]
     widths <- abs(diff(xbr))
-    ## N.B. argument "widths" in barplot must be xbr
+    ## N.B. argument 'widths' in barplot must be xbr
     heights <- counts/widths
   }
-  bin.size <- length(x)/nbins
-  cut.pt <- unique(c(min(x) - abs(min(x))/1000,
-                     approx(seq(length(x)), x, (1:(nbins - 1)) * bin.size, rule = 2)$y, max(x)))
+  bin.size <- length(x) / nbins
+  cut.pt <- unique(c(min(x) - abs(min(x)) / 1000, 
+                     approx(seq(length(x)), x, seq_len(nbins - 1) * bin.size, rule = 2)$y, max(x)))
   aa <- hist(x, breaks = cut.pt, plot = FALSE, probability = TRUE)
-  if(a == Inf) {
+  if (a == Inf) {
     heights <- aa$counts
     xbr <- aa$breaks
   }
-  amt.height<-3
-  q75<-quantile(heights,.75)
-  if (sum(flag.vec)!=0) {
-    amt<-max(heights[!flag.vec])
-    ylim.height<-amt*amt.height
-    ind.h<-flag.vec&heights> ylim.height
-    flag.vec[heights<ylim.height*(amt.height-1)/amt.height]<-F
-    heights[ind.h] <- ylim.height
+  amt.height <- 3
+  q75 <- quantile(heights, 0.75)
+  if (sum(flag.vec) != 0) {
+    amt              <- max(heights[!flag.vec])
+    ylim.height      <- amt * amt.height
+    ind.h            <- flag.vec & heights > ylim.height
+    flag.vec[heights < ylim.height * (amt.height - 1) / amt.height] <- FALSE
+    heights[ind.h]   <- ylim.height
   }
-  amt.txt<-0
-  end.y<-(-10000)
-  if(plot) {
-    barplot(heights, abs(diff(xbr)), space = 0, density = -1, xlab = 
-            xlab, plot = TRUE, xaxt = "n",yaxt='n')
+  amt.txt <- 0
+  end.y <- (-10000)
+  if (plot) {
+    barplot(heights, abs(diff(xbr)), 
+            space = 0, density = -1, 
+            xlab = xlab, plot = TRUE, 
+            xaxt = "n", yaxt = "n")
     at <- pretty(xbr)
     axis(1, at = at - xbr[1], labels = as.character(at))
     if (lab.spikes) {
-      if (sum(flag.vec)>=1) {
-        usr<-par('usr')
-        for ( i in seq(length(xbr)-1)) {
+      if (sum(flag.vec) >= 1) {
+        usr <- par("usr")
+        for (i in seq(length(xbr) - 1)) {
           if (!flag.vec[i]) {
-            amt.txt<-0
-            if (xbr[i]-xbr[1]<end.y) amt.txt<-1
-          }
-          else {
-            amt.txt<-amt.txt+1
-            end.y<-xbr[i]-xbr[1]+3*par('cxy')[1]
+            amt.txt <- 0
+            if (xbr[i] - xbr[1] < end.y) {
+              amt.txt <- 1
+            }
+          } else {
+            amt.txt <- amt.txt + 1
+            end.y <- xbr[i] - xbr[1] + 3 * par("cxy")[1]
           }
           if (flag.vec[i]) {
-            txt<-paste(' ',format(round(counts[i]/
-                                        sum(counts)*100)),'%',sep='')
+            txt <- paste0(" ", format(round(counts[i]/sum(counts) * 100)), "%")
             par(xpd = TRUE)
-            text(xbr[i+1]-xbr[1],ylim.height-par('cxy')[2]*(amt.txt-1),txt, adj=0)
-          }}
-      }
-      else print('no spikes or more than one spike')
+            text(xbr[i + 1] - xbr[1], 
+                 ylim.height - par("cxy")[2] * (amt.txt -1), txt, adj = 0)
+          }
+        }
+      } else print("no spikes or more than one spike")
     }
-    invisible(list(heights = heights, xbr = xbr))
+    return(invisible(list(heights = heights, xbr = xbr)))
+  } else {
+    return(list(heights = heights, xbr = xbr, counts = counts))
   }
-  else {
-    return(list(heights = heights, xbr = xbr,counts=counts))
-  }
-}
-#==================================================================================================#
+} # dhist
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -174,12 +176,11 @@ dhist <- function(x, a=5*iqr(x),
 ##' @title Interquartile range
 ##' @param x vector
 ##' @return numeric vector of length 2, with the 25th and 75th quantiles of input vector x. 
-iqr <- function(x){
+iqr <- function(x) {
   return(diff(quantile(x, c(0.25, 0.75), na.rm = TRUE)))
-}
-##==================================================================================================#
+} # iqr
 
-##--------------------------------------------------------------------------------------------------#
+
 ##' Creates empty ggplot object
 ##'
 ##' An empty base plot to which layers created by other functions
@@ -193,10 +194,7 @@ iqr <- function(x){
 create.base.plot <- function() {
   base.plot <- ggplot()
   return(base.plot)
-}
-#==================================================================================================#
-
-
+} # create.base.plot
 
 
 ##--------------------------------------------------------------------------------------------------#
@@ -217,13 +215,15 @@ create.base.plot <- function() {
 ##' @export plot.data
 ##' @examples
 ##' \dontrun{plot.data(data.frame(Y = c(1, 2), se = c(1,2)), base.plot = NULL, ymax = 10)}
-plot.data <- function(trait.data, base.plot = NULL, ymax, color = 'black') {
-
-  if(is.null(base.plot)) base.plot <- create.base.plot()
+plot.data <- function(trait.data, base.plot = NULL, ymax, color = "black") {
+  
+  if (is.null(base.plot)) {
+    base.plot <- create.base.plot()
+  }
   
   n.pts <- nrow(trait.data)
-  if(n.pts == 1){
-    ymax <- ymax/16
+  if (n.pts == 1) {
+    ymax <- ymax / 16
   } else if (n.pts < 5) {
     ymax <- ymax / 8
   } else {
@@ -231,30 +231,28 @@ plot.data <- function(trait.data, base.plot = NULL, ymax, color = 'black') {
   }
   y.pts <- seq(0, ymax, length.out = 1 + n.pts)[-1]
   
-  if(!'ghs' %in% names(trait.data)) trait.data$ghs <- 1
+  if (!"ghs" %in% names(trait.data)) {
+    trait.data$ghs <- 1
+  }
   
-  plot.data <- data.frame(x = trait.data$Y,
-                          y = y.pts,
-                          se = trait.data$se,
+  plot.data <- data.frame(x = trait.data$Y, 
+                          y = y.pts, 
+                          se = trait.data$se, 
                           control = !trait.data$trt == 1 & trait.data$ghs == 1)
-  new.plot <- base.plot +
-    geom_point(data = plot.data,
-               aes(x = x, y = y,
-                   color = control)) +
-    geom_segment(data = plot.data,
-                 aes(x = x - se, y = y, xend = x + se, yend = y,
-                     color = control)) +
-    scale_color_manual(values = c('black', 'grey')) +
+  new.plot <- base.plot + 
+    geom_point(data = plot.data, aes(x = x, y = y, color = control)) + 
+    geom_segment(data = plot.data, 
+                 aes(x = x - se, y = y, xend = x + se, yend = y, color = control)) + 
+    scale_color_manual(values = c("black", "grey")) + 
     theme(legend.position = "none")
   return(new.plot)
-}
-##==================================================================================================#
+} # plot.data
 
 
 #--------------------------------------------------------------------------------------------------#
 ##' Add borders to .. content for \description{} (no empty lines) ..
 ##'
-##' Has ggplot2 display only specified borders, e.g. ("L"-shaped) borders, rather than a rectangle or no border. Note that the order can be significant; for example, if you specify the L border option and then a theme, the theme settings will override the border option, so you need to specify the theme (if any) before the border option, as above.
+##' Has ggplot2 display only specified borders, e.g. ('L'-shaped) borders, rather than a rectangle or no border. Note that the order can be significant; for example, if you specify the L border option and then a theme, the theme settings will override the border option, so you need to specify the theme (if any) before the border option, as above.
 ##' @name theme_border
 ##' @title Theme border for plot
 ##' @param type 
@@ -268,51 +266,46 @@ plot.data <- function(trait.data, base.plot = NULL, ymax, color = 'black') {
 ##' \dontrun{
 ##' df = data.frame( x=c(1,2,3), y=c(4,5,6) )
 ##' ggplot(data=df, aes(x=x, y=y)) + geom_point() + theme_bw() +
-##'        opts(panel.border = theme_border(c("bottom","left")) )
+##'        opts(panel.border = theme_border(c('bottom','left')) )
 ##' ggplot(data=df, aes(x=x, y=y)) + geom_point() + theme_bw() +
-##'        opts(panel.border = theme_border(c("b","l")) )
+##'        opts(panel.border = theme_border(c('b','l')) )
 ##' }
-theme_border <- function(type = c("left", "right", "bottom", "top", 
-                           "none"), colour = "black", size = 1, linetype = 1) {
-  type <- match.arg(type, several.ok=TRUE) 
-  structure( 
-            function(x = 0, y = 0, width = 1, height = 1, ...) { 
-              xlist <- c() 
-              ylist <- c() 
-              idlist <- c() 
-              if ("bottom" %in% type) { # bottom 
-                xlist <- append(xlist, c(x, x+width)) 
-                ylist <- append(ylist, c(y, y)) 
-                idlist <- append(idlist, c(1,1)) 
-              } 
-              if ("top" %in% type) { # top 
-                xlist <- append(xlist, c(x, x+width)) 
-                ylist <- append(ylist, c(y+height, y+height)) 
-                idlist <- append(idlist, c(2,2)) 
-              } 
-              if ("left" %in% type) { # left 
-                xlist <- append(xlist, c(x, x)) 
-                ylist <- append(ylist, c(y, y+height)) 
-                idlist <- append(idlist, c(3,3)) 
-              } 
-              if ("right" %in% type) { # right 
-                xlist <- append(xlist, c(x+width, x+width)) 
-                ylist <- append(ylist, c(y, y+height)) 
-                idlist <- append(idlist, c(4,4)) 
-              } 
-              polylineGrob( 
-                           x=xlist, y=ylist, id=idlist, ..., default.units = "npc", 
-                           gp=gpar(lwd=size, col=colour, lty=linetype), 
-                           ) 
-            }, 
-            class = "theme", 
-            type = "box", 
-            call = match.call() 
-            ) 
-} 
-#==================================================================================================#
-
-
-####################################################################################################
-### EOF.  End of R script file.        			
-####################################################################################################
+theme_border <- function(type = c("left", "right", "bottom", "top", "none"), 
+                         colour = "black", size = 1, linetype = 1) {
+  type <- match.arg(type, several.ok = TRUE)
+  structure(function(x = 0, y = 0, width = 1, height = 1, ...) {
+    xlist <- c()
+    ylist <- c()
+    idlist <- c()
+    if ("bottom" %in% type) {
+      # bottom
+      xlist <- append(xlist, c(x, x + width))
+      ylist <- append(ylist, c(y, y))
+      idlist <- append(idlist, c(1, 1))
+    }
+    if ("top" %in% type) {
+      # top
+      xlist <- append(xlist, c(x, x + width))
+      ylist <- append(ylist, c(y + height, y + height))
+      idlist <- append(idlist, c(2, 2))
+    }
+    if ("left" %in% type) {
+      # left
+      xlist <- append(xlist, c(x, x))
+      ylist <- append(ylist, c(y, y + height))
+      idlist <- append(idlist, c(3, 3))
+    }
+    if ("right" %in% type) {
+      # right
+      xlist <- append(xlist, c(x + width, x + width))
+      ylist <- append(ylist, c(y, y + height))
+      idlist <- append(idlist, c(4, 4))
+    }
+    polylineGrob(x = xlist, y = ylist, 
+                 id = idlist, ..., 
+                 default.units = "npc", 
+                 gp = gpar(lwd = size, 
+                           col = colour,
+                           lty = linetype), )
+  }, class = "theme", type = "box", call = match.call())
+} # theme_border

--- a/utils/R/r2bugs.distributions.R
+++ b/utils/R/r2bugs.distributions.R
@@ -6,7 +6,7 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-#--------------------------------------------------------------------------------------------------#
+
 ##' convert R parameterizations to BUGS paramaterizations
 ##' 
 ##' R and BUGS have different parameterizations for some distributions. This function transforms the distributions from R defaults to BUGS defaults. BUGS is an implementation of the BUGS language, and these transformations are expected to work for bugs.
@@ -20,59 +20,60 @@
 ##'                      parama = c(1, 1, 1, 1),
 ##'                      paramb = c(2, 2, 2, 2))
 ##' r2bugs.distributions(priors)
-r2bugs.distributions <- function(priors, direction = 'r2bugs') {
-
+r2bugs.distributions <- function(priors, direction = "r2bugs") {
+  
   priors$distn  <- as.character(priors$distn)
   priors$parama <- as.numeric(priors$parama)
   priors$paramb <- as.numeric(priors$paramb)
-
+  
   ## index dataframe according to distribution
-  norm   <- priors$distn %in% c('norm', 'lnorm')    # these have same tramsform
-  weib   <- grepl("weib", priors$distn)             # matches r and bugs version
-  gamma  <- priors$distn == 'gamma'
-  chsq   <- grepl("chisq", priors$distn)            # matches r and bugs version
-  bin    <- priors$distn %in% c('binom', 'bin')     # matches r and bugs version
-  nbin   <- priors$distn %in% c('nbinom', 'negbin') # matches r and bugs version
-
+  norm  <- priors$distn %in% c("norm", "lnorm")  # these have same tramsform
+  weib  <- grepl("weib", priors$distn)  # matches r and bugs version
+  gamma <- priors$distn == "gamma"
+  chsq  <- grepl("chisq", priors$distn)  # matches r and bugs version
+  bin   <- priors$distn %in% c("binom", "bin")  # matches r and bugs version
+  nbin  <- priors$distn %in% c("nbinom", "negbin")  # matches r and bugs version
+  
   ## Check that no rows are categorized into two distributions
-  if(max(rowSums(cbind(norm, weib, gamma, chsq, bin, nbin))) > 1) {
+  if (max(rowSums(cbind(norm, weib, gamma, chsq, bin, nbin))) > 1) {
     badrow <- rowSums(cbind(norm, weib, gamma, chsq, bin, nbin)) > 1
-    stop(paste(unique(priors$distn[badrow])),
-         "are identified as > 1 distribution")
+    stop(paste(unique(priors$distn[badrow])), "are identified as > 1 distribution")
   }
-
-  exponent <- ifelse(direction == "r2bugs", -2, -0.5) 
+  
+  exponent <- ifelse(direction == "r2bugs", -2, -0.5)
   ## Convert sd to precision for norm & lnorm
-  priors$paramb[norm] <-  priors$paramb[norm] ^ exponent
-  if(direction == 'r2bugs'){
+  priors$paramb[norm] <- priors$paramb[norm]^exponent
+  if (direction == "r2bugs") {
     ## Convert R parameter b to BUGS parameter lambda by l = (1/b)^a
-    priors$paramb[weib] <-   (1 / priors$paramb[weib]) ^ priors$parama[weib]
-  } else if (direction == 'bugs2r') {
+    priors$paramb[weib] <- (1/priors$paramb[weib]) ^ priors$parama[weib]
+  } else if (direction == "bugs2r") {
     ## Convert BUGS parameter lambda to BUGS parameter b by b = l^(-1/a)
-    priors$paramb[weib] <-  priors$paramb[weib] ^ (- 1 / priors$parama[weib] )
- 
+    priors$paramb[weib] <- priors$paramb[weib] ^ (-1 / priors$parama[weib])
+    
   }
   ## Reverse parameter order for binomial and negative binomial
-  priors[bin | nbin, c('parama', 'paramb')] <-  priors[bin | nbin, c('paramb', 'parama')]
+  priors[bin | nbin, c("parama", "paramb")] <- priors[bin | nbin, c("paramb", "parama")]
   
   ## Translate distribution names
-  if(direction == "r2bugs"){
+  if (direction == "r2bugs") {
     priors$distn[weib] <- "weib"
     priors$distn[chsq] <- "chisqr"
     priors$distn[bin]  <- "bin"
     priors$distn[nbin] <- "negbin"
-  } else if(direction == "bugs2r"){
+  } else if (direction == "bugs2r") {
     priors$distn[weib] <- "weibull"
     priors$distn[chsq] <- "chisq"
     priors$distn[bin]  <- "binom"
     priors$distn[nbin] <- "nbinom"
   }
   return(priors)
-}
+} # r2bugs.distributions
+
 
 bugs2r.distributions <- function(..., direction = "bugs2r") {
   return(r2bugs.distributions(..., direction))
-}
+} # bugs2r.distributions
+
 
 ##' Sample from an R distribution using JAGS
 ##'
@@ -86,40 +87,26 @@ bugs2r.distributions <- function(..., direction = "bugs2r") {
 ##' @return vector of samples
 ##' @export
 ##' @author David LeBauer
-bugs.rdist <- function(prior = data.frame(
-                         distn = "norm",
-                         parama = 0,
-                         paramb = 1),
-                       n.iter = 100000,
-                       n = NULL) {
+bugs.rdist <- function(prior = data.frame(distn = "norm", parama = 0, paramb = 1), 
+                       n.iter = 1e+05, n = NULL) {
   library(rjags)
-  if(!grepl("chisq", prior$distn)){
-    model.string <- paste("model{Y ~ d", prior$distn, "(",
-                          prior$parama, ", ", prior$paramb,
-                          ")\n a <- x}", sep = "")
-  } else if(grepl("chisq", prior$distn)) {
-    model.string <- paste("model{Y ~ d", prior$distn, "(",
-                          prior$parama,
-                          ")\n a <- x}", sep = "")
+  if (!grepl("chisq", prior$distn)) {
+    model.string <- paste0("model{Y ~ d", prior$distn, "(", prior$parama, ", ", prior$paramb, ")\n a <- x}")
+  } else if (grepl("chisq", prior$distn)) {
+    model.string <- paste0("model{Y ~ d", prior$distn, "(", prior$parama, ")\n a <- x}")
+  } else {
+    logger.severe(paste("Unknown model.string", model.string))
   }
+  
   writeLines(model.string, con = "test.bug")
-  j.model  <- jags.model(file = "test.bug", data = list(x = 1))
-  mcmc.object <- window(coda.samples(model = j.model,
-                              variable.names = c('Y'),
-                              n.iter = n.iter,
-                              thin = 2),
+  j.model <- jags.model(file = "test.bug", data = list(x = 1))
+  mcmc.object <- window(coda.samples(model = j.model, 
+                                     variable.names = c("Y"), 
+                                     n.iter = n.iter, thin = 2), 
                         start = n.iter / 2)
-  Y <- as.matrix(mcmc.object)[,"Y"]
-  if(!is.null(n)){
+  Y <- as.matrix(mcmc.object)[, "Y"]
+  if (!is.null(n)) {
     Y <- sample(Y, n)
   }
   return(Y)
-}
-
-
-#==================================================================================================#
-
-
-####################################################################################################
-### EOF.  End of R script file.            	
-####################################################################################################
+} # bugs.rdist

--- a/utils/R/read.output.R
+++ b/utils/R/read.output.R
@@ -1,12 +1,11 @@
-##-------------------------------------------------------------------------------
-## Copyright (c) 2012 University of Illinois, NCSA.
-## All rights reserved. This program and the accompanying materials
-## are made available under the terms of the 
-## University of Illinois/NCSA Open Source License
-## which accompanies this distribution, and is available at
-## http://opensource.ncsa.illinois.edu/license.html
-
-##---------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+# Copyright (c) 2012 University of Illinois, NCSA.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the 
+# University of Illinois/NCSA Open Source License
+# which accompanies this distribution, and is available at
+# http://opensource.ncsa.illinois.edu/license.html
+#-------------------------------------------------------------------------------
 
 ##' Convert output for a single model run to NetCDF
 ##'
@@ -18,33 +17,33 @@
 ##' @title Convert model output to NetCDF 
 ##' @param runid 
 ##' @param outdir
-##' @param model name of simulation model currently accepts ("ED2", "SIPNET", "BIOCRO")
+##' @param model name of simulation model currently accepts ('ED2', 'SIPNET', 'BIOCRO')
 ##' @param lat Latitude of the site
 ##' @param lon Longitude of the site
 ##' @param start_date Start time of the simulation
 ##' @param end_date End time of the simulation
 ##' @return vector of filenames created, converts model output to netcdf as a side effect
 ##' @author Mike Dietze, David LeBauer
-model2netcdfdep <- function(runid, outdir, model, lat, lon, start_date, end_date){
+model2netcdfdep <- function(runid, outdir, model, lat, lon, start_date, end_date) {
   ## load model-specific PEcAn module
-  do.call(require, list(paste0("PEcAn.", model)))    
-
-
-  model2nc <- paste("model2netcdf", model, sep=".")
-  if(!exists(model2nc)){
+  do.call(require, list(paste0("PEcAn.", model)))
+  
+  model2nc <- paste("model2netcdf", model, sep = ".")
+  if (!exists(model2nc)) {
     logger.warn("File conversion function model2netcdf does not exist for", model)
     return(NA)
   }
   
-  do.call(model2nc, list(outdir, lat, lon, start_date, end_date))    
+  do.call(model2nc, list(outdir, lat, lon, start_date, end_date))
   
   print(paste("Output from run", runid, "has been converted to netCDF"))
-  ncfiles <- list.files(path = outdir, pattern="\\.nc$", full.names=TRUE)
-  if(length(ncfiles) == 0){
+  ncfiles <- list.files(path = outdir, pattern = "\\.nc$", full.names = TRUE)
+  if (length(ncfiles) == 0) {
     logger.severe("Conversion of model files to netCDF unsuccessful")
   }
   return(ncfiles)
-}
+} # model2netcdfdep
+
 
 ##' Convert output for a single model run to NetCDF
 ##'
@@ -56,7 +55,7 @@ model2netcdfdep <- function(runid, outdir, model, lat, lon, start_date, end_date
 ##' @title Convert model output to NetCDF 
 ##' @param runid 
 ##' @param outdir
-##' @param model name of simulation model currently accepts ("ED2", "SIPNET", "BIOCRO")
+##' @param model name of simulation model currently accepts ('ED2', 'SIPNET', 'BIOCRO')
 ##' @param lat Latitude of the site
 ##' @param lon Longitude of the site
 ##' @param start_date Start time of the simulation
@@ -64,9 +63,9 @@ model2netcdfdep <- function(runid, outdir, model, lat, lon, start_date, end_date
 ##' @export
 ##' @return vector of filenames created, converts model output to netcdf as a side effect
 ##' @author Mike Dietze, David LeBauer
-model2netcdf <- function(runid, outdir, model, lat, lon, start_date, end_date){
+model2netcdf <- function(runid, outdir, model, lat, lon, start_date, end_date) {
   logger.severe("model2netcdf will be removed in future versions, plase update your worklow")
-}
+} # model2netcdf
 
 
 ##' Reads the output of a single model run
@@ -91,76 +90,75 @@ model2netcdf <- function(runid, outdir, model, lat, lon, start_date, end_date){
 ##' @return vector of output variable
 ##' @export
 ##' @author Michael Dietze, David LeBauer
-read.output <- function(runid, outdir, start.year=NA,
-                        end.year=NA, variables = "GPP") {
-
+read.output <- function(runid, outdir, start.year = NA, end.year = NA, variables = "GPP") {
+  
   library(ncdf4)
   library(udunits2)
-
-  ## vars in units s-1 to be converted to y-1
-  #cflux = c("GPP", "NPP", "NEE", "TotalResp", "AutoResp", "HeteroResp",
-  #  "DOC_flux", "Fire_flux") # kgC m-2 s-1
-  #wflux = c("Evap", "TVeg", "Qs", "Qsb", "Rainf") # kgH20 m-2 d-1
+  
+  ## vars in units s-1 to be converted to y-1 cflux = c('GPP', 'NPP', 'NEE',
+  ## 'TotalResp', 'AutoResp', 'HeteroResp', 'DOC_flux', 'Fire_flux') # kgC m-2 s-1
+  ## wflux = c('Evap', 'TVeg', 'Qs', 'Qsb', 'Rainf') # kgH20 m-2 d-1
   
   # create list of *.nc years
-  nc.years <- as.vector(unlist(strsplit(list.files(path = outdir, pattern="\\.nc$", full.names=FALSE),".nc")))
+  nc.years <- as.vector(unlist(strsplit(list.files(path = outdir, pattern = "\\.nc$", 
+                                                   full.names = FALSE), ".nc")))
   # select only those *.nc years requested by user
   keep <- which(nc.years >= as.numeric(start.year) & nc.years <= as.numeric(end.year))
-  ncfiles <- list.files(path = outdir, pattern="\\.nc$", full.names=TRUE)
+  ncfiles <- list.files(path = outdir, pattern = "\\.nc$", full.names = TRUE)
   ncfiles <- ncfiles[keep]
   # throw error if no *.nc files selected/availible
   nofiles <- FALSE
-  if(length(ncfiles) == 0) {
-    logger.warn("read.output: no netCDF files of model output present for runid = ", runid, " in ", outdir, 
-                "will return NA")
-    if(length(nc.years)>0) {
-      logger.info("netCDF files for other years present",nc.years)
+  if (length(ncfiles) == 0) {
+    logger.warn("read.output: no netCDF files of model output present for runid = ", 
+                runid, " in ", outdir, "will return NA")
+    if (length(nc.years) > 0) {
+      logger.info("netCDF files for other years present", nc.years)
     }
     nofiles <- TRUE
   } else {
-    logger.info("Reading output for Years: ",start.year," - ", end.year,
-                "in directory:", outdir, "including files", dir(outdir, pattern = "\\.nc$"))
+    logger.info("Reading output for Years: ", start.year, " - ", end.year, 
+                "in directory:", outdir,
+                "including files", dir(outdir, pattern = "\\.nc$"))
   }
   
   result <- list()
-
-  if(!nofiles){
-    for(ncfile in ncfiles) {
-        nc <- nc_open(ncfile)
-        for(v in variables){
-          if(v %in% c(names(nc$var),names(nc$dim))){
-            newresult <- ncvar_get(nc, v)
-#  Dropping attempt to provide more sensible units because of graph unit errors, issue #792            
-#            if(v %in% c(cflux, wflux)){
-#              newresult <- ud.convert(newresult, "kg m-2 s-1", "kg ha-1 yr-1")
-#            }
-            result[[v]] <- abind(result[[v]], newresult)
-          } else if (!(v %in% names(nc$var))){
-            logger.warn(paste(v, "missing in", ncfile))
-          }
+  
+  if (!nofiles) {
+    for (ncfile in ncfiles) {
+      nc <- nc_open(ncfile)
+      for (v in variables) {
+        if (v %in% c(names(nc$var), names(nc$dim))) {
+          newresult <- ncvar_get(nc, v)
+          # Dropping attempt to provide more sensible units because of graph unit errors,
+          # issue #792 if(v %in% c(cflux, wflux)){ newresult <- ud.convert(newresult, 'kg
+          # m-2 s-1', 'kg ha-1 yr-1') }
+          result[[v]] <- abind(result[[v]], newresult)
+        } else if (!(v %in% names(nc$var))) {
+          logger.warn(paste(v, "missing in", ncfile))
         }
-        nc_close(nc)
       }
+      nc_close(nc)
+    }
   } else if (nofiles) {
     result <- lapply(variables, function(x) NA)
   }
-  logger.info(variables, 
-              "Mean:", lapply(result, function(x) signif(mean(x, na.rm = TRUE), 3)),
-              "Median:", lapply(result, function(x) signif(median(x, na.rm = TRUE), 3)))
+  logger.info(variables, "Mean:", 
+              lapply(result, function(x) signif(mean(x, na.rm = TRUE), 3)), "Median:", 
+              lapply(result, function(x) signif(median(x, na.rm = TRUE), 3)))
   return(result)
-}
+} # read.output
+
 
 ##'--------------------------------------------------------------------------------------------------#
 ##' Converts the output of all model runs
 ##'
 ##' @title convert outputs from model specific code to 
 ##' @name convert.outputs
-##' @param model name of simulation model currently accepts ("ED", "SIPNET", "BIOCRO")
+##' @param model name of simulation model currently accepts ('ED', 'SIPNET', 'BIOCRO')
 ##' @param settings settings loaded from pecan.xml
 ##' @param ... arguments passed to \code{\link{read.output}}, e.g. \code{variables}, \code{start.year}, \code{end.year}
 ##' @export
 ##' @author Rob Kooper
 convert.outputs <- function(model, settings, ...) {
   logger.severe("This function is not longer used and will be removed in the future.")
-}
-####################################################################################################
+} # convert.outputs

--- a/utils/R/regrid.R
+++ b/utils/R/regrid.R
@@ -4,28 +4,29 @@
 ##' @param latlon.data dataframe with lat, lon, and some value to be regridded
 ##' @return dataframe with regridded data
 ##' @author David LeBauer
-regrid <- function(latlon.data){
-    library(raster)
-    library(sp)
-    ## from http://stackoverflow.com/a/15351169/513006
-    spdf <- SpatialPointsDataFrame(data.frame(x = latlon.data$lon, y = latlon.data$lat),
-                                   data = data.frame(z = latlon.data$yield))
-    ## Make evenly spaced raster, same extent as original data
-    e <- extent(spdf)  
-    ## Determine ratio between x and y dimensions
-    ratio <- (e@xmax - e@xmin) / (e@ymax - e@ymin)
+regrid <- function(latlon.data) {
+  library(raster)
+  library(sp)
+  ## from http://stackoverflow.com/a/15351169/513006
+  spdf <- SpatialPointsDataFrame(data.frame(x = latlon.data$lon, y = latlon.data$lat), 
+                                 data = data.frame(z = latlon.data$yield))
+  ## Make evenly spaced raster, same extent as original data
+  e <- extent(spdf)
+  ## Determine ratio between x and y dimensions
+  ratio <- (e@xmax - e@xmin) / (e@ymax - e@ymin)
   
-    ## Create template raster to sample to
-    r <- raster( nrows = 56 , ncols = floor( 56 * ratio ) , ext = extent(spdf) )
-    rf <- rasterize( spdf , r , field = "z", fun = mean )
+  ## Create template raster to sample to
+  r  <- raster(nrows = 56, ncols = floor(56 * ratio), ext = extent(spdf))
+  rf <- rasterize(spdf, r, field = "z", fun = mean)
+  
+  # rdf <- data.frame( rasterToPoints( rf ) ) colnames(rdf) <-
+  # colnames(latlon.data)
+  arf <- as.array(rf)
+  
+  # return(rdf)
+  return(arf)
+} # regrid
 
-    #rdf <- data.frame( rasterToPoints( rf ) )    
-    #colnames(rdf) <- colnames(latlon.data)
-    arf <- as.array(rf)
-    
-    #return(rdf)
-    return(arf)
-}
 
 ##' Write gridded data to netcdf file
 ##'
@@ -33,39 +34,29 @@ regrid <- function(latlon.data){
 ##' @param grid.data 
 ##' @return writes netCDF file
 ##' @author David LeBauer
-grid2netcdf <- function(gdata, date = '9999-09-09', outfile = "out.nc"){
-
-    ## Fill in NA's
-    lats <-  unique(gdata$lat)
-    lons <- unique(gdata$lon)
-    dates <- unique(gdata$date)
-    latlons <- data.table(expand.grid(lat = lats,
-                                      lon = lons,
-                                      date = dates))
-    grid.data <- merge(latlons, gdata, by = c('lat','lon', 'date'),all.x = TRUE)
-    lat <- ncdim_def("lat", "degrees_east",
-                     vals =  lats,
-                     longname = "station_latitude") 
-    lon <- ncdim_def("lon", "degrees_north",
-                     vals = lons,
-                     longname = "station_longitude")
-    time <- ncdim_def(name = "time",
-                   units = paste0("days since 1700-01-01"),
-                   vals = as.numeric(ymd(paste0(years, "01-01")) - ymd("1700-01-01")),
-                   calendar = "standard", unlim = TRUE)    
-    
-    yieldvar <- mstmipvar("CropYield", lat, lon, time)
-    nc <- nc_create(filename = outfile,
-                    vars = list(CropYield = yieldvar))
-    
-    ## Output netCDF data
-#    ncvar_put(nc, varid = yieldvar, vals = grid.data[order(lat, lon, order(ymd(date )))]$yield)
-#    ncvar_put(nc, varid = yieldvar, vals = grid.data[order(order(ymd(date), lat, lon))]$yield)
-    ncvar_put(nc, varid = yieldvar, vals = yieldarray)
-        
-    ncatt_put(nc, 0, "description","put description here")
-    nc_close(nc)
-}
-
-
-
+grid2netcdf <- function(gdata, date = "9999-09-09", outfile = "out.nc") {
+  
+  ## Fill in NA's
+  lats      <- unique(gdata$lat)
+  lons      <- unique(gdata$lon)
+  dates     <- unique(gdata$date)
+  latlons   <- data.table(expand.grid(lat = lats, lon = lons, date = dates))
+  grid.data <- merge(latlons, gdata, by = c("lat", "lon", "date"), all.x = TRUE)
+  lat       <- ncdim_def("lat", "degrees_east", vals = lats, longname = "station_latitude")
+  lon       <- ncdim_def("lon", "degrees_north", vals = lons, longname = "station_longitude")
+  time      <- ncdim_def(name = "time", units = paste0("days since 1700-01-01"), 
+                         vals = as.numeric(ymd(paste0(years, "01-01")) - ymd("1700-01-01")), 
+                         calendar = "standard", 
+                         unlim = TRUE)
+  
+  yieldvar <- mstmipvar("CropYield", lat, lon, time)
+  nc <- nc_create(filename = outfile, vars = list(CropYield = yieldvar))
+  
+  ## Output netCDF data
+  #    ncvar_put(nc, varid = yieldvar, vals = grid.data[order(lat, lon, order(ymd(date )))]$yield)
+  #    ncvar_put(nc, varid = yieldvar, vals = grid.data[order(order(ymd(date), lat, lon))]$yield)
+  ncvar_put(nc, varid = yieldvar, vals = yieldarray)
+  
+  ncatt_put(nc, 0, "description", "put description here")
+  nc_close(nc)
+} # grid2netcdf

--- a/utils/R/remote.R
+++ b/utils/R/remote.R
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2014 University of Illinois, NCSA.
+# Copyright (c) 2012 University of Illinois, NCSA.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the 
 # University of Illinois/NCSA Open Source License
@@ -8,10 +8,9 @@
 #-------------------------------------------------------------------------------
 
 #-------------------------------------------------------------------------------
-# Remote utilities. Allows for the following functionality
-# - execute system call on remote machine
-# - execute R call on remote machine, returns result
-# - copy files to/from remote machines
+# Remote utilities. Allows for the following functionality - execute system call
+# on remote machine - execute R call on remote machine, returns result - copy
+# files to/from remote machines
 #-------------------------------------------------------------------------------
 
 #' Execute command remotely
@@ -30,29 +29,31 @@
 #' @export
 #' @examples 
 #' \dontrun{
-#'   host <- list(name="geo.bu.edu", user="kooper", tunnel="/tmp/geo.tunnel")
-#'   pritn(remote.execute.cmd(host, "ls", c("-l", "/"), stderr=TRUE))
+#'   host <- list(name='geo.bu.edu', user='kooper', tunnel='/tmp/geo.tunnel')
+#'   pritn(remote.execute.cmd(host, 'ls', c('-l', '/'), stderr=TRUE))
 #' }
-remote.execute.cmd <- function(host, cmd, args=character(), stderr=FALSE) {
-  if(is.character(host)) {
-    host <- list(name=host)
+remote.execute.cmd <- function(host, cmd, args = character(), stderr = FALSE) {
+  if (is.character(host)) {
+    host <- list(name = host)
   }
-
+  
   if ((host$name == "localhost") || (host$name == fqdn())) {
     logger.debug(paste(cmd, args))
-    system2(cmd, args, stdout=TRUE, stderr=as.logical(stderr))
+    system2(cmd, args, stdout = TRUE, stderr = as.logical(stderr))
   } else {
     remote <- c(host$name)
     if (!is.null(host$tunnel)) {
-      if (!file.exists(host$tunnel)) logger.severe("Could not find tunnel", host$tunnel)
-      remote <- c("-o", paste0('ControlPath="', host$tunnel, '"'), remote)
+      if (!file.exists(host$tunnel)) {
+        logger.severe("Could not find tunnel", host$tunnel)
+      }
+      remote <- c("-o", paste0("ControlPath=\"", host$tunnel, "\""), remote)
     } else if (!is.null(host$user)) {
       remote <- c("-l", host$user, remote)
     }
-    logger.debug(paste(c("ssh", "-T", remote, cmd, args), collapse=" "))
-    system2('ssh', c('-T', remote, cmd, args), stdout=TRUE, stderr=as.logical(stderr))
-  }
-}
+    logger.debug(paste(c("ssh", "-T", remote, cmd, args), collapse = " "))
+    system2("ssh", c("-T", remote, cmd, args), stdout = TRUE, stderr = as.logical(stderr))
+  } 
+} # remote.execute.cmd
 
 
 #' Copy file/dir from remote server to local server
@@ -72,18 +73,23 @@ remote.execute.cmd <- function(host, cmd, args=character(), stderr=FALSE) {
 #' @export
 #' @examples 
 #' \dontrun{
-#'   host <- list(name="geo.bu.edu", user="kooper", tunnel="/tmp/geo.tunnel")
-#'   remote.copy.from(host, "/tmp/kooper", "/tmp/geo.tmp", delete=TRUE)
+#'   host <- list(name='geo.bu.edu', user='kooper', tunnel='/tmp/geo.tunnel')
+#'   remote.copy.from(host, '/tmp/kooper', '/tmp/geo.tmp', delete=TRUE)
 #' }
-remote.copy.from <- function(host, src, dst, delete=FALSE, stderr=FALSE) {
+remote.copy.from <- function(host, src, dst, delete = FALSE, stderr = FALSE) {
   args <- c("-a", "-q")
-  if (as.logical(delete)) args <- c(args, "--delete")
+  if (as.logical(delete)) {
+    args <- c(args, "--delete")
+  }
   if (is.localhost(host)) {
     args <- c(args, src, dst)
   } else {
     if (!is.null(host$tunnel)) {
-      if (!file.exists(host$tunnel)) logger.severe("Could not find tunnel", host$tunnel)
-      args <- c(args, "-e", paste0('ssh -o ControlPath="', host$tunnel, '"', collapse=""))
+      if (!file.exists(host$tunnel)) {
+        logger.severe("Could not find tunnel", host$tunnel)
+      }
+      args <- c(args, "-e", paste0("ssh -o ControlPath=\"", host$tunnel, "\"", 
+                                   collapse = ""))
       args <- c(args, paste0(host$name, ":", src), dst)
     } else if (!is.null(host$user)) {
       args <- c(args, paste0(host$user, "@", host$name, ":", src), dst)
@@ -92,8 +98,9 @@ remote.copy.from <- function(host, src, dst, delete=FALSE, stderr=FALSE) {
     }
   }
   logger.debug("rsync", shQuote(args))
-  system2('rsync', shQuote(args), stdout=TRUE, stderr=as.logical(stderr))
-}
+  system2("rsync", shQuote(args), stdout = TRUE, stderr = as.logical(stderr))
+} # remote.copy.from
+
 
 #' Copy file/dir to remote server from local server
 #'
@@ -112,18 +119,23 @@ remote.copy.from <- function(host, src, dst, delete=FALSE, stderr=FALSE) {
 #' @export
 #' @examples 
 #' \dontrun{
-#'   host <- list(name="geo.bu.edu", user="kooper", tunnel="/tmp/geo.tunnel")
-#'   remote.copy.to(host, "/tmp/kooper", "/tmp/kooper", delete=TRUE)
+#'   host <- list(name='geo.bu.edu', user='kooper', tunnel='/tmp/geo.tunnel')
+#'   remote.copy.to(host, '/tmp/kooper', '/tmp/kooper', delete=TRUE)
 #' }
-remote.copy.to <- function(host, src, dst, delete=FALSE, stderr=FALSE) {
+remote.copy.to <- function(host, src, dst, delete = FALSE, stderr = FALSE) {
   args <- c("-a", "-q")
-  if (as.logical(delete)) args <- c(args, "--delete")
+  if (as.logical(delete)) {
+    args <- c(args, "--delete")
+  }
   if (is.localhost(host)) {
     args <- c(args, src, dst)
   } else {
     if (!is.null(host$tunnel)) {
-      if (!file.exists(host$tunnel)) logger.severe("Could not find tunnel", host$tunnel)
-      args <- c(args, "-e", paste0('ssh -o ControlPath="', host$tunnel, '"', collapse=""))
+      if (!file.exists(host$tunnel)) {
+        logger.severe("Could not find tunnel", host$tunnel)
+      } 
+      args <- c(args, "-e", paste0("ssh -o ControlPath=\"", host$tunnel, "\"", 
+                                   collapse = ""))
       args <- c(args, src, paste0(host$name, ":", dst))
     } else if (!is.null(host$user)) {
       args <- c(args, src, paste0(host$user, "@", host$name, ":", dst))
@@ -132,8 +144,9 @@ remote.copy.to <- function(host, src, dst, delete=FALSE, stderr=FALSE) {
     }
   }
   logger.debug("rsync", shQuote(args))
-  system2('rsync', shQuote(args), stdout=TRUE, stderr=as.logical(stderr))
-}
+  system2("rsync", shQuote(args), stdout = TRUE, stderr = as.logical(stderr))
+} # remote.copy.to
+
 
 #' Check if host is local
 #'
@@ -149,17 +162,17 @@ remote.copy.to <- function(host, src, dst, delete=FALSE, stderr=FALSE) {
 #' is.localhost(fqdn())
 is.localhost <- function(host) {
   if (is.character(host)) {
-    (host == "localhost") || (host == fqdn())
+    return((host == "localhost") || (host == fqdn()))
   } else if (is.list(host)) {
-    (host$name == "localhost") || (host$name == fqdn())
+    return((host$name == "localhost") || (host$name == fqdn()))
   } else {
-      FALSE
+    return(FALSE)
   }
-}
+} # is.localhost
 
-#host <- list(name="geo.bu.edu", user="kooper", tunnel="/tmp/geo.tunnel")
-#out <- remote.copy.to(host, "/tmp/kooper/", "/tmp/kooper/", delete=TRUE, stderr=TRUE)
-#print(out)
+# host <- list(name='geo.bu.edu', user='kooper', tunnel='/tmp/geo.tunnel') 
+# out <- remote.copy.to(host, '/tmp/kooper/', '/tmp/kooper/', delete=TRUE, stderr=TRUE)
+# print(out)
 
 
 #' Execute command remotely
@@ -179,17 +192,17 @@ is.localhost <- function(host) {
 #' @export
 #' @examples 
 #' \dontrun{
-#'   remote.execute.R("list.files()", host="localhost", verbose=FALSE)
+#'   remote.execute.R('list.files()', host='localhost', verbose=FALSE)
 #' }
-remote.execute.R <- function(script, host="localhost", user=NA, verbose=FALSE, R="R") {
-  uuid <- paste0("pecan-", paste(sample(c(letters[1:6],0:9),30,replace=TRUE),collapse=""))
+remote.execute.R <- function(script, host = "localhost", user = NA, verbose = FALSE, 
+                             R = "R") {
+  uuid <- paste0("pecan-", paste(sample(c(letters[1:6], 0:9), 30, replace = TRUE), 
+                                 collapse = ""))
   tmpfile <- file.path("/tmp", uuid)
-  input <- c(paste0("remotefunc <- function() {"),
-             script,
-             "}",
-             "remoteout <- remotefunc()",
-             paste0("fp <- file('", tmpfile, "', 'w')"),
-             paste0("ign <- serialize(remoteout, fp)"),
+  input <- c(paste0("remotefunc <- function() {"), script, "}", 
+             "remoteout <- remotefunc()", 
+             paste0("fp <- file('", tmpfile, "', 'w')"), 
+             paste0("ign <- serialize(remoteout, fp)"), 
              "close(fp)")
   verbose <- ifelse(as.logical(verbose), "", FALSE)
   if ((host == "localhost") || (host == fqdn())) {
@@ -199,22 +212,28 @@ remote.execute.R <- function(script, host="localhost", user=NA, verbose=FALSE, R
         R <- Rbinary
       }
     }
-    result = try(system2(R, "--vanilla", stdout=verbose, stderr=verbose, input=input))
+    result <- try(system2(R, "--vanilla", stdout = verbose, stderr = verbose, 
+                          input = input))
     print(result)
-    if(!file.exists(tmpfile)){fp <- file(tmpfile, 'w');serialize(result,fp);close(fp)}
+    if (!file.exists(tmpfile)) {
+      fp <- file(tmpfile, "w")
+      serialize(result, fp)
+      close(fp)
+    }
   } else {
-    remote <- ifelse(is.na(user), host, paste(user, host, sep='@'))[[1]]
-    result = system2('ssh', c('-T', remote, R, "--vanilla"), stdout=verbose, stderr=verbose, input=input)
+    remote <- ifelse(is.na(user), host, paste(user, host, sep = "@"))[[1]]
+    result <- system2("ssh", c("-T", remote, R, "--vanilla"), stdout = verbose, 
+                      stderr = verbose, input = input)
     remote.copy.from(host, tmpfile, tmpfile)
     remote.execute.cmd(host, "rm", c("-f", tmpfile))
   }
   
   # load result
-  fp <- file(tmpfile, 'r')
+  fp <- file(tmpfile, "r")
   result <- unserialize(fp)
   close(fp)
   unlink(tmpfile)
   invisible(result)
-}
+} # remote.execute.R
 
 # remote.execute.cmd <- function(host, cmd, args=character(), stderr=FALSE) {

--- a/utils/R/remote.R
+++ b/utils/R/remote.R
@@ -8,9 +8,10 @@
 #-------------------------------------------------------------------------------
 
 #-------------------------------------------------------------------------------
-# Remote utilities. Allows for the following functionality - execute system call
-# on remote machine - execute R call on remote machine, returns result - copy
-# files to/from remote machines
+# Remote utilities. Allows for the following functionality
+# - execute system call on remote machine
+# - execute R call on remote machine, returns result
+# - copy files to/from remote machines
 #-------------------------------------------------------------------------------
 
 #' Execute command remotely

--- a/utils/R/remove.config.R
+++ b/utils/R/remove.config.R
@@ -6,15 +6,14 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-remove.config <- function(dir,settings,model){
 
-  fcn.name <- paste("remove.config.",model,sep="")
-  if(exists(fcn.name)){
-    do.call(fcn.name,args=list(dir,settings))
-  } else {
-    warning(paste(fcn.name,"does not exist"))
-    warning("This function is not required, but it's implementation is recommended")
-  }
-
-  
-}
+remove.config <- function(dir, settings, model) {
+    
+    fcn.name <- paste0("remove.config.", model)
+    if (exists(fcn.name)) {
+        do.call(fcn.name, args = list(dir, settings))
+    } else {
+        warning(paste(fcn.name, "does not exist"))
+        warning("This function is not required, but its implementation is recommended")
+    }
+} # remove.config

--- a/utils/R/run.write.configs.R
+++ b/utils/R/run.write.configs.R
@@ -6,7 +6,7 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
-#--------------------------------------------------------------------------------------------------#
+
 ##' Main driver function to call the ecosystem model specific (e.g. ED, SiPNET) 
 ##' run and configuration file scripts 
 ##' 
@@ -14,7 +14,7 @@
 ##' @title Run model specific write configuration functions
 ##' @param model the ecosystem model to generate the configuration files for
 ##' @param write should the runs be written to the database
-##' @param ens.sample.method how to sample the ensemble members("halton" sequence or "uniform" random)
+##' @param ens.sample.method how to sample the ensemble members('halton' sequence or 'uniform' random)
 ##' @param posterior.files Filenames for posteriors for drawing samples for ensemble and sensitivity
 ##'    analysis (e.g. post.distns.Rdata, or prior.distns.Rdata). Defaults to NA, in which case the 
 ##'    most recent posterior or prior (in that order) for the workflow is used. Should be a vector, 
@@ -25,23 +25,26 @@
 ##' @export
 ##'
 ##' @author David LeBauer, Shawn Serbin, Ryan Kelly, Mike Dietze
-run.write.configs <- function(settings, write = TRUE, ens.sample.method="uniform",
-                       posterior.files=rep(NA, length(settings$pfts)), overwrite=TRUE) {
-
+run.write.configs <- function(settings, write = TRUE, ens.sample.method = "uniform", 
+                              posterior.files = rep(NA, length(settings$pfts)), 
+                              overwrite = TRUE) {
+  
   ## Which posterior to use?
-  for(i in seq_along(settings$pfts)){
+  for (i in seq_along(settings$pfts)) {
     ## if posterior.files is specified us that
-    if(is.na(posterior.files[i])){
+    if (is.na(posterior.files[i])) {
       ## otherwise, check to see if posteriorid exists
-      if(!is.null(settings$pfts[[i]]$posteriorid)){
+      if (!is.null(settings$pfts[[i]]$posteriorid)) {
         con <- db.open(settings$database$bety)
-        files = dbfile.check("Posterior",settings$pfts[[i]]$posteriorid,con,settings$host$name)
-        pid = grep("post.distns.*Rdata",files$file_name)  ## is there a posterior file?
-        if(length(pid) == 0){
-          pid = grep("prior.distns.Rdata",files$file_name)  ## is there a prior file?
+        files <- dbfile.check("Posterior",
+                              settings$pfts[[i]]$posteriorid, 
+                              con, settings$host$name)
+        pid <- grep("post.distns.*Rdata", files$file_name)  ## is there a posterior file?
+        if (length(pid) == 0) {
+          pid <- grep("prior.distns.Rdata", files$file_name)  ## is there a prior file?
         }
-        if(length(pid)>0){
-          posterior.files[i] = file.path(files$file_path[pid],files$file_name[pid])
+        if (length(pid) > 0) {
+          posterior.files[i] <- file.path(files$file_path[pid], files$file_name[pid])
         }  ## otherwise leave posteriors as NA
         db.close(con)
       }
@@ -49,124 +52,118 @@ run.write.configs <- function(settings, write = TRUE, ens.sample.method="uniform
     }
   }
   
-  
   ## Sample parameters
-  model = settings$model$type
-  scipen = getOption("scipen")
-  options(scipen=12)
+  model <- settings$model$type
+  scipen <- getOption("scipen")
+  options(scipen = 12)
   get.parameter.samples(settings, posterior.files, ens.sample.method)
   load(file.path(settings$outdir, "samples.Rdata"))
-
+  
   library(coda)
   ## remove previous runs.txt
   if (overwrite && file.exists(file.path(settings$rundir, "runs.txt"))) {
     logger.warn("Existing runs.txt file will be removed.")
     unlink(file.path(settings$rundir, "runs.txt"))
   }
-
+  
   load.modelpkg(model)
-
+  
   ## Check for model-specific write configs
-
-  my.write.config <- paste("write.config.",model,sep="")
-  if(!exists(my.write.config)){
-    logger.error(my.write.config, "does not exist, please make sure that the model package contains a function called",  my.write.config)
+  
+  my.write.config <- paste0("write.config.")
+  if (!exists(my.write.config)) {
+    logger.error(my.write.config, 
+                 "does not exist, please make sure that the model package contains a function called", 
+                 my.write.config)
   }
-
-  ## Prepare for model output.  Cleanup any old config files (if exists)
-  my.remove.config <- paste0("remove.config.",model)
-  if(exists(my.remove.config)) {
+  
+  ## Prepare for model output.  Clean up any old config files (if exists)
+  my.remove.config <- paste0("remove.config.", model)
+  if (exists(my.remove.config)) {
     do.call(my.remove.config, args = list(settings$rundir, settings))
   }
-
   
   # TODO RK : need to write to runs_inputs table
-
+  
   # Save names
   pft.names <- names(trait.samples)
   trait.names <- lapply(trait.samples, names)
-
   
-  ### NEED TO IMPLEMENT: 
-  ## Load Environmental Priors and Posteriors
+  ### NEED TO IMPLEMENT: Load Environmental Priors and Posteriors
   
   ### Sensitivity Analysis
-  if('sensitivity.analysis' %in% names(settings)) {
-
+  if ("sensitivity.analysis" %in% names(settings)) {
+    
     ### Write out SA config files
-    if(!exists("cnt")) {            
+    if (!exists("cnt")) {
       cnt <- 0
       assign("cnt", cnt, .GlobalEnv)
     }
     logger.info("\n ----- Writing model run config files ----")
-    sa.runs <- write.sa.configs(defaults = settings$pfts,
-                                        quantile.samples = sa.samples,
-                                        settings = settings,
-                                        model = model,
-                                        write.to.db = write)
-
+    sa.runs <- write.sa.configs(defaults = settings$pfts, 
+                                quantile.samples = sa.samples, 
+                                settings = settings, 
+                                model = model,
+                                write.to.db = write)
+    
     # Store output in settings and output variables
     runs.samples$sa <- sa.run.ids <- sa.runs$runs
     settings$sensitivity.analysis$ensemble.id <- sa.ensemble.id <- sa.runs$ensemble.id
-
+    
     # Save sensitivity analysis info
-    fname <- sensitivity.filename(settings, "sensitivity.samples", "Rdata", all.var.yr=TRUE, pft=NULL)
-    save(sa.run.ids, sa.ensemble.id, sa.samples, pft.names, trait.names, file=fname)
-
-  } ### End of SA
+    fname <- sensitivity.filename(settings, "sensitivity.samples", "Rdata", 
+                                  all.var.yr = TRUE, pft = NULL)
+    save(sa.run.ids, sa.ensemble.id, sa.samples, pft.names, trait.names, file = fname)
+    
+  }  ### End of SA
   
   ### Write ENSEMBLE
-  if('ensemble' %in% names(settings)){
-        ens.runs <- write.ensemble.configs(defaults = settings$pfts,
-                                                    ensemble.samples = ensemble.samples,
-                                                    settings = settings,
-                                                    model = model,
-                                                    write.to.db = write)
-
+  if ("ensemble" %in% names(settings)) {
+    ens.runs <- write.ensemble.configs(defaults = settings$pfts, 
+                                       ensemble.samples = ensemble.samples, 
+                                       settings = settings,
+                                       model = model, 
+                                       write.to.db = write)
+    
     # Store output in settings and output variables
     runs.samples$ensemble <- ens.run.ids <- ens.runs$runs
     settings$ensemble$ensemble.id <- ens.ensemble.id <- ens.runs$ensemble.id
-    ens.samples <- ensemble.samples # rename just for consistency
+    ens.samples <- ensemble.samples  # rename just for consistency
     
     # Save ensemble analysis info
-    fname <- ensemble.filename(settings, "ensemble.samples", "Rdata", all.var.yr=TRUE)
-    save(ens.run.ids, ens.ensemble.id, ens.samples, pft.names, trait.names, file=fname)
+    fname <- ensemble.filename(settings, "ensemble.samples", "Rdata", all.var.yr = TRUE)
+    save(ens.run.ids, ens.ensemble.id, ens.samples, pft.names, trait.names, file = fname)
   } else {
-    logger.info('not writing config files for ensemble, settings are NULL')
-  } ### End of Ensemble
-
+    logger.info("not writing config files for ensemble, settings are NULL")
+  }  ### End of Ensemble
+  
   logger.info("###### Finished writing model run config files #####")
   logger.info("config files samples in ", file.path(settings$outdir, "run"))
   
   ### Save output from SA/Ensemble runs
-  # A lot of this is duplicate with the ensemble/sa specific output above, but kept for backwards compatibility. 
-  save(ensemble.samples, trait.samples, sa.samples, runs.samples,  pft.names, trait.names,
-       file = file.path(settings$outdir, 'samples.Rdata'))
+  # A lot of this is duplicate with the ensemble/sa specific output above, but kept for backwards compatibility.   
+  save(ensemble.samples, trait.samples, sa.samples, runs.samples, pft.names, trait.names, 
+       file = file.path(settings$outdir, "samples.Rdata"))
   logger.info("parameter values for runs in ", file.path(settings$outdir, "samples.RData"))
-  options(scipen=scipen)
+  options(scipen = scipen)
   
-  invisible(settings)
-}
-#==================================================================================================#
+  return(invisible(settings))
+} # run.write.configs
 
 
 ##' @export
-runModule.run.write.configs <- function(settings, overwrite=TRUE) {
-  if(is.MultiSettings(settings)) {
+runModule.run.write.configs <- function(settings, overwrite = TRUE) {
+  if (is.MultiSettings(settings)) {
     if (overwrite && file.exists(file.path(settings$rundir, "runs.txt"))) {
       logger.warn("Existing runs.txt file will be removed.")
       unlink(file.path(settings$rundir, "runs.txt"))
     }
-    return(papply(settings, runModule.run.write.configs, overwrite=FALSE))
+    return(papply(settings, runModule.run.write.configs, overwrite = FALSE))
   } else if (is.Settings(settings)) {
     write <- settings$database$bety$write
     ens.sample.method <- settings$ensemble$method
-    return(run.write.configs(settings, write, ens.sample.method, overwrite=overwrite))
+    return(run.write.configs(settings, write, ens.sample.method, overwrite = overwrite))
   } else {
     stop("runModule.run.write.configs only works with Settings or MultiSettings")
   }
-}
- 
-####################################################################################################
-### EOF.  End of R script file.          		
-####################################################################################################
+} # runModule.run.write.configs

--- a/utils/R/sensitivity.R
+++ b/utils/R/sensitivity.R
@@ -1,12 +1,12 @@
-##-------------------------------------------------------------------------------
-## Copyright (c) 2012 University of Illinois, NCSA.
-## All rights reserved. This program and the accompanying materials
-## are made available under the terms of the 
-## University of Illinois/NCSA Open Source License
-## which accompanies this distribution, and is available at
-## http://opensource.ncsa.illinois.edu/license.html
-##-------------------------------------------------------------------------------
-##--------------------------------------------------------------------------------------------------#
+#-------------------------------------------------------------------------------
+# Copyright (c) 2012 University of Illinois, NCSA.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the 
+# University of Illinois/NCSA Open Source License
+# which accompanies this distribution, and is available at
+# http://opensource.ncsa.illinois.edu/license.html
+#-------------------------------------------------------------------------------
+
 ##' Reads output of sensitivity analysis runs
 ##'
 ##' 
@@ -23,36 +23,34 @@
 ##' @param variables variables to be read from model output
 ##' @export
 ##' @author Ryan Kelly, David LeBauer, Rob Kooper, Mike Dietze
-#--------------------------------------------------------------------------------------------------#
-read.sa.output <- function(traits, quantiles, pecandir, outdir, pft.name='', 
-                           start.year, end.year, variable, sa.run.ids=NULL){
+read.sa.output <- function(traits, quantiles, pecandir, outdir, pft.name = "", 
+                           start.year, end.year, variable, sa.run.ids = NULL) {
   
   if (is.null(sa.run.ids)) {
-    samples.file <- file.path(pecandir, 'samples.Rdata')
-    if(file.exists(samples.file)){
+    samples.file <- file.path(pecandir, "samples.Rdata")
+    if (file.exists(samples.file)) {
       load(samples.file)
       sa.run.ids <- runs.samples$sa
     } else {
-      logger.error(samples.file, "not found, this file is required by the read.sa.output function")      
+      logger.error(samples.file, "not found, this file is required by the read.sa.output function")
     }
   }
   
-  sa.output <- matrix(nrow = length(quantiles),
-                      ncol = length(traits),
-                      dimnames = list(quantiles, traits))
-  for(trait in traits){
-    for(quantile in quantiles){
+  sa.output <- matrix(nrow = length(quantiles), ncol = length(traits), dimnames = list(quantiles, 
+                                                                                       traits))
+  for (trait in traits) {
+    for (quantile in quantiles) {
       run.id <- sa.run.ids[[pft.name]][quantile, trait]
-      out <- read.output(run.id, file.path(outdir, run.id),
-                         start.year, end.year, variable)
-      sa.output[quantile, trait] <- sapply(out, mean, na.rm=TRUE)
-    } ## end loop over quantiles
-    logger.info("reading sensitivity analysis output for model run at ", quantiles, "quantiles of trait", trait)
-  } ## end loop over traits
+      out <- read.output(run.id, file.path(outdir, run.id), start.year, end.year, variable)
+      sa.output[quantile, trait] <- sapply(out, mean, na.rm = TRUE)
+    }  ## end loop over quantiles
+    logger.info("reading sensitivity analysis output for model run at ", 
+                quantiles, "quantiles of trait", trait)
+  }  ## end loop over traits
   sa.output <- as.data.frame(sa.output)
   return(sa.output)
-}
-##==================================================================================================#
+} # read.sa.output
+
 
 ##' Write sensitivity analysis config files
 ##'
@@ -68,15 +66,15 @@ read.sa.output <- function(traits, quantiles, pecandir, outdir, pft.name='',
 ##' @export
 ##' @author David LeBauer, Carl Davidson
 write.sa.configs <- function(defaults, quantile.samples, settings, model,
-                             clean=FALSE, write.to.db = TRUE){
-  scipen = getOption("scipen")
-  options(scipen=12)
+                             clean = FALSE, write.to.db = TRUE) {
+  scipen <- getOption("scipen")
+  options(scipen = 12)
   
-  my.write.config <- paste("write.config.", model,sep="")
+  my.write.config <- paste("write.config.", model, sep = "")
   
-  if(write.to.db){
-    con <- try(db.open(settings$database$bety), silent=TRUE)
-    if(is.character(con)){
+  if (write.to.db) {
+    con <- try(db.open(settings$database$bety), silent = TRUE)
+    if (is.character(con)) {
       con <- NULL
     }
   } else {
@@ -89,87 +87,107 @@ write.sa.configs <- function(defaults, quantile.samples, settings, model,
   } else {
     workflow.id <- -1
   }
-
+  
   # find all inputs that have an id
   inputs <- names(settings$run$inputs)
-  inputs <- inputs[grepl('.id$', inputs)]
-    
+  inputs <- inputs[grepl(".id$", inputs)]
+  
   runs <- data.frame()
   
-  ##write median run
-  MEDIAN <- '50'
+  ## write median run
+  MEDIAN <- "50"
   median.samples <- list()
-  for(i in 1:length(quantile.samples)){
-    median.samples[[i]] <- quantile.samples[[i]][MEDIAN,]
+  for (i in seq_along(quantile.samples)) {
+    median.samples[[i]] <- quantile.samples[[i]][MEDIAN, ]
   }
   names(median.samples) <- names(quantile.samples)
   
   if (!is.null(con)) {
     now <- format(Sys.time(), "%Y-%m-%d %H:%M:%S")
-    db.query(paste0("INSERT INTO ensembles (created_at, runtype, workflow_id) values ('", now, "', 'sensitivity analysis', ", format(workflow.id,scientific=FALSE), ")"), con=con)
-    ensemble.id <- db.query(paste0("SELECT id FROM ensembles WHERE created_at='", now, "' AND runtype='sensitivity analysis'"), con=con)[['id']]
-    paramlist <- paste0("quantile=MEDIAN,trait=all,pft=", paste(lapply(settings$pfts, function(x) x[['name']]), sep=','))
-    db.query(paste0("INSERT INTO runs (model_id, site_id, start_time, finish_time, outdir, created_at, ensemble_id, parameter_list) values ('", settings$model$id, "', '", settings$run$site$id, "', '", settings$run$start.date, "', '", settings$run$end.date, "', '",settings$run$outdir , "', '", now, "', ", ensemble.id, ", '", paramlist, "')"), con=con)
-    run.id <- db.query(paste0("SELECT id FROM runs WHERE created_at='", now, "' AND parameter_list='", paramlist, "'"), con=con)[['id']]
-
+    db.query(paste0("INSERT INTO ensembles (created_at, runtype, workflow_id) values ('", 
+                    now, "', 'sensitivity analysis', ", 
+                    format(workflow.id, scientific = FALSE), ")"), 
+             con = con)
+    ensemble.id <- db.query(paste0("SELECT id FROM ensembles WHERE created_at='", 
+                                   now, "' AND runtype='sensitivity analysis'"), con = con)[["id"]]
+    paramlist <- paste0("quantile=MEDIAN,trait=all,pft=",
+                        paste(lapply(settings$pfts, function(x) x[["name"]]), sep = ","))
+    db.query(paste0("INSERT INTO runs (model_id, site_id, start_time, finish_time, outdir, created_at, ensemble_id, parameter_list) values ('", 
+                    settings$model$id, "', '", 
+                    settings$run$site$id, "', '", 
+                    settings$run$start.date, "', '", 
+                    settings$run$end.date, "', '", 
+                    settings$run$outdir, "', '", 
+                    now, "', ", 
+                    ensemble.id, ", '", 
+                    paramlist, "')"), con = con)
+    run.id <- db.query(paste0("SELECT id FROM runs WHERE created_at='", now, 
+                              "' AND parameter_list='", paramlist, "'"), con = con)[["id"]]
+    
     # associate posteriors with ensembles
     for (pft in defaults) {
-      db.query(paste0("INSERT INTO posteriors_ensembles (posterior_id, ensemble_id, created_at, updated_at) values (",
-                      pft$posteriorid, ", ", ensemble.id, ", '", now, "', '", now, "');"), con=con)
+      db.query(paste0("INSERT INTO posteriors_ensembles (posterior_id, ensemble_id, created_at, updated_at) values (", 
+                      pft$posteriorid, ", ", 
+                      ensemble.id, ", '", 
+                      now, "', '", 
+                      now, "');"), 
+               con = con)
     }
-
+    
     # associate inputs with runs
     if (!is.null(inputs)) {
-      for(x in inputs) {
-        db.query(paste0("INSERT INTO inputs_runs (input_id, run_id, created_at) ",
-                        "values (", settings$run$inputs[[x]], ", ", run.id, ", NOW());"), con=con)
+      for (x in inputs) {
+        db.query(paste0("INSERT INTO inputs_runs (input_id, run_id, created_at) ", 
+                        "values (", settings$run$inputs[[x]], ", ", run.id, ", NOW());"), 
+                 con = con)
       }
     }
   } else {
-    run.id <- get.run.id('SA', 'median')
+    run.id <- get.run.id("SA", "median")
     ensemble.id <- NA
   }
   medianrun <- run.id
   
   # create folders (cleaning up old ones if needed)
-  if(clean) {
+  if (clean) {
     unlink(file.path(settings$rundir, run.id))
     unlink(file.path(settings$modeloutdir, run.id))
   }
-  dir.create(file.path(settings$rundir, run.id), recursive=TRUE)
-  dir.create(file.path(settings$modeloutdir, run.id), recursive=TRUE)
+  dir.create(file.path(settings$rundir, run.id), recursive = TRUE)
+  dir.create(file.path(settings$modeloutdir, run.id), recursive = TRUE)
   
-  # write run information to disk
-  ## TODO need to print list of pft names and trait names
-  cat("runtype     : sensitivity analysis\n",
-      "workflow id : ", workflow.id, "\n",
+  # write run information to disk TODO need to print list of pft names and trait
+  # names
+  cat("runtype     : sensitivity analysis\n", 
+      "workflow id : ", workflow.id, "\n", 
       "ensemble id : ", ensemble.id, "\n",
-      "pft name    : ALL PFT", "\n",
-      "quantile    : MEDIAN\n",
-      "trait       : ALL TRAIT", "\n",
+      "pft name    : ALL PFT", "\n", 
+      "quantile    : MEDIAN\n", 
+      "trait       : ALL TRAIT", "\n", 
       "run id      : ", run.id, "\n",
-      "model       : ", model, "\n",
+      "model       : ", model, "\n", 
       "model id    : ", settings$model$id, "\n",
-      "site        : ", settings$run$site$name, "\n",
-      "site  id    : ", settings$run$site$id, "\n",
+      "site        : ", settings$run$site$name, "\n", 
+      "site  id    : ", settings$run$site$id, "\n", 
       "met data    : ", settings$run$site$met, "\n",
-      "start date  : ", settings$run$start.date, "\n",
-      "end date    : ", settings$run$end.date, "\n",
-      "hostname    : ", settings$host$name, "\n",
-      "rundir      : ", file.path(settings$host$rundir, run.id), "\n",
-      "outdir      : ", file.path(settings$host$outdir, run.id), "\n",
-      file=file.path(settings$rundir, run.id, "README.txt"), sep='')
+      "start date  : ", settings$run$start.date, "\n", 
+      "end date    : ", settings$run$end.date, "\n", 
+      "hostname    : ", settings$host$name, "\n", 
+      "rundir      : ", file.path(settings$host$rundir, run.id), "\n", 
+      "outdir      : ", file.path(settings$host$outdir, run.id), "\n", 
+      file = file.path(settings$rundir, run.id, "README.txt"), 
+      sep = "")
   
   # write configuration
-  do.call(my.write.config, args=list(defaults = defaults,
-                                     trait.values = median.samples,
-                                     settings = settings,
-                                     run.id = run.id))
-  cat(run.id, file=file.path(settings$rundir, "runs.txt"), sep="\n", append=TRUE)
+  do.call(my.write.config, args = list(defaults = defaults, 
+                                       trait.values = median.samples, 
+                                       settings = settings,
+                                       run.id = run.id))
+  cat(run.id, file = file.path(settings$rundir, "runs.txt"), sep = "\n", append = TRUE)
   
   ## loop over pfts
   runs <- list()
-  for(i in seq(names(quantile.samples))){
+  for (i in seq(names(quantile.samples))) {
     pftname <- names(quantile.samples)[i]
     if (pftname == "env") {
       next
@@ -182,71 +200,88 @@ write.sa.configs <- function(defaults, quantile.samples, settings, model,
     
     ## loop over variables
     for (trait in traits) {
-      for(quantile.str in quantiles.str) {
+      for (quantile.str in quantiles.str) {
         if (quantile.str != MEDIAN) {
-          quantile <- as.numeric(quantile.str)/100
+          quantile <- as.numeric(quantile.str) / 100
           trait.samples <- median.samples
           trait.samples[[i]][trait] <- quantile.samples[[i]][quantile.str, trait]
           
           if (!is.null(con)) {
             now <- format(Sys.time(), "%Y-%m-%d %H:%M:%S")
             paramlist <- paste0("quantile=", quantile.str, ",trait=", trait, ",pft=", pftname)
-            db.query(paste0("INSERT INTO runs (model_id, site_id, start_time, finish_time, outdir, created_at, ensemble_id, parameter_list) values ('", settings$model$id, "', '", settings$run$site$id, "', '", settings$run$start.date, "', '", settings$run$end.date, "', '",settings$run$outdir , "', '", now, "', ", ensemble.id, ", '", paramlist, "')"), con=con)
-            run.id <- db.query(paste0("SELECT id FROM runs WHERE created_at='", now, "' AND parameter_list='", paramlist, "'"), con=con)[['id']]
-
+            db.query(paste0("INSERT INTO runs (model_id, site_id, start_time, finish_time, outdir, created_at, ensemble_id, parameter_list) values ('", 
+                            settings$model$id, "', '", 
+                            settings$run$site$id, "', '", 
+                            settings$run$start.date, "', '",
+                            settings$run$end.date, "', '", 
+                            settings$run$outdir, "', '", 
+                            now, "', ", 
+                            ensemble.id, ", '", 
+                            paramlist, "')"), con = con)
+            run.id <- db.query(paste0("SELECT id FROM runs WHERE created_at='", 
+                                      now, "' AND parameter_list='", paramlist, "'"), con = con)[["id"]]
+            
             # associate posteriors with ensembles
             for (pft in defaults) {
-              db.query(paste0("INSERT INTO posteriors_ensembles (posterior_id, ensemble_id, created_at, updated_at) values (",
-                              pft$posteriorid, ", ", ensemble.id, ", '", now, "', '", now, "');"), con=con)
+              db.query(paste0("INSERT INTO posteriors_ensembles (posterior_id, ensemble_id, created_at, updated_at) values (", 
+                              pft$posteriorid, ", ", 
+                              ensemble.id, ", '", 
+                              now, "', '", now, 
+                              "');"), con = con)
             }
-
+            
             # associate inputs with runs
             if (!is.null(inputs)) {
-              for(x in inputs) {
-                db.query(paste0("INSERT INTO inputs_runs (input_id, run_id, created_at) ",
-                                "values (", settings$run$inputs[[x]], ", ", run.id, ", NOW());"), con=con)
+              for (x in inputs) {
+                db.query(paste0("INSERT INTO inputs_runs (input_id, run_id, created_at) ", 
+                                "values (", settings$run$inputs[[x]], ", ", run.id, ", NOW());"), 
+                         con = con)
               }
             }
-          } else { 
-            run.id <- get.run.id('SA', round(quantile,3), trait=trait, 
-                                 pft.name=names(trait.samples)[i])
+          } else {
+            run.id <- get.run.id("SA", 
+                                 round(quantile, 3), 
+                                 trait = trait, 
+                                 pft.name = names(trait.samples)[i])
           }
           runs[[pftname]][quantile.str, trait] <- run.id
           
           # create folders (cleaning up old ones if needed)
-          if(clean) {
+          if (clean) {
             unlink(file.path(settings$rundir, run.id))
             unlink(file.path(settings$modeloutdir, run.id))
           }
-          dir.create(file.path(settings$rundir, run.id), recursive=TRUE)
-          dir.create(file.path(settings$modeloutdir, run.id), recursive=TRUE)
+          dir.create(file.path(settings$rundir, run.id), recursive = TRUE)
+          dir.create(file.path(settings$modeloutdir, run.id), recursive = TRUE)
           
           # write run information to disk
-          cat("runtype     : sensitivity analysis\n",
-              "workflow id : ", workflow.id, "\n",
-              "ensemble id : ", ensemble.id, "\n",
-              "pft name    : ", names(trait.samples)[i], "\n",
-              "quantile    : ", quantile.str, "\n",
-              "trait       : ", trait, "\n",
-              "run id      : ", run.id, "\n",
-              "model       : ", model, "\n",
-              "model id    : ", settings$model$id, "\n",
-              "site        : ", settings$run$site$name, "\n",
-              "site  id    : ", settings$run$site$id, "\n",
-              "met data    : ", settings$run$site$met, "\n",
-              "start date  : ", settings$run$start.date, "\n",
+          cat("runtype     : sensitivity analysis\n", 
+              "workflow id : ", workflow.id, "\n", 
+              "ensemble id : ", ensemble.id, "\n", 
+              "pft name    : ", names(trait.samples)[i], "\n", 
+              "quantile    : ", quantile.str, "\n", 
+              "trait       : ", trait, "\n", 
+              "run id      : ", run.id, "\n", 
+              "model       : ", model, "\n", 
+              "model id    : ", settings$model$id, "\n", 
+              "site        : ", settings$run$site$name, "\n", 
+              "site  id    : ", settings$run$site$id, "\n", 
+              "met data    : ", settings$run$site$met, "\n", 
+              "start date  : ", settings$run$start.date, "\n", 
               "end date    : ", settings$run$end.date, "\n",
-              "hostname    : ", settings$host$name, "\n",
-              "rundir      : ", file.path(settings$host$rundir, run.id), "\n",
-              "outdir      : ", file.path(settings$host$outdir, run.id), "\n",
-              file=file.path(settings$rundir, run.id, "README.txt"), sep='')
+              "hostname    : ", settings$host$name, "\n", 
+              "rundir      : ", file.path(settings$host$rundir, run.id), "\n", 
+              "outdir      : ", file.path(settings$host$outdir, run.id), "\n", 
+              file = file.path(settings$rundir, run.id, "README.txt"), 
+              sep = "")
           
           # write configuration
-          do.call(my.write.config,
-                  args = list(defaults = defaults,
-                              trait.values = trait.samples,
-                              settings = settings, run.id))
-          cat(run.id, file=file.path(settings$rundir, "runs.txt"), sep="\n", append=TRUE)
+          do.call(my.write.config, args = list(defaults = defaults,
+                                               trait.values = trait.samples, 
+                                               settings = settings,
+                                               run.id))
+          cat(run.id, file = file.path(settings$rundir, "runs.txt"), sep = "\n", 
+              append = TRUE)
         } else {
           runs[[pftname]][MEDIAN, trait] <- medianrun
         }
@@ -256,7 +291,6 @@ write.sa.configs <- function(defaults, quantile.samples, settings, model,
   if (!is.null(con)) {
     db.close(con)
   }
-  options(scipen=scipen)
-  invisible(list(runs=runs, ensemble.id=ensemble.id))
-}
-#==================================================================================================#
+  options(scipen = scipen)
+  return(invisible(list(runs = runs, ensemble.id = ensemble.id)))
+} # write.sa.configs

--- a/utils/R/start.model.runs.R
+++ b/utils/R/start.model.runs.R
@@ -1,14 +1,12 @@
 ##-------------------------------------------------------------------------------
-## Copyright (c) 2012 University of Illinois, NCSA.
-## All rights reserved. This program and the accompanying materials
-## are made available under the terms of the 
-## University of Illinois/NCSA Open Source License
-## which accompanies this distribution, and is available at
+## Copyright (c) 2012 University of Illinois, NCSA.  All rights reserved. This
+## program and the accompanying materials are made available under the terms of
+## the University of Illinois/NCSA Open Source License which accompanies this
+## distribution, and is available at
 ## http://opensource.ncsa.illinois.edu/license.html
 ##-------------------------------------------------------------------------------
 
 
-##--------------------------------------------------------------------------------------------------#
 ##'
 ##' Start selected ecosystem model runs within PEcAn workflow
 ##' 
@@ -21,12 +19,12 @@
 ##' }
 ##' @author Shawn Serbin, Rob Kooper, David LeBauer
 ##'
-start.model.runs <- function(settings, write = TRUE){
+start.model.runs <- function(settings, write = TRUE) {
   model <- settings$model$type
   logger.info("-------------------------------------------------------------------")
   logger.info(paste(" Starting model runs", model))
   logger.info("-------------------------------------------------------------------")
-
+  
   # loop through runs and either call start run, or launch job on remote machine
   jobids <- list()
   
@@ -34,128 +32,152 @@ start.model.runs <- function(settings, write = TRUE){
   nruns <- length(readLines(con = file.path(settings$rundir, "runs.txt")))
   pb <- txtProgressBar(min = 0, max = nruns, style = 3)
   pbi <- 0
-
+  
   # create database connection
   if (write) {
     dbcon <- db.open(settings$database$bety)
   } else {
     dbcon <- NULL
   }
-
+  
   # launcher folder
   launcherfile <- NULL
   jobfile <- NULL
   firstrun <- NULL
-
+  
   # launch each of the jobs
   for (run in readLines(con = file.path(settings$rundir, "runs.txt"))) {
     # write start time to database
     if (!is.null(dbcon)) {
-      db.query(paste("UPDATE runs SET started_at =  NOW() WHERE id = ", format(run,scientific=FALSE)), con=dbcon)
+      db.query(paste("UPDATE runs SET started_at =  NOW() WHERE id = ", 
+                     format(run, scientific = FALSE)), con = dbcon)
     }
-
-    # if running on a remote cluster,
-    # create folders and copy any data to remote host
+    
+    # if running on a remote cluster, create folders and copy any data to remote host
     if (!is.localhost(settings$host)) {
-      remote.execute.cmd(settings$host, "mkdir", c("-p", file.path(settings$host$outdir, format(run,scientific=FALSE))))
-      remote.copy.to(settings$host, file.path(settings$rundir, format(run,scientific=FALSE)), settings$host$rundir, delete=TRUE)
+      remote.execute.cmd(settings$host, "mkdir", c("-p", file.path(settings$host$outdir, 
+                                                                   format(run, scientific = FALSE))))
+      remote.copy.to(settings$host, file.path(settings$rundir, format(run, 
+                                                                      scientific = FALSE)), settings$host$rundir, delete = TRUE)
     }
-
+    
     # check to see if we use the model launcer
     if (!is.null(settings$host$modellauncher)) {
       pbi <- pbi + 1
-
-      # set up launcher script if we use modellauncher 
+      
+      # set up launcher script if we use modellauncher
       if (is.null(firstrun)) {
         firstrun <- run
-        launcherfile <- file.path(settings$rundir, format(run,scientific=FALSE), "launcher.sh")
-        unlink(file.path(settings$rundir, format(run,scientific=FALSE), "joblist.txt"))
-        jobfile <- file(file.path(settings$rundir, format(run,scientific=FALSE), "joblist.txt"), "w")
-
-        writeLines(c("#!/bin/bash",
-                     paste(settings$host$modellauncher$mpirun,
-                           settings$host$modellauncher$binary,
-                           file.path(settings$host$rundir, format(run,scientific=FALSE), "joblist.txt"))), con=launcherfile)
-        writeLines(c("./job.sh"), con=jobfile)
+        launcherfile <- file.path(settings$rundir, 
+                                  format(run, scientific = FALSE), 
+                                  "launcher.sh")
+        unlink(file.path(settings$rundir, 
+                         format(run, scientific = FALSE), 
+                         "joblist.txt"))
+        jobfile <- file(file.path(settings$rundir,
+                                  format(run, scientific = FALSE), 
+                                  "joblist.txt"), "w")
+        
+        writeLines(c("#!/bin/bash", paste(settings$host$modellauncher$mpirun, 
+                                          settings$host$modellauncher$binary, 
+                                          file.path(settings$host$rundir, format(run, scientific = FALSE),
+                                                    "joblist.txt"))), con = launcherfile)
+        writeLines(c("./job.sh"), con = jobfile)
       }
-      writeLines(c(file.path(settings$host$rundir, format(run,scientific=FALSE))), con=jobfile)
-
+      writeLines(c(file.path(settings$host$rundir, format(run, scientific = FALSE))), 
+                 con = jobfile)
+      
     } else {
       # if qsub is requested
-      if (!is.null(settings$host$qsub)){
-        qsub <- gsub("@NAME@", paste("PEcAn-", format(run,scientific=FALSE), sep=""), settings$host$qsub)
-        qsub <- gsub("@STDOUT@", file.path(settings$host$outdir, format(run,scientific=FALSE), "stdout.log"), qsub)
-        qsub <- gsub("@STDERR@", file.path(settings$host$outdir, format(run,scientific=FALSE), "stderr.log"), qsub)
-        qsub <- strsplit(qsub, " (?=([^\"']*\"[^\"']*\")*[^\"']*$)", perl=TRUE)
-
+      if (!is.null(settings$host$qsub)) {
+        qsub <- gsub("@NAME@", paste0("PEcAn-", format(run, scientific = FALSE)), settings$host$qsub)
+        qsub <- gsub("@STDOUT@", file.path(settings$host$outdir,
+                                           format(run, scientific = FALSE), "stdout.log"), qsub)
+        qsub <- gsub("@STDERR@", file.path(settings$host$outdir, 
+                                           format(run, scientific = FALSE), "stderr.log"), qsub)
+        qsub <- strsplit(qsub, " (?=([^\"']*\"[^\"']*\")*[^\"']*$)", perl = TRUE)
+        
         # start the actual model run
         cmd <- qsub[[1]]
         args <- qsub[-1]
         if (is.localhost(settings$host)) {
-          out <- system2(cmd, c(args, file.path(settings$rundir, format(run,scientific=FALSE), "job.sh")), stdout=TRUE, stderr=TRUE)
+          out <- system2(cmd, c(args, file.path(settings$rundir, format(run, 
+                                                                        scientific = FALSE), "job.sh")), stdout = TRUE, stderr = TRUE)
         } else {
-          out <- remote.execute.cmd(settings$host, cmd, c(args, file.path(settings$host$rundir, format(run,scientific=FALSE), "job.sh")), stderr=TRUE)
+          out <- remote.execute.cmd(settings$host, cmd, c(args, file.path(settings$host$rundir, 
+                                                                          format(run, scientific = FALSE), "job.sh")), stderr = TRUE)
         }
-        print(out) # <-- for debugging
+        print(out)  # <-- for debugging
         jobids[run] <- sub(settings$host$qsub.jobid, "\\1", out)
-
-      # if qsub option is not invoked.  just start model runs in serial.
+        
+        # if qsub option is not invoked.  just start model runs in serial.
       } else {
         if (is.localhost(settings$host)) {
-          out <- system2(file.path(settings$rundir, format(run,scientific=FALSE), "job.sh"), stdout=TRUE, stderr=TRUE)
+          out <- system2(file.path(settings$rundir, format(run, scientific = FALSE), 
+                                   "job.sh"), stdout = TRUE, stderr = TRUE)
         } else {
-          out <- remote.execute.cmd(settings$host, file.path(settings$host$rundir, format(run,scientific=FALSE), "job.sh"), stderr=TRUE)
+          out <- remote.execute.cmd(settings$host, file.path(settings$host$rundir, 
+                                                             format(run, scientific = FALSE), "job.sh"), stderr = TRUE)
         }
-
+        
         # check output to see if an error occurred during the model run
         if ("ERROR IN MODEL RUN" %in% out) {
           logger.severe("Model run aborted, with error.\n", out)
         }
-
+        
         # copy data back to local
         if (!is.localhost(settings$host)) {
-          remote.copy.from(settings$host, file.path(settings$host$outdir, format(run,scientific=FALSE)), settings$modeloutdir)
+          remote.copy.from(settings$host, file.path(settings$host$outdir, 
+                                                    format(run, scientific = FALSE)), settings$modeloutdir)
         }
-
+        
         # write finished time to database
         if (!is.null(dbcon)) {
-          db.query(paste("UPDATE runs SET finished_at =  NOW() WHERE id = ", format(run,scientific=FALSE)), con=dbcon)
+          db.query(paste("UPDATE runs SET finished_at =  NOW() WHERE id = ", 
+                         format(run, scientific = FALSE)), con = dbcon)
         }
-
+        
         # update progress bar
         pbi <- pbi + 1
         setTxtProgressBar(pb, pbi)
-      }      
+      }
     }
   }
   close(pb)
-
+  
   # if using the model launcer
   if (!is.null(settings$host$modellauncher)) {
     close(jobfile)
-
+    
     # copy launcer and joblist
     if (!is.localhost(settings$host)) {
-      remote.copy.to(settings$host, file.path(settings$rundir, format(firstrun,scientific=FALSE)), settings$host$rundir, delete=TRUE)
+      remote.copy.to(settings$host, file.path(settings$rundir, 
+                                              format(firstrun, scientific = FALSE)), settings$host$rundir, delete = TRUE)
     }
-
+    
     # if qsub is requested
     if (!is.null(settings$host$qsub)) {
       qsub <- gsub("@NAME@", "PEcAn-all", settings$host$qsub)
-      qsub <- gsub("@STDOUT@", file.path(settings$host$outdir, format(firstrun,scientific=FALSE), "launcher.out.log"), qsub)
-      qsub <- gsub("@STDERR@", file.path(settings$host$outdir, format(firstrun,scientific=FALSE), "launcher.err.log"), qsub)
-      qsub <- strsplit(paste(qsub, settings$host$modellauncher$qsub.extra), " (?=([^\"']*\"[^\"']*\")*[^\"']*$)", perl=TRUE)
-
+      qsub <- gsub("@STDOUT@", file.path(settings$host$outdir, 
+                                         format(firstrun, scientific = FALSE), "launcher.out.log"), qsub)
+      qsub <- gsub("@STDERR@", file.path(settings$host$outdir,
+                                         format(firstrun, scientific = FALSE), "launcher.err.log"), qsub)
+      qsub <- strsplit(paste(qsub, settings$host$modellauncher$qsub.extra), 
+                       " (?=([^\"']*\"[^\"']*\")*[^\"']*$)", perl = TRUE)
+      
       # start the actual model run
       if (is.localhost(settings$host)) {
         cmd <- qsub[[1]]
         qsub <- qsub[-1]
-        out <- system2(cmd, c(qsub, file.path(settings$rundir, format(run,scientific=FALSE), "launcher.sh"), recursive=TRUE), stdout=TRUE)
+        out <- system2(cmd, c(qsub, file.path(settings$rundir,
+                                              format(run, scientific = FALSE), "launcher.sh"), recursive = TRUE), stdout = TRUE)
       } else {
-        out <- system2("ssh", c(settings$host$name, qsub, file.path(settings$host$rundir, format(firstrun,scientific=FALSE), "launcher.sh"), recursive=TRUE), stdout=TRUE)
+        out <- system2("ssh", c(settings$host$name, qsub,
+                                file.path(settings$host$rundir, format(firstrun, scientific = FALSE), "launcher.sh"), recursive = TRUE), 
+                       stdout = TRUE)
       }
-      #print(out) # <-- for debugging
-
+      # print(out) # <-- for debugging
+      
       # HACK: Code below gets 'run' from names(jobids) so need an entry for each run.
       # But when using modellauncher all runs have the same jobid
       for (run in readLines(con = file.path(settings$rundir, "runs.txt"))) {
@@ -163,100 +185,107 @@ start.model.runs <- function(settings, write = TRUE){
       }
     } else {
       if (is.localhost(settings$host)) {
-        out <- system2(file.path(settings$rundir, format(firstrun,scientific=FALSE), "launcher.sh"), stdout=TRUE)
+        out <- system2(file.path(settings$rundir, format(firstrun, scientific = FALSE), 
+                                 "launcher.sh"), stdout = TRUE)
       } else {
-        out <- system2("ssh", c(settings$host$name, file.path(settings$host$rundir, format(firstrun,scientific=FALSE), "launcher.sh")), stdout=TRUE)
+        out <- system2("ssh", c(settings$host$name, file.path(settings$host$rundir, 
+                                                              format(firstrun, scientific = FALSE), 
+                                                              "launcher.sh")), stdout = TRUE)
       }
-
+      
       # check output to see if an error occurred during the model run
       if ("ERROR IN MODEL RUN" %in% out) {
         logger.severe("Model run aborted, with error.\n", out)
       }
-
+      
       # write finished time to database
       if (!is.null(dbcon)) {
         for (run in readLines(con = file.path(settings$rundir, "runs.txt"))) {
-          db.query(paste("UPDATE runs SET finished_at =  NOW() WHERE id = ", format(run,scientific=FALSE)), con=dbcon)
+          db.query(paste("UPDATE runs SET finished_at =  NOW() WHERE id = ", 
+                         format(run, scientific = FALSE)), con = dbcon)
         }
       }
-
+      
       # update progress bar
       setTxtProgressBar(pb, pbi)
     }
   }
-
+  
   # wait for all qsub jobs to finish
   if (length(jobids) > 0) {
-    logger.debug("Waiting for the following jobs:", unlist(jobids, use.names=FALSE))
-    while(length(jobids) > 0) {
+    logger.debug("Waiting for the following jobs:", unlist(jobids, use.names = FALSE))
+    while (length(jobids) > 0) {
       Sys.sleep(10)
-      for(run in names(jobids)) {
+      for (run in names(jobids)) {
         # check to see if job is done
         check <- gsub("@JOBID@", jobids[run], settings$host$qstat)
-        args <- strsplit(check, " (?=([^\"']*\"[^\"']*\")*[^\"']*$)", perl=TRUE)
+        args <- strsplit(check, " (?=([^\"']*\"[^\"']*\")*[^\"']*$)", perl = TRUE)
         if (is.localhost(settings$host)) {
-          #cmd <- args[[1]]
-          #args <- args[-1]
-          #out <- system2(cmd, args, stdout=TRUE)
-          out <- system(check, intern=TRUE, ignore.stdout = FALSE, ignore.stderr = FALSE, wait=TRUE) 
+          # cmd <- args[[1]] args <- args[-1] out <- system2(cmd, args, stdout=TRUE)
+          out <- system(check, 
+                        intern = TRUE, 
+                        ignore.stdout = FALSE,
+                        ignore.stderr = FALSE, 
+                        wait = TRUE)
         } else {
-          out <- remote.execute.cmd(settings$host, check, stderr=TRUE)
+          out <- remote.execute.cmd(settings$host, check, stderr = TRUE)
         }
-
-        if ((length(out) > 0) && (substring(out, nchar(out)-3) == "DONE")) {
-          logger.debug("Job", jobids[run], "for run", format(run,scientific=FALSE), "finished")
+        
+        if ((length(out) > 0) && (substring(out, nchar(out) - 3) == "DONE")) 
+        {
+          logger.debug("Job", jobids[run], "for run", format(run, scientific = FALSE), 
+                       "finished")
           jobids[run] <- NULL
-
+          
           # copy data back to local
           if (!is.localhost(settings$host)) {
-            remote.copy.from(settings$host, file.path(settings$host$outdir, format(run,scientific=FALSE)), settings$modeloutdir)
+            remote.copy.from(settings$host, file.path(settings$host$outdir, 
+                                                      format(run, scientific = FALSE)), settings$modeloutdir)
           }
-
+          
           # TODO check output log
-
+          
           # write finish time to database
-          if (!is.null(dbcon)) {
+          if (!is.null(dbcon)) 
+          {
             if (!is.null(settings$host$modellauncher)) {
               for (run in readLines(con = file.path(settings$rundir, "runs.txt"))) {
-                db.query(paste("UPDATE runs SET finished_at =  NOW() WHERE id = ", format(run,scientific=FALSE)), con=dbcon)
+                db.query(paste("UPDATE runs SET finished_at =  NOW() WHERE id = ", 
+                               format(run, scientific = FALSE)), con = dbcon)
               }
             } else {
-              db.query(paste("UPDATE runs SET finished_at =  NOW() WHERE id = ", format(run,scientific=FALSE)), con=dbcon)
+              db.query(paste("UPDATE runs SET finished_at =  NOW() WHERE id = ", 
+                             format(run, scientific = FALSE)), con = dbcon)
             }
-          } # end writing to database
-
+          }  # end writing to database
+          
           # update progress bar
           if (is.null(settings$host$modellauncher)) {
             pbi <- pbi + 1
           }
           setTxtProgressBar(pb, pbi)
-        } # end job done if loop
-      } # end for loop
-    } # end while loop
+        }  # end job done if loop
+      }  # end for loop
+    }  # end while loop
   }
-
+  
   # copy all data back
   
   # close database connection
   if (!is.null(dbcon)) {
     db.close(dbcon)
   }
-} ### End of function
-##==================================================================================================#
+} # start.model.runs
 
 
 ##' @export
 runModule.start.model.runs <- function(settings) {
-  if(is.MultiSettings(settings)) {
+  if (is.MultiSettings(settings)) {
     return(papply(settings, runModule.start.model.runs))
-  } else if(is.Settings(settings)) {
+  } else if (is.Settings(settings)) {
     write <- settings$database$bety$write
     start.model.runs(settings, write)
   } else {
     stop("runModule.start.model.runs only works with Settings or MultiSettings")
   }
-}
-
-####################################################################################################
-### EOF.  End of R script file.              
-####################################################################################################
+} # runModule.start.model.runs

--- a/utils/R/status.R
+++ b/utils/R/status.R
@@ -8,9 +8,8 @@
 ##' @author Rob Kooper
 status.start <- function(name) {
   if (exists("settings")) {
-    cat(paste(name,
-              format(Sys.time(), "%F %T"), sep="\t"),
-        file=file.path(settings$outdir, "STATUS"), append=TRUE)
+    cat(paste(name, format(Sys.time(), "%F %T"), sep = "\t"), file = file.path(settings$outdir, 
+                                                                               "STATUS"), append = TRUE)
   }
 }
 
@@ -19,13 +18,10 @@ status.start <- function(name) {
 ##' @description PEcAn workflow status tracking: end module
 ##' @author Rob Kooper
 ##' @export
-status.end <- function(status="DONE") {
+status.end <- function(status = "DONE") {
   if (exists("settings")) {
-    cat(paste("",
-              format(Sys.time(), "%F %T"),
-              status,
-              "\n", sep="\t"),
-        file=file.path(settings$outdir, "STATUS"), append=TRUE)
+    cat(paste("", format(Sys.time(), "%F %T"), status, "\n", sep = "\t"), file = file.path(settings$outdir, 
+                                                                                           "STATUS"), append = TRUE)
   }
 }
 
@@ -36,15 +32,14 @@ status.end <- function(status="DONE") {
 ##' @export
 status.skip <- function(name) {
   if (exists("settings")) {
-    cat(paste(name,
-              format(Sys.time(), "%F %T"),
-              "",
-              format(Sys.time(), "%F %T"),
-              "SKIPPED",
-              "\n", sep="\t"),
-        file=file.path(settings$outdir, "STATUS"), append=TRUE)
+    cat(paste(name, 
+              format(Sys.time(), "%F %T"), "", 
+              format(Sys.time(), "%F %T"), 
+              "SKIPPED", "\n", sep = "\t"), 
+        file = file.path(settings$outdir, "STATUS"), 
+        append = TRUE)
   }
-}
+} # status.skip
 
 ##' @name status.check
 ##' @title status.check
@@ -52,25 +47,27 @@ status.skip <- function(name) {
 ##' @author Rob Kooper
 ##' @export
 status.check <- function(name) {
-  if (!exists("settings")) return (0)
-  status.file=file.path(settings$outdir, "STATUS")
-  if (!file.exists(status.file)){
-    return (0)
+  if (!exists("settings")) 
+    return(0)
+  status.file <- file.path(settings$outdir, "STATUS")
+  if (!file.exists(status.file)) {
+    return(0)
   }
-  status.data <- read.table(status.file, row.names=1, header=FALSE, sep="\t", quote="", fill=TRUE)
-  if (! name %in% row.names(status.data)) {
-    return (0)
+  status.data <- read.table(status.file, row.names = 1, header = FALSE, sep = "\t", 
+                            quote = "", fill = TRUE)
+  if (!name %in% row.names(status.data)) {
+    return(0)
   }
-  status.data[name,]
+  status.data[name, ]
   if (is.na(status.data[name, 3])) {
     logger.warn("UNKNOWN STATUS FOR", name)
-    return (0)
+    return(0)
   }
   if (status.data[name, 3] == "DONE") {
-    return (1)
+    return(1)
   }
   if (status.data[name, 3] == "ERROR") {
-    return (-1)
+    return(-1)
   }
-  return (0)
-}
+  return(0)
+} # status.check

--- a/utils/R/transformstats.R
+++ b/utils/R/transformstats.R
@@ -15,58 +15,54 @@
 ##'                                statname=c('SD', 'MSE', 'LSD', 'HSD', 'MSD'))
 ##' transformstats(statdf)
 transformstats <- function(data) {
-  if(!"SE" %in% levels(data$statname)){
+  if (!"SE" %in% levels(data$statname)) {
     data$statname <- factor(data$statname, levels = c(levels(data$statname), "SE"))
   }
-  ## Transformation of stats to SE
-  ## transform SD to SE
-  if (max(c("SD","sd") %in% data$statname)) {
-    sdi <- which(data$statname %in% c("SD","sd"))
-    data$stat[sdi] <- data$stat[sdi] / sqrt(data$n[sdi])
+  ## Transformation of stats to SE transform SD to SE
+  if (max(c("SD", "sd") %in% data$statname)) {
+    sdi <- which(data$statname %in% c("SD", "sd"))
+    data$stat[sdi] <- data$stat[sdi]/sqrt(data$n[sdi])
     data$statname[sdi] <- "SE"
   }
   ## transform MSE to SE
   if ("MSE" %in% data$statname) {
     msei <- which(data$statname == "MSE")
-    data$stat[msei] <- sqrt (data$stat[msei]/data$n[msei])
+    data$stat[msei] <- sqrt(data$stat[msei]/data$n[msei])
     data$statname[msei] <- "SE"
   }
-  ## 95%CI measured from mean to upper or lower CI
-  ## SE = CI/t
+  ## 95%CI measured from mean to upper or lower CI SE = CI/t
   if ("95%CI" %in% data$statname) {
-    cii <- which(data$statname == '95%CI')
-    data$stat[cii] <- data$stat[cii]/qt(0.975,data$n[cii])
+    cii <- which(data$statname == "95%CI")
+    data$stat[cii] <- data$stat[cii]/qt(0.975, data$n[cii])
     data$statname[cii] <- "SE"
   }
   ## Fisher's Least Significant Difference (LSD)
   ## conservatively assume no within block replication
   if ("LSD" %in% data$statname) {
     lsdi <- which(data$statname == "LSD")
-    data$stat[lsdi] <- data$stat[lsdi] / (qt(0.975,data$n[lsdi]) * sqrt( (2 * data$n[lsdi])))
+    data$stat[lsdi] <- data$stat[lsdi]/(qt(0.975, data$n[lsdi]) * sqrt((2 * data$n[lsdi])))
     data$statname[lsdi] <- "SE"
   }
   ## Tukey's Honestly Significant Difference (HSD),
   ## conservatively assuming 3 groups being tested so df =2
   if ("HSD" %in% data$statname) {
     hsdi <- which(data$statname == "HSD")
-    n = data$n[hsdi]
-    n[is.na(n)] = 2 ## minimum n that can be used if NA
-    data$stat[hsdi] <- data$stat[hsdi] / (qtukey(0.975, n, df = 2))
+    n <- data$n[hsdi]
+    n[is.na(n)] <- 2  ## minimum n that can be used if NA
+    data$stat[hsdi] <- data$stat[hsdi]/(qtukey(0.975, n, df = 2))
     data$statname[hsdi] <- "SE"
     data$n[hsdi] <- n
-  }              
+  }
   ## MSD Minimum Squared Difference
   ## MSD = t_{\alpha/2, 2n-2}*SD*sqrt(2/n)
   ## SE  = MSD*n/(t*sqrt(2))
   if ("MSD" %in% data$statname) {
     msdi <- which(data$statname == "MSD")
-    data$stat[msdi] <- data$stat[msdi] * data$n[msdi] / ( qt(0.975,2*data$n[msdi]-2)*sqrt(2))
+    data$stat[msdi] <- data$stat[msdi] * data$n[msdi] / (qt(0.975, 2 * data$n[msdi] - 2) * sqrt(2))
     data$statname[msdi] <- "SE"
   }
-  if (FALSE %in% c('SE','none') %in% data$statname) {
-    print(paste(trait, ': ERROR!!! data contains untransformed statistics'))
+  if (FALSE %in% c("SE", "none") %in% data$statname) {
+    print(paste(trait, ": ERROR!!! data contains untransformed statistics"))
   }
   return(data)
-}
-#==================================================================================================#
-
+} # transformstats

--- a/utils/R/utils.R
+++ b/utils/R/utils.R
@@ -6,6 +6,7 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
+
 #--------------------------------------------------------------------------------------------------#
 # Small, miscellaneous functions for use throughout PECAn
 #--------------------------------------------------------------------------------------------------#
@@ -25,36 +26,37 @@
 ##' @param nsoil nsoil if dimension requests it
 ##' @return ncvar based on MstMIP definition
 ##' @author Rob Kooper
-mstmipvar <- function(name, lat=NA, lon=NA, time=NA, nsoil=NA, silent=FALSE) {
-  data(mstmip_vars, package="PEcAn.utils")
-  var <- mstmip_vars[mstmip_vars$Variable.Name==name,]
+mstmipvar <- function(name, lat = NA, lon = NA, time = NA, nsoil = NA, silent = FALSE) {
+  data(mstmip_vars, package = "PEcAn.utils")
+  var <- mstmip_vars[mstmip_vars$Variable.Name == name, ]
   dims <- list()
-
+  
   if (nrow(var) == 0) {
-    data(mstmip_local, package="PEcAn.utils")
-    var <- mstmip_local[mstmip_local$Variable.Name==name,]
+    data(mstmip_local, package = "PEcAn.utils")
+    var <- mstmip_local[mstmip_local$Variable.Name == name, ]
     if (nrow(var) == 0) {
       if (!silent) {
         logger.info("Don't know about variable", name, " in mstmip_vars in PEcAn.utils")
       }
       if (is.na(time)) {
-        time <- ncdim_def(name="time", units="days since 1900-01-01 00:00:00", vals=1:365, calendar="standard", unlim=TRUE)
+        time <- ncdim_def(name = "time", units = "days since 1900-01-01 00:00:00", 
+                          vals = 1:365, calendar = "standard", unlim = TRUE)
       }
       return(ncvar_def(name, "", list(time), -999, name))
     }
   }
-
-  for(i in 1:4) {
-    vd <- var[[paste0('dim', i)]]
-    if (vd == 'lon' && !is.na(lon)) {
-      dims[[length(dims)+1]] <- lon
-    } else if (vd == 'lat' && !is.na(lat)) {
-      dims[[length(dims)+1]] <- lat
-    } else if (vd == 'time' && !is.na(time)) {
-      dims[[length(dims)+1]] <- time
-    } else if (vd == 'nsoil' && !is.na(nsoil)) {
-      dims[[length(dims)+1]] <- nsoil
-    } else if (vd == 'na') {
+  
+  for (i in 1:4) {
+    vd <- var[[paste0("dim", i)]]
+    if (vd == "lon" && !is.na(lon)) {
+      dims[[length(dims) + 1]] <- lon
+    } else if (vd == "lat" && !is.na(lat)) {
+      dims[[length(dims) + 1]] <- lat
+    } else if (vd == "time" && !is.na(time)) {
+      dims[[length(dims) + 1]] <- time
+    } else if (vd == "nsoil" && !is.na(nsoil)) {
+      dims[[length(dims) + 1]] <- nsoil
+    } else if (vd == "na") {
       # skip
     } else {
       if (!silent) {
@@ -63,11 +65,11 @@ mstmipvar <- function(name, lat=NA, lon=NA, time=NA, nsoil=NA, silent=FALSE) {
     }
   }
   ncvar <- ncvar_def(name, as.character(var$Units), dims, -999)
-  if (var$Long.name != 'na') {
+  if (var$Long.name != "na") {
     ncvar$longname <- as.character(var$Long.name)
   }
   return(ncvar)
-}
+} # mstimipvar
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -81,11 +83,11 @@ mstmipvar <- function(name, lat=NA, lon=NA, time=NA, nsoil=NA, silent=FALSE) {
 ##' @return num with zeros to the left
 ##' @export
 ##' @author Carl Davidson
-left.pad.zeros <- function(num, digits = 5){
-  format_string <- paste('%',sprintf('0%.0f.0f',digits),sep='')
+left.pad.zeros <- function(num, digits = 5) {
+  format_string <- paste0("%", sprintf("0%.0f.0f", digits))
   return(sprintf(format_string, num))
-}
-#==================================================================================================#
+} # left.pad.zeros
+
 
 ##' Truncates vector at 0
 ##' @name zero.truncate
@@ -95,11 +97,9 @@ left.pad.zeros <- function(num, digits = 5){
 ##' @export
 ##' @author <unknown>
 zero.truncate <- function(y) {
-  y[y<0 | 
-          is.na(y)] <- 0
+  y[y < 0 | is.na(y)] <- 0
   return(y)
-}
-#==================================================================================================#
+} # zero.truncate
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -116,11 +116,10 @@ zero.truncate <- function(y) {
 ##' @author David LeBauer
 ##' @author Shawn Serbin
 #--------------------------------------------------------------------------------------------------#
-rsync <- function(args, from, to, pattern='') {
+rsync <- function(args, from, to, pattern = "") {
   logger.warn("NEED TO USE TUNNEL")
-  system(paste0('rsync',' ', args,' ', from, pattern, ' ', to), intern=TRUE )
-}
-#==================================================================================================#
+  system(paste0("rsync", " ", args, " ", from, pattern, " ", to), intern = TRUE)
+} # rsync
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -132,16 +131,15 @@ rsync <- function(args, from, to, pattern='') {
 ##' @param args 
 ##' @export
 #--------------------------------------------------------------------------------------------------#
-ssh <- function(host, ..., args=''){
+ssh <- function(host, ..., args = "") {
   logger.warn("NEED TO USE TUNNEL")
-  if(host == 'localhost'){
-    command <- paste(..., args, sep='')
+  if (host == "localhost") {
+    command <- paste(..., args, sep = "")
   } else {
-    command <- paste('ssh -T ', host, ' "', ..., '" ', args, sep='')
+    command <- paste("ssh -T ", host, " \"", ..., "\" ", args, sep = "")
   }
   system(command)
-}
-#==================================================================================================#
+} # ssh
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -152,8 +150,7 @@ ssh <- function(host, ..., args=''){
 ##' @param x vector
 ##' @return comma delimited string
 ##' @export
-vecpaste <- function(x) paste(paste("'", x, "'", sep=''), collapse=',')
-#==================================================================================================#
+vecpaste <- function(x) paste(paste0("'", x, "'"), collapse = ",")
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -161,7 +158,7 @@ vecpaste <- function(x) paste(paste("'", x, "'", sep=''), collapse=',')
 ##'
 ##' Provides a consistent method of naming runs; for use in model input files and indices
 ##' @title Get Run ID
-##' @param run.type character, can be any character; currently "SA" is used for sensitivity analysis, "ENS" for ensemble run.
+##' @param run.type character, can be any character; currently 'SA' is used for sensitivity analysis, 'ENS' for ensemble run.
 ##' @param index unique index for different runs, e.g. integer counting members of an 
 ##' ensemble or a quantile used to which a trait has been perturbed for sensitivity analysis   
 ##' @param trait name of trait being sampled (for sensitivity analysis)
@@ -169,20 +166,21 @@ vecpaste <- function(x) paste(paste("'", x, "'", sep=''), collapse=',')
 ##' @return id representing a model run
 ##' @export
 ##' @examples
-##' get.run.id("ENS", left.pad.zeros(1, 5))
-##' get.run.id("SA", round(qnorm(-3),3), trait = "Vcmax")
+##' get.run.id('ENS', left.pad.zeros(1, 5))
+##' get.run.id('SA', round(qnorm(-3),3), trait = 'Vcmax')
 ##' @author Carl Davidson, David LeBauer
 #--------------------------------------------------------------------------------------------------#
-get.run.id <- function(run.type, index, trait = NULL, pft.name = NULL){
+get.run.id <- function(run.type, index, trait = NULL, pft.name = NULL) {
   result <- paste(c(run.type, pft.name, trait, index), collapse = "-")
   return(result)
-}
-#==================================================================================================#
+} # get.run.id
+
 
 ##' @export
-listToXml <- function (x, ...) {
+listToXml <- function(x, ...) {
   UseMethod("listToXml")
-}
+} # listToXml
+
 
 #--------------------------------------------------------------------------------------------------#
 ##' Convert List to XML
@@ -196,9 +194,9 @@ listToXml <- function (x, ...) {
 ##' @author David LeBauer, Carl Davidson, Rob Kooper
 #--------------------------------------------------------------------------------------------------#
 listToXml.default <- function(item, tag) {
-
+  
   # just a textnode, or empty node with attributes
-  if(typeof(item) != 'list') {
+  if (typeof(item) != "list") {
     if (length(item) > 1) {
       xml <- xmlNode(tag)
       for (name in names(item)) {
@@ -209,31 +207,28 @@ listToXml.default <- function(item, tag) {
       return(xmlNode(tag, item))
     }
   }
-
+  
   # create the node
   if (identical(names(item), c("text", ".attrs"))) {
     # special case a node with text and attributes
-    xml <- xmlNode(tag, item[['text']])
+    xml <- xmlNode(tag, item[["text"]])
   } else {
     # node with child nodes
     xml <- xmlNode(tag)
-    for(i in 1:length(item)) {
+    for (i in seq_along(item)) {
       if (is.null(names(item)) || names(item)[i] != ".attrs") {
         xml <- append.xmlNode(xml, listToXml(item[[i]], names(item)[i]))
       }
-    }    
+    }
   }
   
   # add attributes to node
-  attrs <- item[['.attrs']]
+  attrs <- item[[".attrs"]]
   for (name in names(attrs)) {
     xmlAttrs(xml)[[name]] <- attrs[[name]]
   }
   return(xml)
-}
-#==================================================================================================#
-
-
+} # listToXml.default
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -247,15 +242,14 @@ listToXml.default <- function(item, tag) {
 ##' @return data frame with back-transformed log density estimate 
 ##' @author \href{http://stats.stackexchange.com/q/6588/2750}{Rob Hyndman}
 ##' @references M. P. Wand, J. S. Marron and D. Ruppert, 1991. Transformations in Density Estimation. Journal of the American Statistical Association. 86(414):343-353 \url{http://www.jstor.org/stable/2290569}
-zero.bounded.density <- function (x, bw = "SJ", n = 1001) {
-  y <- log(x)
-  g <- density(y, bw = bw, n = n)
+zero.bounded.density <- function(x, bw = "SJ", n = 1001) {
+  y     <- log(x)
+  g     <- density(y, bw = bw, n = n)
   xgrid <- exp(g$x)
-  g$y <- c(0, g$y/xgrid)
-  g$x <- c(0, xgrid)
+  g$y   <- c(0, g$y / xgrid)
+  g$x   <- c(0, xgrid)
   return(g)
-}
-#==================================================================================================#
+} # zero.bounded.density
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -267,17 +261,16 @@ zero.bounded.density <- function (x, bw = "SJ", n = 1001) {
 ##' @export
 ##' @author David LeBauer
 summarize.result <- function(result) {
-  ans1 <- ddply(result[result$n==1,],
-                .(citation_id, site_id, trt_id, control, greenhouse, date, time, cultivar_id, specie_id),
-                summarise,
-                n = length(n),
-                mean = mean(mean),
-                statname = ifelse(length(n)==1,'none','SE'),
-                stat = sd(mean)/sqrt(length(n)))
-  ans2 <- result[result$n!=1, colnames(ans1)]
+  ans1 <- ddply(result[result$n == 1, ], 
+                .(citation_id, site_id, trt_id, control, greenhouse, 
+                  date, time, cultivar_id, specie_id), 
+                summarise, n = length(n), 
+                mean = mean(mean), 
+                statname = ifelse(length(n) == 1, "none", "SE"), 
+                stat = sd(mean) / sqrt(length(n)))
+  ans2 <- result[result$n != 1, colnames(ans1)]
   return(rbind(ans1, ans2))
-}
-#==================================================================================================#
+} # summarize.result
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -288,19 +281,18 @@ summarize.result <- function(result) {
 ##' @param sample.size 
 ##' @return list with summary statistics for parameters in an MCMC chain
 ##' @author David LeBauer
-get.stats.mcmc <- function(mcmc.summary, sample.size){
+get.stats.mcmc <- function(mcmc.summary, sample.size) {
   a <- list(n = sample.size)
-  for (parm in c('beta.o','sd.y', 'sd.site','sd.trt','beta.ghs[2]')){
-    parm.name <- ifelse(parm == 'beta.ghs[2]', 'beta.ghs', parm)
-    if(parm %in% rownames(mcmc.summary$statistics)){
-      a[[parm.name]] <-  get.parameter.stat(mcmc.summary, parameter = parm)
+  for (parm in c("beta.o", "sd.y", "sd.site", "sd.trt", "beta.ghs[2]")) {
+    parm.name <- ifelse(parm == "beta.ghs[2]", "beta.ghs", parm)
+    if (parm %in% rownames(mcmc.summary$statistics)) {
+      a[[parm.name]] <- get.parameter.stat(mcmc.summary, parameter = parm)
     } else {
       a[[parm.name]] <- NA
     }
   }
   return(unlist(a))
-}
-#==================================================================================================#
+} # get.stats.mcmc
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -316,10 +308,11 @@ get.stats.mcmc <- function(mcmc.summary, sample.size){
 ##' @param n
 ##' @export
 ##' @author David LeBauer
-paste.stats <- function(mcmc.summary, median, lcl, ucl, n = 2) {  
-  paste("$", tabnum(median, n),  "(", tabnum(lcl, n), ",", tabnum(ucl,n), ")", "$", sep = '')
-}
-#==================================================================================================#
+paste.stats <- function(mcmc.summary, median, lcl, ucl, n = 2) {
+  paste0("$", tabnum(median, n), 
+         "(", tabnum(lcl, n), ",", tabnum(ucl, n), ")", 
+         "$")
+} # paste.stats
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -333,13 +326,12 @@ paste.stats <- function(mcmc.summary, median, lcl, ucl, n = 2) {
 ##' @export
 ##' @examples
 ##' \dontrun{get.parameter.stat(mcmc.summaries[[1]], 'beta.o')}
-get.parameter.stat <- function(mcmc.summary, parameter){
+get.parameter.stat <- function(mcmc.summary, parameter) {
   paste.stats(median = mcmc.summary$quantiles[parameter, "50%"],
-              lcl   = mcmc.summary$quantiles[parameter, c("2.5%")],
-              ucl   = mcmc.summary$quantiles[parameter, c("97.5%")],
-              n     = 2)
-}
-#==================================================================================================#
+              lcl = mcmc.summary$quantiles[parameter, c("2.5%")], 
+              ucl = mcmc.summary$quantiles[parameter, c("97.5%")], 
+              n = 2)
+} # get.parameter.stat
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -351,35 +343,27 @@ get.parameter.stat <- function(mcmc.summary, parameter){
 ##' @param B second parameter
 ##' @return list with mean, variance, and 95 CI
 ##' @author David LeBauer
-## in future, perhaps create S3 functions:
-## get.stats.pdf <- pdf.stats
-#--------------------------------------------------------------------------------------------------#
+## in future, perhaps create S3 functions: get.stats.pdf <- pdf.stats
 pdf.stats <- function(distn, A, B) {
   distn <- as.character(distn)
-  mean <- switch(distn,
-                 gamma   = A/B,
-                 lnorm   = exp(A + 1/2 * B^2),
-                 beta    = A/(A+B),
-                 weibull = B * gamma(1 + 1/A),
-                 norm    = A,
-                 f       = ifelse(B>2, B/(B - 2), mean(rf(10000, A, B)))
-                 )
-  var <- switch(distn,
-                gamma   = A/B^2,
-                lnorm   = exp(2*A + B^2) * (exp(B^2) - 1),
-                beta    =  A*B/((A+B)^2 * (A + B + 1)),
-                weibull = B^2 * (gamma(1 + 2 / A) - gamma(1 + 1/A)^2),
-                norm    = B^2,
-                f       = ifelse(B>4, 2*B^2*(A+B-2) / (A*(B-2)^2*(B-4)), var(rf(100000, A, B)))
-                )
-  qci  <- get(paste("q", distn, sep = ""))
+  mean <- switch(distn, gamma = A/B, lnorm = exp(A + 1/2 * B^2), beta = A/(A + 
+                                                                             B), weibull = B * gamma(1 + 1/A), norm = A, f = ifelse(B > 2, B/(B - 2), 
+                                                                                                                                    mean(rf(10000, A, B))))
+  var <- switch(distn, gamma = A/B^2, 
+                lnorm = exp(2 * A + B ^ 2) * (exp(B ^ 2) - 1), 
+                beta = A * B/((A + B) ^ 2 * (A + B + 1)), 
+                weibull = B ^ 2 * (gamma(1 + 2 / A) - 
+                                     gamma(1 + 1 / A) ^ 2), 
+                norm = B ^ 2, f = ifelse(B > 4, 
+                                         2 * B^2 * (A + B - 2) / (A * (B - 2) ^ 2 * (B - 4)), 
+                                         var(rf(1e+05, A, B))))
+  qci <- get(paste0("q", distn))
   ci <- qci(c(0.025, 0.975), A, B)
   lcl <- ci[1]
   ucl <- ci[2]
-  out  <- unlist(list(mean = mean, var = var, lcl = lcl, ucl = ucl)) 
+  out <- unlist(list(mean = mean, var = var, lcl = lcl, ucl = ucl))
   return(out)
-}
-#==================================================================================================#
+} # pdf.stats
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -401,20 +385,18 @@ pdf.stats <- function(distn, A, B) {
 ##' trait.lookup()[,c('figid', 'units')]
 ##' }
 trait.lookup <- function(traits = NULL) {
-  #HACK: shameless hack
-  #Ultimately we'll want this to be read once at the start of run time
-  #This could also be represented in the database, 
-  #but because it is used to determine which parameters to feed to the model,
-  #it could be argued that it's conceptually model specific
+  # HACK: shameless hack Ultimately we'll want this to be read once at the start of
+  # run time This could also be represented in the database, but because it is used
+  # to determine which parameters to feed to the model, it could be argued that
+  # it's conceptually model specific
   data(trait.dictionary)
-  if(is.null(traits)) {
+  if (is.null(traits)) {
     trait.defs <- trait.dictionary
   } else {
-    trait.defs <- trait.dictionary[match(traits, trait.dictionary$id),]
+    trait.defs <- trait.dictionary[match(traits, trait.dictionary$id), ]
   }
   return(trait.defs)
-}
-#==================================================================================================#
+} # trait.lookup
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -429,12 +411,11 @@ trait.lookup <- function(traits = NULL) {
 ##' @examples
 ##' tabnum(1.2345)
 ##' tabnum(1.2345, n = 4)
-tabnum <- function(x, n=3) {
-  ans <- as.numeric(signif(x,n))
+tabnum <- function(x, n = 3) {
+  ans <- as.numeric(signif(x, n))
   names(ans) <- names(x)
   return(ans)
-}
-#==================================================================================================#
+} # tabnum
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -447,11 +428,9 @@ tabnum <- function(x, n=3) {
 ##' @return numeric value at reference temperature
 ##' @export
 ##' @author unknown
-#--------------------------------------------------------------------------------------------------#
-arrhenius.scaling <- function(observed.value, old.temp, new.temp = 25){
-  return(observed.value / exp (3000 * ( 1 / (273.15 + new.temp) - 1 / (273.15 + old.temp))))
-}
-#==================================================================================================#
+arrhenius.scaling <- function(observed.value, old.temp, new.temp = 25) {
+  return(observed.value / exp(3000 * (1 / (273.15 + new.temp) - 1 / (273.15 + old.temp))))
+} # arrhenius.scaling
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -465,23 +444,16 @@ arrhenius.scaling <- function(observed.value, old.temp, new.temp = 25){
 capitalize <- function(x) {
   x <- as.character(x)
   s <- strsplit(x, " ")[[1]]
-  paste(toupper(substring(s, 1,1)), substring(s, 2),
-        sep="", collapse=" ")
-}
-#==================================================================================================#
-
-#--------------------------------------------------------------------------------------------------#
+  return(paste(toupper(substring(s, 1, 1)), substring(s, 2), sep = "", collapse = " "))
+} # capitalize
 
 isFALSE <- function(x) !isTRUE(x)
-#==================================================================================================#
-
-
 
 
 #--------------------------------------------------------------------------------------------------#
 ##' New xtable
 ##'
-##' utility to properly escape the "%" sign for latex
+##' utility to properly escape the '%' sign for latex
 ##' @title newxtable
 ##' @param x data.frame to be converted to latex table
 ##' @param environment can be 'table'; 'sidewaystable' if using latex rotating package
@@ -492,16 +464,15 @@ isFALSE <- function(x) !isTRUE(x)
 ##' @param align 
 ##' @return Latex version of table, with percentages properly formatted 
 ##' @author David LeBauer
-newxtable <- function(x, environment = 'table', table.placement = 'ht',
-                      label = NULL, caption = NULL, caption.placement = NULL, align = NULL) {
+newxtable <- function(x, environment = "table", table.placement = "ht", label = NULL, 
+                      caption = NULL, caption.placement = NULL, align = NULL) {
   print(xtable(x, label = label, caption = caption, align = align),
         floating.environment = environment,
         table.placement = table.placement,
         caption.placement = caption.placement,
-#        sanitize.text.function = function(x) gsub("%", "\\\\%", x),
+        #        sanitize.text.function = function(x) gsub("%", "\\\\%", x),
         sanitize.rownames.function = function(x) paste(''))
-}
-#==================================================================================================#
+} # newxtable
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -514,11 +485,10 @@ newxtable <- function(x, environment = 'table', table.placement = 'ht',
 ##' @param title manuscript title
 ##' @return bibtex citation
 #--------------------------------------------------------------------------------------------------#
-bibtexify <- function (author, year, title) {
-  acronym <- abbreviate(title, minlength = 3, strict=TRUE)
-  paste(author, year, acronym, sep='')
-}
-#==================================================================================================#
+bibtexify <- function(author, year, title) {
+  acronym <- abbreviate(title, minlength = 3, strict = TRUE)
+  return(paste0(author, year, acronym))
+} # bibtexify
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -532,16 +502,17 @@ bibtexify <- function (author, year, title) {
 ##' @return sequence from 1:length(unique(x))
 ##' @export
 ##' @author David LeBauer
-as.sequence <- function(x, na.rm = TRUE){
+as.sequence <- function(x, na.rm = TRUE) {
   x2 <- as.integer(factor(x, unique(x)))
-  if(all(is.na(x2))){
+  if (all(is.na(x2))) {
     x2 <- rep(1, length(x2))
   }
-  if(na.rm == TRUE){
+  if (na.rm == TRUE) {
     x2[is.na(x2)] <- max(x2, na.rm = TRUE) + 1
   }
   return(x2)
-}
+} # as.sequence
+
 
 #--------------------------------------------------------------------------------------------------#
 ##' Test ssh access
@@ -552,9 +523,10 @@ as.sequence <- function(x, na.rm = TRUE){
 ##' @param host 
 ##' @return logical - TRUE if remote connection is available 
 ##' @author Rob Kooper
-test.remote <- function(host){
+test.remote <- function(host) {
   return(try(remote.execute.cmd(host, "/bin/true")) == 0)
-}
+} # test.remote
+
 
 ##' Create a temporary settings file
 ##'
@@ -566,13 +538,13 @@ test.remote <- function(host){
 ##' @return character vector written to and read from a temporary file
 ##' @export
 ##' @author David LeBauer
-temp.settings <- function(settings.txt){
+temp.settings <- function(settings.txt) {
   temp <- tempfile()
   on.exit(unlink(temp))
   writeLines(settings.txt, con = temp)
   settings <- readLines(temp)
   return(settings)
-}
+} # temp.settings
 
 
 ##' Test if function gives an error
@@ -585,14 +557,15 @@ temp.settings <- function(settings.txt){
 ##' @examples
 ##' tryl(1+1)
 ##' # TRUE
-##' tryl(sum("a"))
+##' tryl(sum('a'))
 ##' # FALSE
 ##' @author David LeBauer
-tryl <- function(FUN){
+tryl <- function(FUN) {
   out <- tryCatch(FUN, error = function(e) e)
   ans <- !any(class(out) == "error")
   return(ans)
-}
+} # tryl
+
 
 ##' load model package
 ##' @title Load model package
@@ -602,16 +575,17 @@ tryl <- function(FUN){
 ##' @examples
 ##' \dontrun{require.modelpkg(BioCro)}
 ##' @author David LeBauer
-load.modelpkg <- function(model){
+load.modelpkg <- function(model) {
   pecan.modelpkg <- paste0("PEcAn.", model)
-  if(!pecan.modelpkg  %in% names(sessionInfo()$otherPkgs)){
-    if(pecan.modelpkg  %in% rownames(installed.packages())) {
+  if (!pecan.modelpkg %in% names(sessionInfo()$otherPkgs)) {
+    if (pecan.modelpkg %in% rownames(installed.packages())) {
       do.call(require, args = list(pecan.modelpkg))
     } else {
-      logger.error("I can't find a package for the ", model, "model; I expect it to be named ", pecan.modelpkg)
+      logger.error("I can't find a package for the ", model,
+                   "model; I expect it to be named ", pecan.modelpkg)
     }
   }
-}
+} # load.modelpkg
 
 ##' conversion function for the unit conversions that udunits cannot handle but often needed in PEcAn calculations
 ##' @title misc.convert
@@ -621,14 +595,16 @@ load.modelpkg <- function(model){
 ##' @return val converted values
 ##' @export
 ##' @author Istem Fer
-misc.convert <- function(x, u1, u2){
-  if(u1 == "umol C m-2 s-1" & u2 == "kg C m-2 s-1"){
-    val <- ud.convert(x, "ug", "kg") * 12    # atomic mass of carbon
-  }else if(u1 == "kg C m-2 s-1" &  u2 == "umol C m-2 s-1"){
-    val <- ud.convert(x, "kg", "ug") / 12    # atomic mass of carbon
+misc.convert <- function(x, u1, u2) {
+  if (u1 == "umol C m-2 s-1" & u2 == "kg C m-2 s-1") {
+    val <- ud.convert(x, "ug", "kg") * 12  # atomic mass of carbon
+  } else if (u1 == "kg C m-2 s-1" & u2 == "umol C m-2 s-1") {
+    val <- ud.convert(x, "kg", "ug")/12  # atomic mass of carbon
+  } else {
+    logger.severe(paste("Unknown units", u1, u2))
   }
   return(val)
-}
+} # misc.convert
 
 
 ##' function to check whether units are convertible by misc.convert function
@@ -638,14 +614,11 @@ misc.convert <- function(x, u1, u2){
 ##' @return logical
 ##' @export
 ##' @author Istem Fer
-misc.are.convertible <- function(u1, u2){
-  if(match(u1, c("umol C m-2 s-1", "kg C m-2 s-1")) ==  match(u2, c("kg C m-2 s-1", "umol C m-2 s-1"))){
+misc.are.convertible <- function(u1, u2) {
+  if (match(u1, c("umol C m-2 s-1", "kg C m-2 s-1")) ==
+      match(u2, c("kg C m-2 s-1", "umol C m-2 s-1"))) {
     return(TRUE)
   } else {
     return(FALSE)
   }
-}
-
-####################################################################################################
-### EOF.  End of R script file.              
-####################################################################################################
+} # misc.are.convertible

--- a/utils/R/write.config.utils.R
+++ b/utils/R/write.config.utils.R
@@ -6,11 +6,10 @@
 # which accompanies this distribution, and is available at
 # http://opensource.ncsa.illinois.edu/license.html
 #-------------------------------------------------------------------------------
+
 #--------------------------------------------------------------------------------------------------#
 ### TODO: Generalize this code for all ecosystem models (e.g. ED2.2, SiPNET, etc).
-
 #--------------------------------------------------------------------------------------------------#
-
 
 #--------------------------------------------------------------------------------------------------#
 ##' Returns a vector of quantiles specified by a given <quantiles> xml tag
@@ -21,23 +20,23 @@
 ##' @export
 ##' @author David LeBauer
 get.quantiles <- function(quantiles.tag) {
-  quantiles<-vector()
+  quantiles <- vector()
   if (!is.null(quantiles.tag$quantile)) {
-    quantiles <- as.numeric(quantiles.tag[names(quantiles.tag)=='quantile'])
+    quantiles <- as.numeric(quantiles.tag[names(quantiles.tag) == "quantile"])
   }
-  if (!is.null(quantiles.tag$sigma)){
-    sigmas <- as.numeric(quantiles.tag[names(quantiles.tag)=='sigma'])
+  if (!is.null(quantiles.tag$sigma)) {
+    sigmas <- as.numeric(quantiles.tag[names(quantiles.tag) == "sigma"])
     quantiles <- append(quantiles, 1 - pnorm(sigmas))
   }
   if (length(quantiles) == 0) {
-    quantiles <- 1-pnorm(-3:3) #default
+    quantiles <- 1 - pnorm(-3:3)  #default
   }
   if (!0.5 %in% quantiles) {
     quantiles <- append(quantiles, 0.5)
   }
   return(sort(quantiles))
-}
-##==================================================================================================#
+} # get.quantiles
+
 
 ##' get sensitivity samples as a list
 ##'
@@ -48,16 +47,15 @@ get.quantiles <- function(quantiles.tag) {
 ##' sensitivity analysis
 ##' @export
 ##' @return sa.sample.list
-get.sa.sample.list <- function(pft, env, quantiles){
+get.sa.sample.list <- function(pft, env, quantiles) {
   sa.sample.list <- list()
-  for(i in 1:length(pft)){
-    sa.sample.list[[i]] = get.sa.samples(pft[[i]], quantiles)
+  for (i in seq_along(pft)) {
+    sa.sample.list[[i]] <- get.sa.samples(pft[[i]], quantiles)
   }
-  sa.sample.list[[length(pft)+1]] <- get.sa.samples(env, quantiles)
+  sa.sample.list[[length(pft) + 1]] <- get.sa.samples(env, quantiles)
   names(sa.sample.list) <- c(names(pft), "env")
   return(sa.sample.list)
-}
-#==================================================================================================#
+} # get.sa.sample.list
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -73,19 +71,16 @@ get.sa.sample.list <- function(pft, env, quantiles){
 ##' @return a list of lists representing quantile values of trait distributions
 ##' @export
 ##' @author David LeBauer
-get.sa.samples <- function(samples, quantiles){
+get.sa.samples <- function(samples, quantiles) {
   sa.samples <- data.frame()
-  for(trait in names(samples)){
-    for(quantile in quantiles){
-      sa.samples[as.character(round(quantile*100,3)), trait] <- quantile(samples[[trait]], quantile)
+  for (trait in names(samples)) {
+    for (quantile in quantiles) {
+      sa.samples[as.character(round(quantile * 100, 3)), trait] <- 
+        quantile(samples[[trait]], quantile)
     }
   }
   return(sa.samples)
-}
-#==================================================================================================#
-
-
-#--------------------------------------------------------------------------------------------------#
+} # get.sa.samples
 
 
 #--------------------------------------------------------------------------------------------------#
@@ -95,12 +90,12 @@ get.sa.samples <- function(samples, quantiles){
 ##' @param cnt 
 ##' @return updated value of cnt to global environment
 ##' @export
-counter <- function(cnt){
-  cnt = cnt + 1
-  #return(cnt)
-  assign("cnt",cnt,.GlobalEnv) # Assign count to the environment
-}
-#==================================================================================================#
+counter <- function(cnt) {
+  cnt <- cnt + 1
+  # return(cnt)
+  assign("cnt", cnt, .GlobalEnv)  # Assign count to the environment
+} # counter
+
 
 ##' checks that met2model function exists
 ##'
@@ -109,11 +104,7 @@ counter <- function(cnt){
 ##' @title met2model.exists
 ##' @param model model package name
 ##' @return logical
-met2model.exists <- function(model){
+met2model.exists <- function(model) {
   load.modelpkg(model)
-  exists(paste0("met2model.",model))  
-}
-
-####################################################################################################
-### EOF.  End of R script file.          		
-####################################################################################################
+  exists(paste0("met2model.", model))
+} # met2model.exists


### PR DESCRIPTION
Ran through formatR::tidy_dir with arrow=TRUE and indent=2; made sure all if blocks have braces. Tried to make sure formatR didn’t make things too jaggy. Substituted `seq_len`, `seq_along`, and `paste0`, and `file.path` as necessary. Made sure all functions end with an explicit `return`.

**Non-style notes:**
* `convert.input`: changed GMT to UTC; added if-block failure case
* `sendmail`: note new line 32 (`sendmail <- Sys.which("sendmail")`) -
OK?
* `bugs.rdist`: added if-block failure
* added if-block failure to `misc.convert`