### PR TITLE
Move responsibility for handling `car` dependency 

### DIFF
--- a/scripts/install.dependencies.R
+++ b/scripts/install.dependencies.R
@@ -21,7 +21,7 @@ if (!("Rgraphviz" %in% installed.packages()[, "Package"])) {
 }
 
 # install packages needed from CRAN
-list.of.packages <- c("car", "chron", "coda", "data.table", "doSNOW", "dplR", "earth", 
+list.of.packages <- c("chron", "coda", "data.table", "doSNOW", "dplR", "earth", 
                       "emulator", "ggmap", "ggplot2", "gridExtra", "Hmisc", "httr", "kernlab", 
                       "GPfit", "knitr", "lubridate", "Maeswrap", "MASS", "MCMCpack", "mvtnorm", "ncdf4", 
                       "plotrix", "plyr", "raster", "randtoolbox", "rjags", "rgdal", "tgp", "DBI", 


### PR DESCRIPTION
Removed responsibility for handling `car` dependency  from `install.dependencies`.

## Description
Removed car from package list in scripts/install.dependencies; made
sure it was listed in package DESCRIPTION files; removed `library`
calls; added `car::` namespace to function calls. See #1088.

[In this case, `car` is only used by `modules/data.remote/inst/`
scripts, so didn't need to do anything.]
## Motivation and Context
There shouldn't be any need for install.dependencies to do most of what it does.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number --> #1088 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 