### PR TITLE
Make sure functions end with explicit `return()`s

### DIFF
--- a/models/dalec/R/met2model.DALEC.R
+++ b/models/dalec/R/met2model.DALEC.R
@@ -169,6 +169,6 @@ met2model.DALEC <- function(in.path, in.prefix, outfolder, start_date, end_date,
   ## write output
   write.table(out, out.file.full, quote = FALSE, sep = " ", row.names = FALSE, col.names = FALSE)
   
-  invisible(results)
+  return(invisible(results))
   
 } # met2model.DALEC

--- a/models/ed/R/met2model.ED2.R
+++ b/models/ed/R/met2model.ED2.R
@@ -329,5 +329,5 @@ met2model.ED2 <- function(in.path, in.prefix, outfolder, start_date, end_date, l
   }  ### end loop over met files
   
   print("Done with met2model.ED2")
-  invisible(results)
+  return(invisible(results))
 } # met2model.ED2

--- a/models/fates/R/met2model.FATES.R
+++ b/models/fates/R/met2model.FATES.R
@@ -31,7 +31,7 @@ met2model.FATES <- function(in.path, in.prefix, outfolder, start_date, end_date,
   # defining temporal dimension needs to be figured out. If we configure FATES to use same tstep then we may not need to change dimensions  
   
   library(PEcAn.utils)
-
+  
   ncvar_get <- ncdf4::ncvar_get
   ncdim_def <- ncdf4::ncdim_def
   ncatt_get <- ncdf4::ncatt_get
@@ -41,7 +41,7 @@ met2model.FATES <- function(in.path, in.prefix, outfolder, start_date, end_date,
     var   <- ncdf4::ncvar_def(name = name, units = unit, dim = dim, missval = -6999, verbose = verbose)
     ncout <- ncdf4::ncvar_add(nc = ncout, v = var, verbose = verbose)
     ncvar_put(nc = ncout, varid = name, vals = data)
-    invisible(ncout)
+    return(invisible(ncout))
   }
   sm <- c(0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365) * 86400  ## day of year thresholds
   
@@ -157,12 +157,12 @@ met2model.FATES <- function(in.path, in.prefix, outfolder, start_date, end_date,
   
   logger.info("Done with met2model.FATES")
   
-  data.frame(file = paste0(outfolder, "/"), 
-             host = c(fqdn()), 
-             mimetype = c("application/x-netcdf"), 
-             formatname = c("CLM met"), 
-             startdate = c(start_date), 
-             enddate = c(end_date), 
-             dbfile.name = "", 
-             stringsAsFactors = FALSE)
+  return(data.frame(file = paste0(outfolder, "/"), 
+                    host = c(fqdn()), 
+                    mimetype = c("application/x-netcdf"), 
+                    formatname = c("CLM met"), 
+                    startdate = c(start_date), 
+                    enddate = c(end_date), 
+                    dbfile.name = "", 
+                    stringsAsFactors = FALSE))
 } # met2model.FATES

--- a/models/gday/R/met2model.GDAY.R
+++ b/models/gday/R/met2model.GDAY.R
@@ -269,5 +269,5 @@ met2model.GDAY <- function(in.path, in.prefix, outfolder, start_date, end_date,
   ## write output
   write.table(out, out.file.full, quote = FALSE, sep = ",", row.names = FALSE, col.names = FALSE)
   
-  invisible(results)
+  return(invisible(results))
 } # met2model.GDAY

--- a/models/linkages/R/met2model.LINKAGES.R
+++ b/models/linkages/R/met2model.LINKAGES.R
@@ -106,5 +106,5 @@ met2model.LINKAGES <- function(in.path, in.prefix, outfolder, start_date, end_da
   precip.mat <- month_matrix_precip
   temp.mat <- month_matrix_temp_mean
   save(precip.mat, temp.mat, file = out.file)
-  invisible(results)
+  return(invisible(results))
 } # met2model.LINKAGES

--- a/models/linkages/R/read.restart.LINKAGES.R
+++ b/models/linkages/R/read.restart.LINKAGES.R
@@ -42,5 +42,5 @@ read.restart.LINKAGES <- function(outdir, runid, stop.time, settings, var.names 
   print(runid)
   
   # Put forecast into vector
-  t(unlist(ens))
+  return(t(unlist(ens)))
 } # read.restart.LINKAGES

--- a/models/linkages/R/sample.IC.LINKAGES.R
+++ b/models/linkages/R/sample.IC.LINKAGES.R
@@ -21,5 +21,5 @@ sample.IC.LINKAGES <- function(ne, state) {
   biomass_thoc2 = ifelse(rep("biomass_thoc2" %in% names(state),ne),
                          state$biomass_thoc2[1, sample.int(ncol(state$biomass_thoc2), ne), 1] * 0.1, ## unit Mg/ha ->kg/m2
                          runif(ne, 0, 14000)) ## prior  
-  data.frame(biomass_tsca, biomass_acsa3, biomass_beal2, biomass_thoc2)
+  return(data.frame(biomass_tsca, biomass_acsa3, biomass_beal2, biomass_thoc2))
 } # sample.IC.LINKAGES

--- a/models/linkages/R/spinup.LINKAGES.R
+++ b/models/linkages/R/spinup.LINKAGES.R
@@ -31,8 +31,8 @@ spinup.LINKAGES <- function(start.year, end.year, temp.mat, precip.mat, paleon =
   
   ### Add some sort of test for steady state or not
   
-  list(start.year = start.year, 
-       nyear = nyear,
-       temp.mat = temp.mat, 
-       precip.mat = precip.mat)
+  return(list(start.year = start.year, 
+              nyear = nyear,
+              temp.mat = temp.mat, 
+              precip.mat = precip.mat))
 } # spinup.LINKAGES

--- a/models/linkages/R/split.inputs.LINKAGES.R
+++ b/models/linkages/R/split.inputs.LINKAGES.R
@@ -22,5 +22,5 @@ split.inputs.LINKAGES <- function(settings, start.time, stop.time) {
   new.met <- paste0(settings$rundir, "/climate.Rdata")  # doesn't do anything but write stuff to README
   settings$run$inputs$met$path <- new.met  #HACK
   
-  settings$run$inputs
+  return(settings$run$inputs)
 } # split.inputs.LINKAGES

--- a/models/lpjguess/R/met2model.LPJGUESS.R
+++ b/models/lpjguess/R/met2model.LPJGUESS.R
@@ -153,5 +153,5 @@ met2model.LPJGUESS <- function(in.path, in.prefix, outfolder, start_date, end_da
   ## close netcdf files
   sapply(ncin, nc_close)
   
-  invisible(results)
+  return(invisible(results))
 } # met2model.LPJGUESS

--- a/models/maat/R/met2model.MAAT.R
+++ b/models/maat/R/met2model.MAAT.R
@@ -227,10 +227,10 @@ met2model.MAAT <- function(in.path, in.prefix, outfolder, start_date, end_date,
             indent = TRUE, 
             prefix = PREFIX_XML)
     
-    invisible(results)
+    return(invisible(results))
     
   } else {
     print("NO MET TO OUTPUT")
-    invisible(NULL)
+    return(invisible(NULL))
   }
 } # met2model.MAAT

--- a/models/maespa/R/met2model.MAESPA.R
+++ b/models/maespa/R/met2model.MAESPA.R
@@ -198,5 +198,5 @@ met2model.MAESPA <- function(in.path, in.prefix, outfolder, start_date, end_date
   replacePAR(out.file.full, "enddate", "metformat", newval = enddate, noquotes = TRUE)
   replacePAR(out.file.full, "columns", "metformat", newval = columnnames, noquotes = TRUE)
   
-  invisible(results)
+  return(invisible(results))
 } # met2model.MAESPA

--- a/models/sipnet/R/met2model.SIPNET.R
+++ b/models/sipnet/R/met2model.SIPNET.R
@@ -219,9 +219,9 @@ met2model.SIPNET <- function(in.path, in.prefix, outfolder, start_date, end_date
     
     ## write output
     write.table(out, out.file.full, quote = FALSE, sep = "\t", row.names = FALSE, col.names = FALSE)
-    invisible(results)
+    return(invisible(results))
   } else {
     print("NO MET TO OUTPUT")
-    invisible(NULL)
+    return(invisible(NULL))
   }
 } # met2model.SIPNET

--- a/models/sipnet/R/read.restart.SIPNET.R
+++ b/models/sipnet/R/read.restart.SIPNET.R
@@ -77,5 +77,5 @@ read.restart.SIPNET <- function(outdir, runid, stop.time, settings, var.names, p
   }
   
   print(runid)
-  unlist(forecast)
+  return(unlist(forecast))
 } # read.restart.SIPNET

--- a/models/sipnet/R/sample.IC.SIPNET.R
+++ b/models/sipnet/R/sample.IC.SIPNET.R
@@ -66,5 +66,6 @@ sample.IC.SIPNET <- function(ne, state, year = 1) {
                     state$microbe[1, sample.int(ncol(state$microbe), ne), year], 
                     runif(ne, 0, 1))  ## prior 
   
-  data.frame(NPP, plantWood, lai, litter, soil, litterWFrac, soilWFrac, snow, microbe)
+  return(data.frame(NPP, plantWood, lai, litter,
+                    soil, litterWFrac, soilWFrac, snow, microbe))
 } # sample.IC.SIPNET

--- a/models/sipnet/R/split.inputs.SIPNET.R
+++ b/models/sipnet/R/split.inputs.SIPNET.R
@@ -45,5 +45,5 @@ split.inputs.SIPNET <- function(settings, start.time, stop.time) {
   write.table(dat[sel1:sel2, ], file, row.names = FALSE, col.names = FALSE)
   
   settings$run$inputs$met$path <- file
-  settings$run$inputs
+  return(settings$run$inputs)
 } # split.inputs.SIPNET

--- a/modules/DART/R/date2month.R
+++ b/modules/DART/R/date2month.R
@@ -10,5 +10,5 @@ days2month <- function(days) {
   }
   
   day <- days - ec[month]
-  c(day, month)
+  return(c(day, month))
 } # days2month

--- a/modules/allometry/R/read.allom.data.R
+++ b/modules/allometry/R/read.allom.data.R
@@ -249,5 +249,5 @@ read.allom.data <- function(pft.data, component, field, parm, nsim = 10000) {
     
   }  ## end HAVE ALLOM TALLY DATA
   
-  list(parm = allomParms, field = allom$field)
+  return(list(parm = allomParms, field = allom$field))
 } # read.allom.data

--- a/modules/assim.batch/R/load.L2Ameriflux.cf.R
+++ b/modules/assim.batch/R/load.L2Ameriflux.cf.R
@@ -18,5 +18,5 @@ load.L2Ameriflux.cf <- function(file.in) {
   }
   ncdf4::nc_close(nc)
   
-  as.data.frame(do.call(cbind, vars))
+  return(as.data.frame(do.call(cbind, vars)))
 } # load.L2Ameriflux.cf

--- a/modules/assim.batch/R/pda.get.model.output.R
+++ b/modules/assim.batch/R/pda.get.model.output.R
@@ -119,5 +119,3 @@ pda.get.model.output <- function(settings, run.id, con, inputs) {
   
   return(model.out)
 }
-
-

--- a/modules/assim.batch/R/pda.utils.R
+++ b/modules/assim.batch/R/pda.utils.R
@@ -372,8 +372,8 @@ pda.define.prior.fn <- function(prior) {
     p
   }
   
-  return(list(dprior = dprior, rprior = rprior, qprior = qprior, pprior = pprior, dmvprior = dmvprior, 
-              rmvprior = rmvprior))
+  return(list(dprior = dprior, rprior = rprior, qprior = qprior,
+              pprior = pprior, dmvprior = dmvprior, rmvprior = rmvprior))
 } # pda.define.prior.fn
 
 
@@ -698,7 +698,7 @@ pda.plot.params <- function(settings, mcmc.param.list, prior.ind) {
     params.subset.list[[i]] <- do.call("rbind", params.subset[[i]])
   } 
   # reformat each sublist such that params have their own list and return
-  lapply(1:length(params.subset.list), function(x) as.list(data.frame(params.subset.list[[x]])))
+  return(lapply(1:length(params.subset.list), function(x) as.list(data.frame(params.subset.list[[x]]))))
   
 } # pda.plot.params
 

--- a/modules/assim.sequential/R/sda.enkf.R
+++ b/modules/assim.sequential/R/sda.enkf.R
@@ -819,4 +819,3 @@ sda.enkf <- function(settings, obs.mean, obs.cov, IC = NULL, Q = NULL) {
   dev.off()
   
 } # sda.enkf
-

--- a/modules/benchmark/R/load.data.R
+++ b/modules/benchmark/R/load.data.R
@@ -67,7 +67,6 @@ load.data <- function(data.path, format, start_year = NA, end_year = NA, site = 
      out$posix <- strptime(apply(y, 1, function(x) paste(x, collapse = " ")), format=paste(format$vars$storage_type[time.row], collapse = " "), tz = "UTC")
   }
 
-  
   return(out)
 } # load.data
 

--- a/modules/benchmark/R/match.timestep.R
+++ b/modules/benchmark/R/match.timestep.R
@@ -10,5 +10,5 @@ match.timestep <- function(date_coarse, date_fine, data_fine) {
   
   midpoints <- c(-Inf, head(date_fine, -1)) + c(0, diff(as.numeric(date_fine)) / 2)
   
-  data_fine[findInterval(date_coarse, midpoints)]
+  return(data_fine[findInterval(date_coarse, midpoints)])
 } # match.timestep

--- a/modules/benchmark/R/mean.over.larger.timestep.R
+++ b/modules/benchmark/R/mean.over.larger.timestep.R
@@ -7,5 +7,5 @@
 ##' 
 ##' @author Betsy Cowdery, Michael Dietze
 mean.over.larger.timestep <- function(date.coarse, date.fine, data.fine) {
-  tapply(X = data.fine, INDEX = findInterval(date.fine, date.coarse), FUN = mean)
+  return(tapply(X = data.fine, INDEX = findInterval(date.fine, date.coarse), FUN = mean))
 } # mean.over.larger.timestep

--- a/modules/benchmark/R/metric.AME.R
+++ b/modules/benchmark/R/metric.AME.R
@@ -6,5 +6,5 @@
 ##' @author Betsy Cowdery
 
 metric.AME <- function(dat, ...) {
-  max(abs(dat$model - dat$obvs))
+  return(max(abs(dat$model - dat$obvs)))
 } # metric.AME

--- a/modules/benchmark/R/metric.MAE.R
+++ b/modules/benchmark/R/metric.MAE.R
@@ -5,5 +5,5 @@
 ##' 
 ##' @author Betsy Cowdery
 metric.MAE <- function(dat, ...) {
-  mean(abs(dat$model - dat$obvs))
+  return(mean(abs(dat$model - dat$obvs)))
 } # metric.MAE

--- a/modules/benchmark/R/metric.MSE.R
+++ b/modules/benchmark/R/metric.MSE.R
@@ -5,5 +5,5 @@
 ##' 
 ##' @author Betsy Cowdery
 metric.MSE <- function(dat, ...) {
-  mean((dat$model - dat$obvs)^2)
+  return(mean((dat$model - dat$obvs) ^ 2))
 } # metric.MSE

--- a/modules/benchmark/R/metric.PPMC.R
+++ b/modules/benchmark/R/metric.PPMC.R
@@ -7,5 +7,5 @@
 metric.PPMC <- function(dat, ...) {
   numer <- sum((dat$obvs - mean(dat$obvs)) * (dat$model - mean(dat$model)))
   denom <- sqrt(sum((dat$obvs - mean(dat$obvs)) ^ 2)) * sqrt(sum((dat$model - mean(dat$model)) ^ 2))
-  numer / denom
+  return(numer / denom)
 } # metric.PPMC

--- a/modules/benchmark/R/metric.R2.R
+++ b/modules/benchmark/R/metric.R2.R
@@ -7,5 +7,5 @@
 metric.R2 <- function(dat, ...) {
   numer <- sum((dat$obvs - mean(dat$obvs)) * (dat$model - mean(dat$model)))
   denom <- sqrt(sum((dat$obvs - mean(dat$obvs)) ^ 2)) * sqrt(sum((dat$model - mean(dat$model)) ^ 2))
-  (numer / denom) ^ 2
+  return((numer / denom) ^ 2)
 } # metric.R2

--- a/modules/benchmark/R/metric.RAE.R
+++ b/modules/benchmark/R/metric.RAE.R
@@ -7,5 +7,5 @@
 metric.RAE <- function(dat, ...) {
   numer <- mean(abs(dat$obvs - dat$model))
   denom <- mean(abs(dat$obvs - mean(dat$obvs)))
-  numer/denom
+  return(numer/denom)
 } # metric.RAE

--- a/modules/benchmark/R/metric.RMSE.R
+++ b/modules/benchmark/R/metric.RMSE.R
@@ -5,5 +5,5 @@
 ##' 
 ##' @author Betsy Cowdery
 metric.RMSE <- function(dat, ...) {
-  sqrt(mean((dat$model - dat$obvs) ^ 2))
+  return(sqrt(mean((dat$model - dat$obvs) ^ 2)))
 } # metric.RMSE

--- a/modules/data.atmosphere/R/debias.met.R
+++ b/modules/data.atmosphere/R/debias.met.R
@@ -166,7 +166,7 @@ debias.met <- function(outfolder, source_met, train_met, site_id, de_method='lin
   results$mimetype <- 'application/x-netcdf'
   results$formatname <- 'CF Meteorology'
   
-  invisible(results)
+  return(invisible(results))
 }
 
 #debias.met('debi','GFDL.CM3.rcp45.r1i1p1.2006.nc', 'US-WCr.2006.nc', 4, de_method = 'linear')

--- a/modules/data.atmosphere/R/download.Ameriflux.R
+++ b/modules/data.atmosphere/R/download.Ameriflux.R
@@ -91,7 +91,7 @@ download.Ameriflux <- function(sitename, outfolder, start_date, end_date,
   }
   
   # return list of files downloaded
-  invisible(results)
+  return(invisible(results))
 } # download.Ameriflux
 
 #site <- download.Ameriflux.site(622)

--- a/modules/data.atmosphere/R/download.AmerifluxLBL.R
+++ b/modules/data.atmosphere/R/download.AmerifluxLBL.R
@@ -161,5 +161,5 @@ download.AmerifluxLBL <- function(sitename, outfolder, start_date, end_date,
   results$formatname[row] <- "AMERIFLUX_BASE_HH"
   
   # return list of files downloaded
-  invisible(results)
+  return(invisible(results))
 } # download.AmerifluxLBL

--- a/modules/data.atmosphere/R/download.CRUNCEP_Global.R
+++ b/modules/data.atmosphere/R/download.CRUNCEP_Global.R
@@ -95,5 +95,5 @@ download.CRUNCEP <- function(outfolder, start_date, end_date, site_id, lat.in, l
     results$formatname[i] <- "CF Meteorology"
   }
   
-  invisible(results)
+  return(invisible(results))
 } # download.CRUNCEP

--- a/modules/data.atmosphere/R/download.FACE.R
+++ b/modules/data.atmosphere/R/download.FACE.R
@@ -35,14 +35,14 @@ download.FACE <- function(sitename, outfolder, start_date, end_date, overwrite =
   system(paste("wget -c ", url, " -O ", out.file))
   
   # return file info
-  invisible(data.frame(file = out.file, 
-                       host = fqdn(), 
-                       mimetype = "application/x-netcdf", 
-                       formatname = "FACE", 
-                       startdate = start_date, 
-                       enddate = end_date,
-                       dbfile.name = "FACE", 
-                       stringsAsFactors = FALSE))
+  return(invisible(data.frame(file = out.file, 
+                              host = fqdn(), 
+                              mimetype = "application/x-netcdf", 
+                              formatname = "FACE", 
+                              startdate = start_date, 
+                              enddate = end_date,
+                              dbfile.name = "FACE", 
+                              stringsAsFactors = FALSE)))
   
   ######################
   

--- a/modules/data.atmosphere/R/download.Fluxnet2015.R
+++ b/modules/data.atmosphere/R/download.Fluxnet2015.R
@@ -153,5 +153,5 @@ download.Fluxnet2015 <- function(sitename, outfolder, start_date, end_date,
   results$formatname[row] <- "FLUXNET2015_SUBSET_HH"
   
   # return list of files downloaded
-  invisible(results)
+  return(invisible(results))
 } # download.Fluxnet2015

--- a/modules/data.atmosphere/R/download.FluxnetLaThuile.R
+++ b/modules/data.atmosphere/R/download.FluxnetLaThuile.R
@@ -82,5 +82,5 @@ download.FluxnetLaThuile <- function(sitename, outfolder, start_date, end_date,
   }
   
   # return list of files downloaded
-  invisible(results)
+  return(invisible(results))
 } # download.FluxnetLaThuile

--- a/modules/data.atmosphere/R/download.GFDL.R
+++ b/modules/data.atmosphere/R/download.GFDL.R
@@ -142,5 +142,5 @@ download.GFDL <- function(outfolder, start_date, end_date, site_id, lat.in, lon.
     results$formatname[i] <- "CF Meteorology"
   }
   
-  invisible(results)
+  return(invisible(results))
 } # download.GFDL

--- a/modules/data.atmosphere/R/download.GLDAS.R
+++ b/modules/data.atmosphere/R/download.GLDAS.R
@@ -164,5 +164,5 @@ download.GLDAS <- function(outfolder, start_date, end_date, site_id, lat.in, lon
     results$formatname[i] <- "CF Meteorology"
   }
   
-  invisible(results)
+  return(invisible(results))
 } # download.GLDAS

--- a/modules/data.atmosphere/R/download.MACA.R
+++ b/modules/data.atmosphere/R/download.MACA.R
@@ -150,7 +150,7 @@ download.MACA <- function(outfolder, start_date, end_date, site_id, lat.in, lon.
     
   }
   
-  invisible(results)
+  return(invisible(results))
 }
 
 #download.MACA('maca','2006-01-01 00:00:00','2006-12-31 23:59:59',5,45,-90)

--- a/modules/data.atmosphere/R/download.MsTMIP_NARR.R
+++ b/modules/data.atmosphere/R/download.MsTMIP_NARR.R
@@ -105,5 +105,5 @@ download.MsTMIP_NARR <- function(outfolder, start_date, end_date, site_id, lat.i
     results$formatname[i] <- "CF Meteorology"
   }
   
-  invisible(results)
+  return(invisible(results))
 } # download.MsTMIP_NARR

--- a/modules/data.atmosphere/R/download.NARR.R
+++ b/modules/data.atmosphere/R/download.NARR.R
@@ -59,5 +59,5 @@ download.NARR <- function(outfolder, start_date, end_date, overwrite = FALSE, ve
     }
   }
   
-  invisible(results)
+  return(invisible(results))
 } # download.NARR

--- a/modules/data.atmosphere/R/download.NLDAS.R
+++ b/modules/data.atmosphere/R/download.NLDAS.R
@@ -165,5 +165,5 @@ download.NLDAS <- function(outfolder, start_date, end_date, site_id, lat.in, lon
     results$formatname[i] <- "CF Meteorology"
   }
   
-  invisible(results)
+  return(invisible(results))
 } # download.NLDAS

--- a/modules/data.atmosphere/R/download.PalEON.R
+++ b/modules/data.atmosphere/R/download.PalEON.R
@@ -83,5 +83,5 @@ download.PalEON <- function(sitename, outfolder, start_date, end_date, overwrite
     }
   }
   
-  invisible(results)
+  return(invisible(results))
 } # download.PalEON

--- a/modules/data.atmosphere/R/met.process.R
+++ b/modules/data.atmosphere/R/met.process.R
@@ -351,7 +351,7 @@ browndog.met <- function(browndog, source, site, start_date, end_date, model, di
     results$dbfile.name <- basename(downloadedfile)
   }
   
-  invisible(return(results))
+  return(invisible(results))
 } # browndog.met
 
 ################################################################################################################################# 
@@ -372,5 +372,5 @@ browndog.met <- function(browndog, source, site, start_date, end_date, model, di
 site_from_tag <- function(sitename, tag) {
   temp <- regmatches(sitename, gregexpr("(?<=\\().*?(?=\\))", sitename, perl = TRUE))[[1]]
   pref <- paste0(tag, "-")
-  unlist(strsplit(temp[grepl(pref, temp)], pref))[2]
+  return(unlist(strsplit(temp[grepl(pref, temp)], pref))[2])
 } # site_from_tag

--- a/modules/data.atmosphere/R/met.process.R
+++ b/modules/data.atmosphere/R/met.process.R
@@ -82,7 +82,7 @@ met.process <- function(site, input_met, start_date, end_date, model,
                           formatname = result$formatname, 
                           parentid = NA, 
                           con = con, hostname = result$host)
-      invisible(return(result$file))
+      return(invisible(result$file))
     }
   }
   
@@ -273,7 +273,7 @@ browndog.met <- function(browndog, source, site, start_date, end_date, model, di
     sitename <- gsub("[\\s/()]", "-", site$name, perl = TRUE)
   } else {
     logger.warn("Could not process source", source)
-    invisible(return(NA))
+    return(invisible(NA))
   }
   
   # this logic should live somewhere else, maybe the registry?
@@ -319,7 +319,7 @@ browndog.met <- function(browndog, source, site, start_date, end_date, model, di
                           stringsAsFactors = FALSE)
   } else {
     logger.warn("Could not process model", model)
-    invisible(return(NA))
+    return(invisible(NA))
   }
   
   xmldata <- paste0("<input>", 

--- a/modules/data.atmosphere/R/met.process.stage.R
+++ b/modules/data.atmosphere/R/met.process.stage.R
@@ -24,5 +24,5 @@ met.process.stage <- function(input.id, raw.id, con) {
     stage <- list(download.raw = FALSE, met2cf = FALSE, standardize = FALSE, 
                   met2model = FALSE, id.name = "model.id")
   }
-  invisible(stage)
+  return(invisible(stage))
 } # met.process.stage

--- a/modules/data.atmosphere/R/met2CF.ALMA.R
+++ b/modules/data.atmosphere/R/met2CF.ALMA.R
@@ -484,5 +484,5 @@ met2CF.ALMA <- function(in.path, in.prefix, outfolder, start_date, end_date, ove
     ncdf4::nc_close(nc2)
   }  ## end loop over years
   
-  invisible(results)
+  return(invisible(results))
 } # met2CF.ALMA

--- a/modules/data.atmosphere/R/met2CF.ALMA.R
+++ b/modules/data.atmosphere/R/met2CF.ALMA.R
@@ -186,7 +186,7 @@ met2CF.PalEON <- function(in.path, in.prefix, outfolder, start_date, end_date, l
     ncdf4::nc_close(nc2)
   }  ## end loop over years
   
-  invisible(results)
+  return(invisible(results)
 } # met2CF.PalEON
 
 

--- a/modules/data.atmosphere/R/met2CF.ALMA.R
+++ b/modules/data.atmosphere/R/met2CF.ALMA.R
@@ -186,7 +186,7 @@ met2CF.PalEON <- function(in.path, in.prefix, outfolder, start_date, end_date, l
     ncdf4::nc_close(nc2)
   }  ## end loop over years
   
-  return(invisible(results)
+  return(invisible(results))
 } # met2CF.PalEON
 
 

--- a/modules/data.atmosphere/R/met2CF.Ameriflux.R
+++ b/modules/data.atmosphere/R/met2CF.Ameriflux.R
@@ -299,5 +299,5 @@ met2CF.Ameriflux <- function(in.path, in.prefix, outfolder, start_date, end_date
     ncdf4::nc_close(nc2)
   }  ## end loop over years
   
-  invisible(results)
+  return(invisible(results))
 } # met2CF.Ameriflux

--- a/modules/data.atmosphere/R/met2CF.NARR.R
+++ b/modules/data.atmosphere/R/met2CF.NARR.R
@@ -84,5 +84,5 @@ met2CF.NARR <- function(in.path, in.prefix, outfolder, start_date, end_date,
     file.rename(tmpfile, newfile)
   }
   
-  invisible(results)
+  return(invisible(results))
 } # met2CF.NARR

--- a/modules/data.atmosphere/R/met2CF.csv.R
+++ b/modules/data.atmosphere/R/met2CF.csv.R
@@ -599,14 +599,14 @@ met2CF.csv <- function(in.path, in.prefix, outfolder, start_date, end_date, form
       ncdf4::nc_close(nc)
     }  ## end loop over years
   }  ## end else file found
-  invisible(results)
+  return(invisible(results))
 } # met2CF.csv
 
 
 datetime <- function(list) {
   date_string <- sapply(list, as.character)
   datetime <- paste(list, "00")
-  ymd_hms(datetime)
+  return(ymd_hms(datetime))
 } # datetime
 
 met.conv <- function(x, orig, bety, CF) {

--- a/modules/data.atmosphere/R/met_functions.R
+++ b/modules/data.atmosphere/R/met_functions.R
@@ -85,5 +85,6 @@ lightME <- function(lat = 40, DOY = 190, t.d = 12, t.sn = 12, atm.P = 1e+05, alp
   propIdir <- I.dir / (I.dir + I.diff)
   propIdiff <- I.diff / (I.dir + I.diff)
   
-  list(I.dir = I.dir, I.diff = I.diff, cos.th = CosZenithAngle, propIdir = propIdir, propIdiff = propIdiff)
+  return(list(I.dir = I.dir, I.diff = I.diff, cos.th = CosZenithAngle,
+              propIdir = propIdir, propIdiff = propIdiff))
 } # lightME

--- a/modules/data.atmosphere/R/metgapfill.R
+++ b/modules/data.atmosphere/R/metgapfill.R
@@ -667,5 +667,5 @@ metgapfill <- function(in.path, in.prefix, outfolder, start_date, end_date, lst 
   ## Step 6.Replace gaps with debiased time series (perhaps store statistics of fit somewhere as a measure of uncertainty?)
   ## Step 7. Write to outfolder the new NetCDF file
   
-  invisible(results)
+  return(invisible(results))
 } # metgapfill

--- a/modules/data.atmosphere/R/metutils.R
+++ b/modules/data.atmosphere/R/metutils.R
@@ -4,12 +4,12 @@ qcsolar <- function(x) ifelse(x < 0, 0, ifelse(abs(x) > 1300, mean(x[x < 1300]),
 qcwind <- function(x) ifelse(abs(x) > 102, mean(abs(x[x < 102])), x)
 qcprecip <- function(x) ifelse(x > 0.005 | x < 0, mean(x[x < 0.005 & x > 0]), x)
 qcrh <- function(x) {
-  ifelse(x > 100 | x < 0, mean(x[x < 100 & x > 0]), x)  #using logical range (0-100) rather than 'valid range (-25-125)'
+  return(ifelse(x > 100 | x < 0, mean(x[x < 100 & x > 0]), x))  # using logical range (0-100) rather than 'valid range (-25-125)'
 } # qcrh
 
 qcshum <- function(x) {
   x <- ifelse(x > 100 | x < 0, mean(x[x < 0.6553 & x > 0]), x)
-  x[is.na(x)] <- mean(x, na.rm = TRUE)
+  return(x[is.na(x)] <- mean(x, na.rm = TRUE))
 } # qcshum
 
 ##' Convert specific humidity to relative humidity
@@ -67,7 +67,7 @@ get.vpd <- function(rh, temp) {
   ## calculate saturation vapor pressure
   es <- get.es(temp)
   ## calculate vapor pressure deficit
-  ((100 - rh)/100) * es
+  return(((100 - rh)/100) * es)
 } # get.vpd
 
 ##' Calculate saturation vapor pressure
@@ -81,7 +81,7 @@ get.vpd <- function(rh, temp) {
 ##' temp <- -30:30
 ##' plot(temp, get.es(temp))
 get.es <- function(temp) {
-  6.11 * exp((2500000/461) * (1/273 - 1/(273 + temp)))
+  return(6.11 * exp((2500000/461) * (1/273 - 1/(273 + temp))))
 } # get.es
 
 ## TODO: merge SatVapPress with get.es; add option to choose method
@@ -89,8 +89,8 @@ SatVapPres <- function(T) {
   # /estimates saturation vapor pressure (kPa) Goff-Gratch 1946 /input: T = absolute temperature
   T_st <- 373.15  ##steam temperature (K)
   e_st <- 1013.25  ##/saturation vapor pressure at steam temp (hPa)
-  0.1 * exp(-7.90298 * (T_st/T - 1) + 5.02808 * log(T_st/T) - 1.3816e-07 * (10^(11.344 * (1 - T/T_st)) - 
-    1) + 0.0081328 * (10^(-3.49149 * (T_st/T - 1)) - 1) + log(e_st))
+  return(0.1 * exp(-7.90298 * (T_st/T - 1) + 5.02808 * log(T_st/T) - 1.3816e-07 * (10^(11.344 * (1 - T/T_st)) - 
+    1) + 0.0081328 * (10^(-3.49149 * (T_st/T - 1)) - 1) + log(e_st)))
 } # SatVapPres
 
 
@@ -107,7 +107,7 @@ SatVapPres <- function(T) {
 ##' @author David LeBauer
 get.rh <- function(T, Td) {
   arg <- -L / (Rw * T * Td) * (T - Td)
-  100 * exp(-L / (Rw * T * Td) * (T - Td))
+  return(100 * exp(-L / (Rw * T * Td) * (T - Td)))
 } # get.rh
 
 ##' Convert raster to lat, lon, var
@@ -145,7 +145,7 @@ wide2long <- function(data.wide, lat, lon, var) {
 ##' @author David LeBauer
 par2ppfd <- function(watts) {
   ppfd <- watts/(2.35 * 10^5)
-  udunits2::ud.convert(ppfd, "mol ", "umol")
+  return(udunits2::ud.convert(ppfd, "mol ", "umol"))
 } # par2ppfd
 
 
@@ -161,7 +161,7 @@ par2ppfd <- function(watts) {
 ##' @export
 ##' @return PAR W/m2
 sw2par <- function(sw) {
-  sw * 0.486
+  return(sw * 0.486)
 } # sw2par
 
 ##' CF Shortwave to PPFD
@@ -174,7 +174,7 @@ sw2par <- function(sw) {
 ##' @return PPFD umol /m2 / s
 sw2ppfd <- function(sw) {
   par <- sw2par(sw)
-  par2ppfd(par)
+  return(par2ppfd(par))
 } # sw2ppfd
 
 
@@ -200,7 +200,7 @@ sw2ppfd <- function(sw) {
 ##' @export
 ##' @return PPFD umol /m2 / s
 solarMJ2ppfd <- function(solarMJ) {
-  (0.12 * solarMJ) * 2.07 * 1e+06 / 3600
+  return((0.12 * solarMJ) * 2.07 * 1e+06 / 3600)
 } # solarMJ2ppfd
 
 ##' estimated exner function
@@ -209,7 +209,7 @@ solarMJ2ppfd <- function(solarMJ) {
 ##' @export
 ##' @author Mike Dietze
 exner <- function(pres) {
-  1004 * pres ^ (287 / 1004)
+  return(1004 * pres ^ (287 / 1004))
 } # exner
 
 ##' estimate air density from pressure, temperature, and humidity
@@ -220,7 +220,7 @@ exner <- function(pres) {
 ##' @export
 ##' @author Mike Dietze
 AirDens <- function(pres, T, rv) {
-  pres/(287 * T * (1 + 0.61 * rv))
+  return(pres / (287 * T * (1 + 0.61 * rv)))
 } # AirDens
 
 ##' calculate latent heat of vaporization for water 
@@ -231,5 +231,5 @@ AirDens <- function(pres, T, rv) {
 ##' @author Istem Fer
 ##' @return lV   latent heat of vaporization (J kg-1)
 get.lv <- function(airtemp = 268.6465) {
-  (94.21 * (365 - (airtemp - 273.15)) ^ 0.31249) * 4.183 * 1000
+  return((94.21 * (365 - (airtemp - 273.15)) ^ 0.31249) * 4.183 * 1000)
 } # get.lv

--- a/modules/data.atmosphere/R/permute.nc.R
+++ b/modules/data.atmosphere/R/permute.nc.R
@@ -62,5 +62,5 @@ permute.nc <- function(in.path, in.prefix, outfolder, start_date, end_date,
     unlink(tmp.file)
   }
   
-  invisible(results)
+  return(invisible(results))
 } # permute.nc

--- a/modules/data.atmosphere/R/read.register.R
+++ b/modules/data.atmosphere/R/read.register.R
@@ -47,5 +47,5 @@ read.register <- function(register.xml, con) {
                                             "' and mime_type = '", register$format$mimetype, "'"), con)[[1]]
     }
   }
-  invisible(register)
+  return(invisible(register))
 } # read.register

--- a/modules/data.land/R/buildJAGSdata_InventoryRings.R
+++ b/modules/data.land/R/buildJAGSdata_InventoryRings.R
@@ -62,12 +62,12 @@ buildJAGSdata_InventoryRings <- function(combined, inc.unit.conv = 0.1) {
   
   ## build data object for JAGS
   n <- nrow(y)
-  list(y = y[1:n, ], 
-       z = z[1:n, ],
-       ni = n, nt = ncol(y), 
-       x_ic = 1, tau_ic = 1e-04,
-       a_dbh = 16, r_dbh = 8, 
-       a_inc = 0.001, r_inc = 1, 
-       a_add = 1, r_add = 1, 
-       time = time)
+  return(list(y = y[1:n, ], 
+              z = z[1:n, ],
+              ni = n, nt = ncol(y), 
+              x_ic = 1, tau_ic = 1e-04,
+              a_dbh = 16, r_dbh = 8, 
+              a_inc = 0.001, r_inc = 1, 
+              a_add = 1, r_add = 1, 
+              time = time))
 } # buildJAGSdata_InventoryRings

--- a/modules/data.land/R/extract.stringCode.R
+++ b/modules/data.land/R/extract.stringCode.R
@@ -2,7 +2,7 @@
 ##' @title extract.string.code
 ##' @export
 extract.stringCode <- function(x, extractor = from.TreeCode) {
-  extractor(x)
+  return(extractor(x))
 } # extract.stringCode
 
 ##' @name from.TreeCode
@@ -13,7 +13,7 @@ from.TreeCode <- function(x) {
   PLOT <- substr(x, 2, 2)
   SUBPLOT <- substr(x, 3, 3)
   TAG <- substr(x, 4, 1000000L)
-  data.frame(SITE, PLOT, SUBPLOT, TAG)
+  return(data.frame(SITE, PLOT, SUBPLOT, TAG))
 } # from.TreeCode
 
 ##' @name to.TreeCode
@@ -28,7 +28,7 @@ to.TreeCode <- function(SITE, PLOT, SUBPLOT, TAG = NULL) {
   if (!is.null(x)) {
     x <- paste0(x, TAG)
   }
-  x
+  return(x)
 } # to.TreeCode
 
 ##' @name from.Tag
@@ -36,7 +36,7 @@ to.TreeCode <- function(SITE, PLOT, SUBPLOT, TAG = NULL) {
 ##' @export
 from.Tag <- function(x) {
   miss <- rep(NA, length(x))
-  data.frame(SITE = miss, PLOT = miss, SUBPLOT = miss, TAG = x)
+  return(data.frame(SITE = miss, PLOT = miss, SUBPLOT = miss, TAG = x))
 } # from.Tag
 
 ##' @name to.Tag
@@ -46,5 +46,5 @@ to.Tag <- function(SITE, PLOT, SUBPLOT, TAG = NULL) {
   SITE <- as.character(SITE)
   PLOT <- as.character(PLOT)
   SUBPLOT <- as.character(SUBPLOT)
-  as.character(TAG)
+  return(as.character(TAG))
 } # to.Tag

--- a/modules/data.land/R/fuse_plot_treering.R
+++ b/modules/data.land/R/fuse_plot_treering.R
@@ -135,6 +135,6 @@ fuse_plot_treering <- function(plot.data, inc.data, tuscon.data, inc.unit.conv =
     row.names(diameters[[i]]) <- dnames
   }
   
-  list(diameters = diameters, increments = increments, survival = survival,
-       species = spp, depth = depth)
+  return(list(diameters = diameters, increments = increments, survival = survival,
+              species = spp, depth = depth))
 } # fuse_plot_treering

--- a/modules/data.land/R/land.utils.R
+++ b/modules/data.land/R/land.utils.R
@@ -7,8 +7,9 @@ get.elevation <- function(lat, lon) {
   page <- getURL(url)
   ans  <- xmlTreeParse(page, useInternalNodes = TRUE)
   heightNode <- xpathApply(ans, "//meters")[[1]]
-  as.numeric(xmlValue(heightNode))
+  return(as.numeric(xmlValue(heightNode)))
 } # get.elevation
+
 
 is.land <- function(lat, lon) {
   ncvar_get <- ncdf4::ncvar_get
@@ -17,11 +18,11 @@ is.land <- function(lat, lon) {
   lati <- which.min(abs(Lat - lat))
   loni <- which.min(abs(Lon - lon))
   mask <- ncvar_get(nc = met.nc, varid = "mask", start = c(loni, lati), count = c(1, 1))
-  mask >= 0
+  return(mask >= 0)
 } # is.land
 
 get.latlonbox <- function(lati, loni, Lat = Lat, Lon = Lon) {
   lat <- c(mean(Lat[lati:(lati - 1)]), mean(Lat[lati:(lati + 1)]))
   lon <- c(mean(Lon[loni:(loni - 1)]), mean(Lon[loni:(loni + 1)]))
-  c(sort(lat), sort(lon))
+  return(c(sort(lat), sort(lon)))
 } # get.latlonbox

--- a/modules/data.land/R/parse.MatrixNames.R
+++ b/modules/data.land/R/parse.MatrixNames.R
@@ -15,5 +15,5 @@ parse.MatrixNames <- function(w, pre = "x", numeric = FALSE) {
     class(w) <- "numeric"
   }
   colnames(w) <- c("row", "col")
-  as.data.frame(w)
+  return(as.data.frame(w))
 } # parse.MatrixNames

--- a/modules/data.land/R/plot2AGB.R
+++ b/modules/data.land/R/plot2AGB.R
@@ -121,7 +121,7 @@ plot2AGB <- function(combined, out, outfolder, allom.stats, unit.conv = 0.02) {
        mbiomass_tsca, sbiomass_tsca, mbiomass_acsa3, sbiomass_acsa3, 
        mbiomass_beal2, sbiomass_beal2, mbiomass_thoc2, sbiomass_thoc2, 
        file = file.path(outfolder, "plot2AGB.Rdata"))
-  list(AGB = AGB, NPP = NPP, 
-       biomass_tsca = biomass_tsca, biomass_acsa3 = biomass_acsa3, 
-       biomass_beal2 = biomass_beal2, biomass_thoc2 = biomass_thoc2)
+  return(list(AGB = AGB, NPP = NPP, 
+              biomass_tsca = biomass_tsca, biomass_acsa3 = biomass_acsa3, 
+              biomass_beal2 = biomass_beal2, biomass_thoc2 = biomass_thoc2))
 } # plot2AGB

--- a/modules/data.land/R/read.plot.R
+++ b/modules/data.land/R/read.plot.R
@@ -14,5 +14,5 @@ read.plot <- function(file) {
   spp  <- as.character(dat[, which(toupper(names(dat)) == "SPECIES")])
   dbh  <- dat[, which(toupper(names(dat)) == "DBH")]
   
-  data.frame(plot = plot, tree = tree, spp = spp, dbh = dbh)
+  return(data.frame(plot = plot, tree = tree, spp = spp, dbh = dbh))
 } # read.plot

--- a/modules/data.remote/R/call_MODIS.R
+++ b/modules/data.remote/R/call_MODIS.R
@@ -69,5 +69,5 @@ call_MODIS <- function(outfolder = ".", fname = "m_data.nc", start, end, lat, lo
   }
   date <- python.get("date")
   
-  invisible(list(m = m, k = k, date = date))
+  return(invisible(list(m = m, k = k, date = date)))
 } # call_MODIS

--- a/modules/emulator/R/GaussProcess.R
+++ b/modules/emulator/R/GaussProcess.R
@@ -308,8 +308,8 @@ GaussProcess <- function(x, y, isotropic = TRUE, nugget = TRUE, method = "bayes"
     progressBar(1.1, prevTime)
   }
   
-  list(method = method, tauwjump = tauwjump, tauw = tauwgibbs, 
-       psijump = psijump, psi = psigibbs, mu = mugibbs, tauv = tauvgibbs,
-       W = Wgibbs, nugget = nugget, isotropic = isotropic, d = d, samp = samp, 
-       x.id = x.id, x.compact = x.compact, y = y, zeroMean = zeroMean)
+  return(list(method = method, tauwjump = tauwjump, tauw = tauwgibbs, 
+              psijump = psijump, psi = psigibbs, mu = mugibbs, tauv = tauvgibbs,
+              W = Wgibbs, nugget = nugget, isotropic = isotropic, d = d, samp = samp, 
+              x.id = x.id, x.compact = x.compact, y = y, zeroMean = zeroMean))
 } # GaussProcess

--- a/modules/emulator/R/arate.R
+++ b/modules/emulator/R/arate.R
@@ -6,5 +6,5 @@
 ##'
 ##' @author Michael Dietze
 arate <- function(x) {
-  1 - (sum(diff(x) == 0, na.rm = TRUE) / (length(x) - 1))
+  return(1 - (sum(diff(x) == 0, na.rm = TRUE) / (length(x) - 1)))
 } # arate

--- a/modules/emulator/R/calcSpatialCov.list.R
+++ b/modules/emulator/R/calcSpatialCov.list.R
@@ -32,5 +32,5 @@ calcSpatialCov.list <- function(d, psi, tau) {
   for (k in seq_len(m)) {
     H <- H - psi[k] * d[[k]]
   }
-  tau * exp(H)
+  return(tau * exp(H))
 } # calcSpatialCov.list

--- a/modules/emulator/R/calcSpatialCov.matrix.R
+++ b/modules/emulator/R/calcSpatialCov.matrix.R
@@ -20,5 +20,5 @@ calcSpatialCov.matrix <- function(d, psi, tau) {
       H[i, ] <- tau * exp(-psi * d[i, ])
     }
   }
-  H
+  return(H)
 }

--- a/modules/emulator/R/distance.R
+++ b/modules/emulator/R/distance.R
@@ -27,5 +27,5 @@ distance <- function(x, power = 1) {
       }
     }
   }
-  dst
+  return(dst)
 } # distance

--- a/modules/emulator/R/distance.matrix.R
+++ b/modules/emulator/R/distance.matrix.R
@@ -18,5 +18,5 @@ distance.matrix <- function(x, power = 1, dim = 2) {
       # d[i,j] <- 0 for(k in 1:dim){ d[i,j] <- d[i,j] + (x[i,k]-x[j,k])^power }
     }
   }
-  d
+  return(d)
 } # distance.matrix

--- a/modules/emulator/R/distance12.matrix.R
+++ b/modules/emulator/R/distance12.matrix.R
@@ -16,5 +16,5 @@ distance12.matrix <- function(x, n1, power = 1) {
   for (i in seq_len(n)) {
     d[i, ] <- (x[i, 1] - x[sel, 1]) ^ power + (x[i, 2] - x[sel, 2]) ^ power
   }
-  d
+  return(d)
 } # distance12.matrix

--- a/modules/emulator/R/groupid.R
+++ b/modules/emulator/R/groupid.R
@@ -26,5 +26,5 @@ groupid <- function(x) {
       j <- j + 1
     }
   }
-  v
+  return(v)
 } # groupid

--- a/modules/emulator/R/jump.R
+++ b/modules/emulator/R/jump.R
@@ -7,7 +7,7 @@
 ##' 
 ##' @author Michael Dietze
 jump <- function(ic = 0, rate = 0.4, ...) {
-  new("jump", history = ic, arate = 0, target = rate)
+  return(new("jump", history = ic, arate = 0, target = rate))
 } # jump
 
 ##' multivariate version
@@ -15,5 +15,5 @@ jump <- function(ic = 0, rate = 0.4, ...) {
 ##' @export
 mvjump <- function(ic = 0, rate = 0.4, nc = 2, ...) {
   icm <- (matrix(ic, nrow = 1, ncol = nc))
-  new("mvjump", history = icm, arate = 0, target = rate)
+  return(new("mvjump", history = icm, arate = 0, target = rate))
 } # mvjump

--- a/modules/emulator/R/ldinvgamma.R
+++ b/modules/emulator/R/ldinvgamma.R
@@ -17,6 +17,6 @@ ldinvgamma <- function(x, shape, scale = 1) {
     }
     alpha <- shape
     beta <- scale
-    alpha * log(beta) - lgamma(alpha) - (alpha + 1) * log(x) - (beta / x)
+    return(alpha * log(beta) - lgamma(alpha) - (alpha + 1) * log(x) - (beta / x))
 } # ldinvgamma
 

--- a/modules/emulator/R/lhc.R
+++ b/modules/emulator/R/lhc.R
@@ -20,6 +20,6 @@ lhc <- function(x, n.samp) {
         myseq <- seq(x[i, 1], x[i, 2], length = n.samp + 1)
         samp[i, ] <- runif(n.samp, myseq[permute[i, ]], myseq[permute[i, ] + 1])
     }
-    t(samp)
+    return(t(samp))
 } # lhc
 

--- a/modules/emulator/R/p.jump.R
+++ b/modules/emulator/R/p.jump.R
@@ -18,5 +18,5 @@ p.jump <- function(jmp) {
 ##' 
 p.mvjump <- function(jmp) {
   n <- nrow(attr(jmp, "history"))
-  attr(jmp, "history")[n, ]
+  return(attr(jmp, "history")[n, ])
 } # p.jump

--- a/modules/emulator/R/predict.density.R
+++ b/modules/emulator/R/predict.density.R
@@ -24,5 +24,5 @@ predict.density <- function(den, xnew) {
         (xnew[i] - den$x[j])
     }
   }
-  ynew
+  return(ynew)
 } # predict.density

--- a/modules/emulator/R/update.jump.R
+++ b/modules/emulator/R/update.jump.R
@@ -60,5 +60,5 @@ update.mvjump <- function(jmp, chain) {
     attr(jmp, "history") <- rbind(attr(jmp, "history"), hnew)
     attr(jmp, "arate")[l + 1] <- a
   }
-  jmp
+  return(jmp)
 } # update.jump

--- a/modules/priors/R/priors.R
+++ b/modules/priors/R/priors.R
@@ -172,7 +172,7 @@ prior.fn <- function(parms, x, alpha, distn, central.tendency = NULL, trait = NU
 ##' @export
 ##' @seealso \{code{\link{get.sample}}
 pr.samp <- function(distn, parama, paramb, n) {
-  do.call(paste0("r", distn), list(n, parama, paramb))
+  return(do.call(paste0("r", distn), list(n, parama, paramb)))
 } # pr.samp
 
 
@@ -190,10 +190,10 @@ get.sample <- function(prior, n) {
   print(paste("get.sample", prior$distn))
   if (as.character(prior$distn) %in% c("exp", "pois", "geom")) {
     ## one parameter distributions
-    do.call(paste0("r", prior$distn), list(n, prior$parama))
+    return(do.call(paste0("r", prior$distn), list(n, prior$parama)))
   } else {
     ## two parameter distributions
-    do.call(paste0("r", prior$distn), list(n, prior$parama, prior$paramb))
+    return(do.call(paste0("r", prior$distn), list(n, prior$parama, prior$paramb)))
   }
 } # get.sample
 

--- a/modules/uncertainty/R/run.sensitivity.analysis.R
+++ b/modules/uncertainty/R/run.sensitivity.analysis.R
@@ -164,8 +164,3 @@ runModule.run.sensitivity.analysis <- function(settings, ...) {
     stop("runModule.run.sensitivity.analysis only works with Settings or MultiSettings")
   }
 }
-
-
-####################################################################################################
-### EOF.  End of R script file.        			
-####################################################################################################

--- a/settings/R/Settings.R
+++ b/settings/R/Settings.R
@@ -34,6 +34,3 @@ as.Settings <- function(x) {
 is.Settings <- function(x) {
   return(is(x, "Settings"))
 }
-
-
-

--- a/settings/R/clean.settings.R
+++ b/settings/R/clean.settings.R
@@ -61,5 +61,5 @@ clean.settings <- function(inputfile = "pecan.xml", outputfile = "pecan.xml") {
   XML::saveXML(listToXml(settings, "pecan"), file = outputfile)
   
   ## Return settings file as a list
-  invisible(settings)
+  return(invisible(settings))
 } # clean.settings

--- a/settings/R/read.settings.R
+++ b/settings/R/read.settings.R
@@ -455,7 +455,7 @@ check.settings <- function(settings) {
   options(scipen = scipen)
   
   # all done return cleaned up settings
-  invisible(settings)
+  return(invisible(settings))
 } # check.settings
 
 
@@ -659,7 +659,7 @@ check.run.settings <- function(settings, dbcon = NULL) {
   options(scipen = scipen)
   
   # all done return cleaned up settings
-  invisible(settings)
+  return(invisible(settings))
 } # check.run.settings
 
 check.model.settings <- function(settings, dbcon = NULL) {

--- a/settings/R/read.settings.R
+++ b/settings/R/read.settings.R
@@ -218,6 +218,7 @@ check.bety.version <- function(dbcon) {
   }
 } # check.bety.version
 
+
 ##' Sanity checks. Checks the settings file to make sure expected fields exist. It will try to use
 ##' default values for any missing values, or stop the exection if no defaults are possible.
 ##'
@@ -1091,7 +1092,7 @@ update.settings <- function(settings) {
     settings$model$soil <- NULL
   }
   
-  invisible(settings)
+  return(invisible(settings))
 } # update.settings
 
 ##' Add secret information from ~/.pecan.xml
@@ -1139,7 +1140,7 @@ addSecrets <- function(settings) {
     }
   }  
   
-  invisible(settings)
+  return(invisible(settings))
 } # addSecrets
 
 ##--------------------------------------------------------------------------------------------------#
@@ -1241,10 +1242,5 @@ read.settings <- function(inputfile = "pecan.xml", outputfile = "pecan.CHECKED.x
     .libPaths(settings$Rlib)
   }
   
-  invisible(settings)
+  return(invisible(settings))
 } # read.settings
-##=================================================================================================#
-
-####################################################################################################
-### EOF.  End of R script file.              
-####################################################################################################

--- a/utils/R/ensemble.R
+++ b/utils/R/ensemble.R
@@ -284,5 +284,5 @@ write.ensemble.configs <- function(defaults, ensemble.samples, settings, model,
     db.close(con)
   }
   
-  invisible(list(runs = runs, ensemble.id = ensemble.id))
+  return(invisible(list(runs = runs, ensemble.id = ensemble.id)))
 } # write.ensemble.configs

--- a/utils/R/get.results.R
+++ b/utils/R/get.results.R
@@ -228,7 +228,7 @@ runModule.get.results <- function(settings) {
   if (is.MultiSettings(settings)) {
     return(papply(settings, runModule.get.results))
   } else if (is.Settings(settings)) {
-    get.results(settings)
+    return(get.results(settings))
   } else {
     stop("runModule.get.results only works with Settings or MultiSettings")
   }

--- a/utils/R/listToArgString.R
+++ b/utils/R/listToArgString.R
@@ -31,10 +31,10 @@ listToArgString <- function(l) {
 
 .parseArg <- function(x) {
   if (is.character(x) || lubridate::is.POSIXt(x) || lubridate::is.Date(x)) {
-    paste0("'", x, "'")
+    return(paste0("'", x, "'"))
   } else if (is.null(x)) {
-    "NULL"
+    return("NULL")
   } else {
-    x
+    return(x)
   }
 } # .parseArg

--- a/utils/R/remote.R
+++ b/utils/R/remote.R
@@ -234,7 +234,7 @@ remote.execute.R <- function(script, host = "localhost", user = NA, verbose = FA
   result <- unserialize(fp)
   close(fp)
   unlink(tmpfile)
-  invisible(result)
+  return(invisible(result))
 } # remote.execute.R
 
 # remote.execute.cmd <- function(host, cmd, args=character(), stderr=FALSE) {

--- a/utils/R/start.model.runs.R
+++ b/utils/R/start.model.runs.R
@@ -284,7 +284,7 @@ runModule.start.model.runs <- function(settings) {
     return(papply(settings, runModule.start.model.runs))
   } else if (is.Settings(settings)) {
     write <- settings$database$bety$write
-    start.model.runs(settings, write)
+    return(start.model.runs(settings, write))
   } else {
     stop("runModule.start.model.runs only works with Settings or MultiSettings")
   }

--- a/utils/R/write.config.utils.R
+++ b/utils/R/write.config.utils.R
@@ -106,5 +106,5 @@ counter <- function(cnt) {
 ##' @return logical
 met2model.exists <- function(model) {
   load.modelpkg(model)
-  exists(paste0("met2model.", model))
+  return(exists(paste0("met2model.", model)))
 } # met2model.exists


### PR DESCRIPTION
Make sure functions end with explicit `return()`s

## Description
PEcAn style preference is for explicit `return` calls at end of functions. Have not yet touched `db/` because waiting for #1091 to be merged.

## Motivation and Context
Clarifies code behavior.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 