### PR TITLE
Bugfixes to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ $(MODELS_I): $(MODULES_I)
 
 .install/db: .install/utils
 .install/settings: .install/utils .install/db
-.install/visualization: .install/db
+.install/visualization: .install/db .install/shiny
 .install/modules/data.atmosphere: .install/utils .install/reddyproc
 .install/modules/data.land: .install/db .install/utils
 .install/modules/meta.analysis: .install/utils .install/db
@@ -76,7 +76,12 @@ clean:
 	rm -rf .install .check .test .doc
 
 .install/devtools:
-	Rscript -e "req <- require('devtools'); if(!req) install.packages('devtools', repos = 'http://cran.rstudio.com')"
+	Rscript -e "if(!require('devtools')) install.packages('devtools', repos = 'http://cran.rstudio.com')"
+	mkdir -p $(@D)
+	echo `date` > $@
+
+.install/shiny:
+	Rscript -e "if(!require('shiny')) install.packages('shiny', repos = 'http://cran.rstudio.com')"
 	mkdir -p $(@D)
 	echo `date` > $@
 

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ ALL_PKGS_D := $(BASE_D) $(MODELS_D) $(MODULES_D)
 all: document install
 
 document: .doc/all
-install: document .install/all 
-check: install .check/all
-test: install .test/all 
+install: .install/all 
+check: .check/all
+test: .test/all 
 
 ### Dependencies
 .doc/all: $(ALL_PKGS_D)
@@ -47,30 +47,19 @@ test: install .test/all
 .check/all: $(ALL_PKGS_C)
 .test/all: $(ALL_PKGS_T)
 
+depends = .install/$(1) .doc/$(1) .check/$(1) .test/$(1)
+
+$(call depends,db): .install/utils
+$(call depends,settings): .install/utils .install/db
+$(call depends,visualization): .install/db .install/shiny
+$(call depends,modules/data.atmosphere): .install/utils .install/reddyproc
+$(call depends,modules/data.land): .install/db .install/utils
+$(call depends,modules/meta.analysis): .install/utils .install/db
+$(call depends,modules/priors): .install/utils
+$(call depends,modules/rtm): .install/modules/assim.batch
+
 $(MODELS_I): $(MODULES_I)
 
-# These two blocks are redunant for now because dependencies need to be 
-# specified separately for installation and documentation. I have some ideas 
-# about how to fix this, but it's not a priority. For now, just make sure to 
-# add dependencies for any new package into here.
-
-.install/db: .install/utils
-.install/settings: .install/utils .install/db
-.install/visualization: .install/db .install/shiny
-.install/modules/data.atmosphere: .install/utils .install/reddyproc
-.install/modules/data.land: .install/db .install/utils
-.install/modules/meta.analysis: .install/utils .install/db
-.install/modules/priors: .install/utils
-.install/modules/rtm: .install/modules/assim.batch
-
-.doc/db: .doc/utils
-.doc/settings: .doc/utils .doc/db
-.doc/visualization: .doc/db
-.doc/modules/data.atmosphere: .doc/utils
-.doc/modules/data.land: .doc/db .doc/utils
-.doc/modules/meta.analysis: .doc/utils .doc/db
-.doc/modules/priors: .doc/utils
-.doc/modules/rtm: .doc/modules/assim.batch
 
 clean:
 	rm -rf .install .check .test .doc

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ ALL_PKGS_D := $(BASE_D) $(MODELS_D) $(MODULES_D)
 all: document install
 
 document: .doc/all
-install: .install/all 
+install: document .install/all 
 check: install .check/all
 test: install .test/all 
 
@@ -49,6 +49,11 @@ test: install .test/all
 
 $(MODELS_I): $(MODULES_I)
 
+# These two blocks are redunant for now because dependencies need to be 
+# specified separately for installation and documentation. I have some ideas 
+# about how to fix this, but it's not a priority. For now, just make sure to 
+# add dependencies for any new package into here.
+
 .install/db: .install/utils
 .install/settings: .install/utils .install/db
 .install/visualization: .install/db
@@ -57,6 +62,15 @@ $(MODELS_I): $(MODULES_I)
 .install/modules/meta.analysis: .install/utils .install/db
 .install/modules/priors: .install/utils
 .install/modules/rtm: .install/modules/assim.batch
+
+.doc/db: .doc/utils
+.doc/settings: .doc/utils .doc/db
+.doc/visualization: .doc/db
+.doc/modules/data.atmosphere: .doc/utils
+.doc/modules/data.land: .doc/db .doc/utils
+.doc/modules/meta.analysis: .doc/utils .doc/db
+.doc/modules/priors: .doc/utils
+.doc/modules/rtm: .doc/modules/assim.batch
 
 clean:
 	rm -rf .install .check .test .doc
@@ -79,22 +93,22 @@ doc_R_pkg = Rscript -e "devtools::document('"$(strip $(1))"')"
 $(ALL_PKGS_I) $(ALL_PKGS_C) $(ALL_PKGS_T) $(ALL_PKGS_D): .install/devtools
 
 .SECONDEXPANSION:
-.doc/%: $$(wildcard %/**/*)
+.doc/%: $$(wildcard %/**/*) $$(wildcard %/*)
 	$(call doc_R_pkg, $(subst .doc/,,$@))
 	mkdir -p $(@D)
 	echo `date` > $@
 
-.install/%: $$(wildcard %/**/*)
+.install/%: $$(wildcard %/**/*) $$(wildcard %/*)
 	$(call install_R_pkg, $(subst .install/,,$@))
 	mkdir -p $(@D)
 	echo `date` > $@
 
-.check/%: $$(wildcard %/**/*)
+.check/%: $$(wildcard %/**/*) $$(wildcard %/*)
 	$(call check_R_pkg, $(subst .check/,,$@))
 	mkdir -p $(@D)
 	echo `date` > $@
 
-.test/%: $$(wildcard %/**/*)
+.test/%: $$(wildcard %/**/*) $$(wildcard %/*)
 	$(call test_R_pkg, $(subst .test/,,$@))
 	mkdir -p $(@D)
 	echo `date` > $@

--- a/db/man/get.trait.data.Rd
+++ b/db/man/get.trait.data.Rd
@@ -16,7 +16,7 @@ get.trait.data(pfts, modeltype, dbfiles, database, forceupdate,
 
 \item{database}{database connection parameters}
 
-\item{forceupdate}{set this to true to force an update, auto will check to see if an update is needed.}
+\item{forceupdate}{set this to true to force an update, false to check to see if an update is needed.}
 
 \item{trait.names}{list of traits to query. If TRUE, uses trait.dictionary}
 }

--- a/db/man/get.trait.data.pft.Rd
+++ b/db/man/get.trait.data.pft.Rd
@@ -4,7 +4,7 @@
 \alias{get.trait.data.pft}
 \title{Gets trait data from the database}
 \usage{
-get.trait.data.pft(pft, modeltype, dbfiles, dbcon, forceupdate = TRUE,
+get.trait.data.pft(pft, modeltype, dbfiles, dbcon, forceupdate = FALSE,
   trait.names = traitdictionary$id)
 }
 \arguments{

--- a/settings/DESCRIPTION
+++ b/settings/DESCRIPTION
@@ -12,7 +12,7 @@ Require: hdf5
 Description: Contains functions to read PEcAn settings files
 Depends:
     PEcAn.utils,
-    PEcAn.DB,
+    PEcAn.DB
 Imports:
     plyr (>= 1.8.4),
     lubridate (>= 1.6.0),

--- a/utils/man/do.conversions.Rd
+++ b/utils/man/do.conversions.Rd
@@ -4,7 +4,7 @@
 \alias{do.conversions}
 \title{do.conversions}
 \usage{
-do.conversions(settings)
+do.conversions(settings, overwrite.met = FALSE, overwrite.fia = FALSE)
 }
 \description{
 Input conversion workflow


### PR DESCRIPTION
## Description
* Fix Makefile dependencies so that required installs happen before documentation.
* Fix Makefile bug where package root directory (DESCRIPTION, NAMESPACE, etc.) was ignored in rules
* Fix trailing comma in `settings/DESCRIPTION` file `Depends` field.
* Update documentation for a few packages where it was out of date (just running `roxygenize`).

## Motivation and Context
Suppose `pkg2` depends on `pkg1`. `devtools::document('pkg2')` will fail if `pkg1` is not installed. However, we want to do `devtools::document('pkg1')` before installing `pkg1` to update the `NAMESPACE` and documentation. This package implements this logic into the Makefile. See discussion in issue #1148 .

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.