### PR TITLE
Fix query.format.vars calls in PDA

### DIFF
--- a/modules/assim.batch/DESCRIPTION
+++ b/modules/assim.batch/DESCRIPTION
@@ -12,6 +12,7 @@ Description: The Predictive Ecosystem Carbon Analyzer (PEcAn) is a scientific
     efficacy of scientific investigation.
 Depends:
     PEcAn.utils,
+    PEcAn.visualization,
     ellipse,
     IDPmisc
 Imports:

--- a/modules/assim.batch/R/pda.bayesian.tools.R
+++ b/modules/assim.batch/R/pda.bayesian.tools.R
@@ -44,15 +44,17 @@ pda.bayesian.tools <- function(settings, params.id = NULL, param.names = NULL, p
     con <- NULL
   }
   
+  bety <- PEcAn.visualization::betyConnect("~/pecan/web/config.php")
+  
   ## Load priors
-  temp        <- pda.load.priors(settings, con)
+  temp        <- pda.load.priors(settings, bety$con)
   prior.list  <- temp$prior
   settings    <- temp$settings
   pname       <- lapply(prior.list, rownames)
   n.param.all <- sapply(prior.list, nrow)
   
   ## Load data to assimilate against
-  inputs  <- load.pda.data(settings, con)
+  inputs  <- load.pda.data(settings, bety)
   n.input <- length(inputs)
   
   ## Set model-specific functions
@@ -124,7 +126,7 @@ pda.bayesian.tools <- function(settings, params.id = NULL, param.names = NULL, p
     start.model.runs(settings, settings$database$bety$write)
     
     ## Read model outputs
-    model.out <- pda.get.model.output(settings, run.id, con, inputs)
+    model.out <- pda.get.model.output(settings, run.id, bety, inputs)
     
     ## calculate and return likelihood
     pda.calc.llik(settings, con, model.out, run.id, inputs, llik.fn)

--- a/modules/assim.batch/R/pda.emulator.R
+++ b/modules/assim.batch/R/pda.emulator.R
@@ -54,16 +54,18 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
   } else {
     con <- NULL
   }
+
+  bety <- PEcAn.visualization::betyConnect("~/pecan/web/config.php")
   
   ## Load priors
-  temp        <- pda.load.priors(settings, con, path.flag)
+  temp        <- pda.load.priors(settings, bety$con, path.flag)
   prior.list  <- temp$prior
   settings    <- temp$settings
   pname       <- lapply(prior.list, rownames)
   n.param.all <- sapply(prior.list, nrow)
   
   ## Load data to assimilate against
-  inputs      <- load.pda.data(settings, con)
+  inputs      <- load.pda.data(settings, bety)
   n.input     <- length(inputs)
   
   ## Set model-specific functions
@@ -185,7 +187,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
     
     for (i in seq_len(settings$assim.batch$n.knot)) {
       ## read model outputs
-      model.out[[i]] <- pda.get.model.output(settings, run.ids[i], con, inputs)
+      model.out[[i]] <- pda.get.model.output(settings, run.ids[i], bety, inputs)
       
       ## calculate likelihood
       LL.0[i] <- pda.calc.llik(settings, con, model.out = model.out[[i]], 

--- a/modules/assim.batch/R/pda.get.model.output.R
+++ b/modules/assim.batch/R/pda.get.model.output.R
@@ -8,7 +8,7 @@
 ##'
 ##' @author Ryan Kelly, Istem Fer
 ##' @export
-pda.get.model.output <- function(settings, run.id, con, inputs) {
+pda.get.model.output <- function(settings, run.id, bety, inputs) {
   
   library(PEcAn.benchmark)
   library(PEcAn.utils)
@@ -33,7 +33,7 @@ pda.get.model.output <- function(settings, run.id, con, inputs) {
     # if no derivation is requested expr will be the same as variable name
     expr <- lapply(variable.name, `[[`, "expression")
     
-    format <- query.format.vars(settings$assim.batch$inputs[[k]]$input.id, con)
+    format <- query.format.vars(settings$assim.batch$inputs[[k]]$input.id, bety)
     
     for(l in seq_along(model.var)){
       
@@ -109,9 +109,9 @@ pda.get.model.output <- function(settings, run.id, con, inputs) {
     # the model output is since the beginning of the year but 'settings$run$start.date' may not be the first day of the year, using lubridate::floor_date
     model$posix <- seq.POSIXt(from = lubridate::floor_date(as.POSIXlt(settings$run$start.date, tz="GMT"), "year"), by = diff(model.secs)[1], length.out = length(model$time))
     
-    dat <- align.data(model_full = model, obvs_full = inputs[[k]]$data, dat_vars = data.var, 
+    dat <- PEcAn.benchmark::align.data(model.calc = model, obvs.calc = inputs[[k]]$data, var = data.var, 
                       start_year = start.year, end_year = end.year, align_method = inputs[[k]]$align.method)
-    
+
     model.out[[k]] <- dat[,colnames(dat) %in% paste0(data.var,".m"), drop = FALSE]
     colnames(model.out[[k]]) <- data.var
   }

--- a/modules/assim.batch/R/pda.load.data.R
+++ b/modules/assim.batch/R/pda.load.data.R
@@ -10,7 +10,7 @@
 ##'
 ##' @author Ryan Kelly, Istem Fer
 ##' @export
-load.pda.data <- function(settings, con) {
+load.pda.data <- function(settings, bety) {
   
   library(PEcAn.benchmark)
   
@@ -39,7 +39,7 @@ load.pda.data <- function(settings, con) {
       logger.error("Must provide both ID and PATH for all data assimilation inputs.")
     }
     
-    format <- query.format.vars(inputs[[i]]$input.id, con)
+    format <- query.format.vars(inputs[[i]]$input.id, bety)
     
     vars.used.index <- which(format$vars$bety_name %in% data.var)
     

--- a/modules/assim.batch/R/pda.mcmc.R
+++ b/modules/assim.batch/R/pda.mcmc.R
@@ -41,15 +41,17 @@ pda.mcmc <- function(settings, params.id = NULL, param.names = NULL, prior.id = 
     con <- NULL
   }
   
+  bety <- PEcAn.visualization::betyConnect("~/pecan/web/config.php")
+  
   ## Load priors
-  temp        <- pda.load.priors(settings, con)
+  temp        <- pda.load.priors(settings, bety$con)
   prior.list  <- temp$prior
   settings    <- temp$settings
   pname       <- lapply(prior.list, rownames)
   n.param.all <- sapply(prior.list, nrow)
   
   ## Load data to assimilate against
-  inputs  <- load.pda.data(settings, con)
+  inputs  <- load.pda.data(settings, bety)
   n.input <- length(inputs)
   
   ## Set model-specific functions
@@ -183,7 +185,7 @@ pda.mcmc <- function(settings, params.id = NULL, param.names = NULL, prior.id = 
           start.model.runs(settings, settings$database$bety$write)
           
           ## Read model outputs
-          model.out <- pda.get.model.output(settings, run.id, con, inputs)
+          model.out <- pda.get.model.output(settings, run.id, bety, inputs)
           
           ## Calculate likelihood (and store in database)
           LL.new <- pda.calc.llik(settings, con, model.out, run.id, inputs, llik.fn)

--- a/modules/assim.batch/R/pda.mcmc.bs.R
+++ b/modules/assim.batch/R/pda.mcmc.bs.R
@@ -48,15 +48,17 @@ pda.mcmc.bs <- function(settings, params.id = NULL, param.names = NULL, prior.id
     con <- NULL
   }
   
+  bety <- PEcAn.visualization::betyConnect("~/pecan/web/config.php")
+  
   ## Load priors
-  temp        <- pda.load.priors(settings, con)
+  temp        <- pda.load.priors(settings, bety$con)
   prior.list  <- temp$prior
   settings    <- temp$settings
   pname       <- lapply(prior.list, rownames)
   n.param.all <- sapply(prior.list, nrow)
   
   ## Load data to assimilate against
-  inputs  <- load.pda.data(settings, con)
+  inputs  <- load.pda.data(settings, bety)
   n.input <- length(inputs)
   
   ## Set model-specific functions
@@ -184,7 +186,7 @@ pda.mcmc.bs <- function(settings, params.id = NULL, param.names = NULL, prior.id
         start.model.runs(settings, settings$database$bety$write)
         
         ## Read model outputs
-        model.out <- pda.get.model.output(settings, run.id, con, inputs)
+        model.out <- pda.get.model.output(settings, run.id, bety, inputs)
         
         ## Calculate likelihood (and store in database)
         LL.new <- pda.calc.llik(settings, con, model.out, run.id, inputs, llik.fn)

--- a/modules/assim.batch/R/pda.utils.R
+++ b/modules/assim.batch/R/pda.utils.R
@@ -623,7 +623,7 @@ pda.plot.params <- function(settings, mcmc.param.list, prior.ind) {
   for (i in seq_along(settings$pfts)) {
     params.subset[[i]] <- as.mcmc.list(lapply(mcmc.param.list[[i]], mcmc))
     
-    burnin <- getBurnin(params.subset[[i]])
+    burnin <- getBurnin(params.subset[[i]], method = "gelman.plot")
     
     # rare, but this can happen; better to throw an error than continue, as it might lead
     # mis-interpretation of posteriors otherwise

--- a/modules/assim.batch/man/load.pda.data.Rd
+++ b/modules/assim.batch/man/load.pda.data.Rd
@@ -7,7 +7,7 @@
 \usage{
 load.L2Ameriflux.cf(file.in)
 
-load.pda.data(settings, con)
+load.pda.data(settings, bety)
 }
 \arguments{
 \item{file.in}{= the netcdf file of L2 data}

--- a/modules/assim.batch/man/pda.get.model.output.Rd
+++ b/modules/assim.batch/man/pda.get.model.output.Rd
@@ -4,7 +4,7 @@
 \alias{pda.get.model.output}
 \title{Get Model Output for PDA}
 \usage{
-pda.get.model.output(settings, run.id, con, inputs)
+pda.get.model.output(settings, run.id, bety, inputs)
 }
 \arguments{
 \item{all}{params are the identically named variables in pda.mcmc / pda.emulator}

--- a/modules/benchmark/R/align.data.R
+++ b/modules/benchmark/R/align.data.R
@@ -20,6 +20,8 @@ align.data <- function(model.calc, obvs.calc, var, start_year, end_year, align_m
   diff.m <- diff(model.calc$posix)
   diff.o <- diff(obvs.calc$posix)
   
+  units(diff.m) <- units(diff.o) <- max(units(diff.m),units(diff.o))
+  
   mode.m <- as.numeric(diff.m[which.max(tabulate(match(unique(diff.m), diff.m)))])
   mode.o <- as.numeric(diff.o[which.max(tabulate(match(unique(diff.o), diff.o)))])
   max.diff <- if(mode.m > mode.o) diff.m else diff.o
@@ -40,7 +42,6 @@ align.data <- function(model.calc, obvs.calc, var, start_year, end_year, align_m
     obvs <- obvs.calc[obvs.calc$posix >= rng_dat[1] & obvs.calc$posix <= rng_dat[2], ]
   }
 
-  # units(diff.m) <- units(diff.o) <- "secs"
   
   if (mode.m > mode.o) {
     date.coarse <- model$posix

--- a/modules/benchmark/R/match.timestep.R
+++ b/modules/benchmark/R/match.timestep.R
@@ -10,5 +10,5 @@ match.timestep <- function(date.coarse, date.fine, data.fine) {
   
   midpoints <- c(-Inf, head(as.numeric(date.fine), -1)) + c(0, diff(as.numeric(date.fine)) / 2)
   
-  return(data.fine[unique(findInterval(date.coarse, midpoints))])
+  return(data.fine[findInterval(date.coarse, midpoints)])
 } # match.timestep

--- a/modules/benchmark/R/match.timestep.R
+++ b/modules/benchmark/R/match.timestep.R
@@ -6,9 +6,9 @@
 ##' @export match.timestep
 ##' 
 ##' @author Istem Fer
-match.timestep <- function(date_coarse, date_fine, data_fine) {
+match.timestep <- function(date.coarse, date.fine, data.fine) {
   
-  midpoints <- c(-Inf, head(date_fine, -1)) + c(0, diff(as.numeric(date_fine)) / 2)
+  midpoints <- c(-Inf, head(as.numeric(date.fine), -1)) + c(0, diff(as.numeric(date.fine)) / 2)
   
-  return(data_fine[findInterval(date_coarse, midpoints)])
+  return(data.fine[unique(findInterval(date.coarse, midpoints))])
 } # match.timestep


### PR DESCRIPTION
Minor bugfixes in the PDA code after recent benchmark changes

## Description
Changed` query.format.vars` calls to use `dplyr` connection.
Also addressed some of the changes in align.data and fixed one minor bug. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
