### PR TITLE
Fixing error where query.format.vars fails for more than one variable

### DIFF
--- a/db/R/query.format.vars.R
+++ b/db/R/query.format.vars.R
@@ -40,7 +40,7 @@ query.format.vars <- function(bety,input.id=NA,format.id=NA,var.ids=NA){
   # get variable names and units of input data
   fv <- db.query(paste("SELECT variable_id,name,unit,storage_type,column_number from formats_variables where format_id = ", f$id),con)
   
-  if(!is.na(var.ids)){
+  if(all(!is.na(var.ids))){
     # Need to subset the formats table
     fv <- fv %>% dplyr::filter(variable_id %in% var.ids | storage_type != "") 
   }


### PR DESCRIPTION
One line change in code `query.format.vars.R`
I had an if statement with condition length > 1.