### PR TITLE
Data tunnel part 2

### DIFF
--- a/utils/R/convert.input.R
+++ b/utils/R/convert.input.R
@@ -67,13 +67,13 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                         files.to.delete <- remote.execute.R( paste0("list.files('",
                                                              existing.dbfile[["file_path"]],
                                                              "', full.names=TRUE)"),
-                                                             host, user = NA, verbose = TRUE,R = Rbinary)
+                                                             host, user = NA, verbose = TRUE,R = Rbinary, scratchdir = outdir)
       
                         file.deletion.commands <- .get.file.deletion.commands(files.to.delete)
       
                         remote.execute.R( file.deletion.commands$move.to.tmp,
                                           host, user = NA, 
-                                          verbose = TRUE,R = Rbinary)
+                                          verbose = TRUE,R = Rbinary, scratchdir = outdir)
       
                        
                         # Schedule files to be replaced or deleted on exiting the function
@@ -83,13 +83,13 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                                     logger.info("Conversion successful, with overwrite=TRUE. Deleting old files.")
                                     remote.execute.R( file.deletion.commands$delete.tmp, 
                                                       host, user = NA, 
-                                                      verbose = TRUE,  R = Rbinary )
+                                                      verbose = TRUE,  R = Rbinary, scratchdir = outdir )
                           
                                 } else {
                                     logger.info("Conversion failed. Replacing old files.")
                                     remote.execute.R( file.deletion.commands$replace.from.tmp, 
                                                       host, user = NA, 
-                                                      verbose = TRUE, R = Rbinary )
+                                                      verbose = TRUE, R = Rbinary, scratchdir = outdir )
                                 }
                         )#Close on.exit
                         
@@ -144,13 +144,13 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                         files.to.delete <- remote.execute.R( paste0("list.files('",
                                                                     existing.dbfile[["file_path"]],
                                                                     "', full.names=TRUE)"),
-                                                                     host, user = NA, verbose = TRUE,R = Rbinary)
+                                                                     host, user = NA, verbose = TRUE,R = Rbinary, scratchdir = outdir)
           
                         file.deletion.commands <- .get.file.deletion.commands(files.to.delete)
           
                         remote.execute.R( file.deletion.commands$move.to.tmp,
                                           host, user = NA, 
-                                          verbose = TRUE,R = Rbinary)
+                                          verbose = TRUE,R = Rbinary, scratchdir = outdir)
           
                         # Schedule files to be replaced or deleted on exiting the function
                         successful <- FALSE
@@ -159,14 +159,14 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                                     logger.info("Conversion successful, with overwrite=TRUE. Deleting old files.")
                                     remote.execute.R( file.deletion.commands$delete.tmp,
                                                       host, user = NA, 
-                                                      verbose = TRUE,  R = Rbinary )
+                                                      verbose = TRUE,  R = Rbinary, scratchdir = outdir )
             
                                     } else {
                                       
                                     logger.info("Conversion failed. Replacing old files.")
                                     remote.execute.R( file.deletion.commands$replace.from.tmp,
                                                       host, user = NA,
-                                                      verbose = TRUE, R = Rbinary )
+                                                      verbose = TRUE, R = Rbinary, scratchdir = outdir )
                                     } 
                         )#close on on.exit
           
@@ -361,7 +361,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
     cmdFcn <- paste0(pkg, "::", fcn, "(", arg.string, ")")
     logger.debug(paste0("convert.input executing the following function:\n", cmdFcn))
     
-    result <- remote.execute.R(script = cmdFcn, host, user = NA, verbose = TRUE, R = Rbinary)
+    result <- remote.execute.R(script = cmdFcn, host, user = NA, verbose = TRUE, R = Rbinary, scratchdir = outdir)
   }
   
   logger.info("RESULTS: Convert.Input")

--- a/utils/R/remote.R
+++ b/utils/R/remote.R
@@ -244,9 +244,6 @@ remote.execute.R <- function(script, host = "localhost", user = NA, verbose = FA
       remote <- c("-l", host$user, remote)
     }
     logger.debug(paste(c("ssh", "-T", remote, R), collapse = " "))
-#    result <- system2("ssh", c("-T", remote, R, "--vanilla"), stdout = verbose, 
-#    result <- system2("ssh", c("-T", remote, paste0(R, "script")), stdout = verbose, 
-#                                            stderr = verbose, input = input)
     result <- system2("ssh", c("-T", remote, R, "--no-save","--no-restore"), stdout = verbose,  
                       stderr = verbose, input = input)
     remote.copy.from(host, tmpfile, uuid)

--- a/utils/R/remote.R
+++ b/utils/R/remote.R
@@ -85,8 +85,10 @@ remote.copy.from <- function(host, src, dst, delete = FALSE, stderr = FALSE) {
   if (is.localhost(host)) {
     args <- c(args, src, dst)
   } else {
-    tunnel <- ifelse(is.null(host$data_tunnel),host$tunnel,host$data_tunnel)
-    hostname <- ifelse(is.null(host$data_hostname),host$name,host$data_hostname)
+    tunnel <- host$tunnel
+    if(!is.null(host$data_tunnel)) tunnel <- host$data_tunnel
+    hostname <- host$name
+    if(!is.null(host$data_hostname)) hostname <- host$data_hostname
     if (!is.null(tunnel)) {
       if (!file.exists(tunnel)) {
         logger.severe("Could not find tunnel", tunnel)
@@ -133,8 +135,10 @@ remote.copy.to <- function(host, src, dst, delete = FALSE, stderr = FALSE) {
   if (is.localhost(host)) {
     args <- c(args, src, dst)
   } else {
-    tunnel <- ifelse(is.null(host$data_tunnel),host$tunnel,host$data_tunnel)
-    hostname <- ifelse(is.null(host$data_hostname),host$name,host$data_hostname)
+    tunnel <- host$tunnel
+    if(!is.null(host$data_tunnel)) tunnel <- host$data_tunnel
+    hostname <- host$name
+    if(!is.null(host$data_hostname)) hostname <- host$data_hostname
     if (!is.null(tunnel)) {
       if (!file.exists(tunnel)) {
         logger.severe("Could not find tunnel", tunnel)

--- a/utils/R/remote.R
+++ b/utils/R/remote.R
@@ -240,7 +240,10 @@ remote.execute.R <- function(script, host = "localhost", user = NA, verbose = FA
       remote <- c("-l", host$user, remote)
     }
     logger.debug(paste(c("ssh", "-T", remote, R), collapse = " "))
-    result <- system2("ssh", c("-T", remote, R, "--vanilla"), stdout = verbose, 
+#    result <- system2("ssh", c("-T", remote, R, "--vanilla"), stdout = verbose, 
+#    result <- system2("ssh", c("-T", remote, paste0(R, "script")), stdout = verbose, 
+#                                            stderr = verbose, input = input)
+    result <- system2("ssh", c("-T", remote, R, "--no-save","--no-restore"), stdout = verbose,  
                       stderr = verbose, input = input)
     remote.copy.from(host, tmpfile, uuid)
     remote.execute.cmd(host, "rm", c("-f", tmpfile))

--- a/utils/inst/LBNL_remote_test.R
+++ b/utils/inst/LBNL_remote_test.R
@@ -1,0 +1,50 @@
+## testing LBL remote
+
+setwd("~/git/pecan/web")
+
+## connection settings
+## define 'pass' as Google Authenticator current password (string)
+exe_host <- "lrc-login.lbl.gov"
+data_host <- "lrc-xfer.lbl.gov"
+user <- 'dietze'
+tunnelDir <- "/tmp/LBNL"
+exeDir <- file.path(tunnelDir,"exe")
+dataDir <- file.path(tunnelDir,"data")
+dir.create(exeDir)
+dir.create(dataDir)
+R <- "/global/software/sl-6.x86_64/modules/langs/r/3.2.5/bin/R"
+
+##open connections
+write(pass,file.path(exeDir,"password"))
+con1 <- system2("./sshtunnel.sh",c(exe_host,user,exeDir,">",file.path(exeDir,"log"),"&"))
+file.remove(file.path(exeDir,"password"))
+
+write(pass,file.path(dataDir,"password"))
+con2 <- system2("./sshtunnel.sh",c(data_host,user,dataDir,">",file.path(dataDir,"log"),"&"))
+file.remove(file.path(dataDir,"password"))
+
+## build host list
+host <- list(name=exe_host,
+             data_hostname = data_host,
+             tunnel = file.path(exeDir,"tunnel"),
+             data_tunnel = file.path(dataDir,"tunnel"),
+             Rbinary = R)
+settings <- list(host=host)
+
+
+## test remote.copy.to
+PEcAn.utils::remote.copy.to(host,"favicon.ico","~/favicon.ico")
+
+## test remote.execute.cmd
+foo <- PEcAn.utils::remote.execute.cmd(host,"pwd")
+print(foo)
+PEcAn.utils::remote.execute.cmd(host,"mv",c("/global/home/users/dietze/favicon.ico","/global/home/users/dietze/favicon.jpg"))
+
+## test remote.copy.from
+PEcAn.utils::remote.copy.from(host,"~/favicon.jpg","favicon.jpg")
+
+## test remote.execute.R
+b <- PEcAn.utils::remote.execute.R(script = "return(1)",host = host,R=R,verbose=TRUE,scratchdir="/global/scratch/dietze/")
+
+## kill tunnels
+PEcAn.utils::kill.tunnel(settings)

--- a/utils/inst/LBNL_remote_test.R
+++ b/utils/inst/LBNL_remote_test.R
@@ -46,5 +46,10 @@ PEcAn.utils::remote.copy.from(host,"~/favicon.jpg","favicon.jpg")
 ## test remote.execute.R
 b <- PEcAn.utils::remote.execute.R(script = "return(1)",host = host,R=R,verbose=TRUE,scratchdir="/global/scratch/dietze/")
 
+c <- PEcAn.utils::remote.execute.R(script = "return(require(PEcAn.data.atmosphere))",host = host,R=R,verbose=TRUE,scratchdir="/global/scratch/dietze/")
+
+d <- PEcAn.utils::remote.execute.R(script = "return(.libPaths())",host = host,R=R,verbose=TRUE,scratchdir="/global/scratch/dietze/")
+
+
 ## kill tunnels
 PEcAn.utils::kill.tunnel(settings)


### PR DESCRIPTION
A few small additional tweaks to data tunnel work:

1) ability to specify alternative location for temporary files on remote in remote.execute.R. Change is in response to /tmp not being global on LBNL cluster

2) requested ifelse changes from @ashiklom 

3) changes away from R --vanilla in remote.execute.R. Also suggested by @ashiklom and required for R to be able to find R_LIB_USER on some remote systems

4) documenting the test script I've been using to get things working on the LBNL cluster