### PR TITLE
minor fixes after VM tests

### DIFF
--- a/modules/assim.batch/DESCRIPTION
+++ b/modules/assim.batch/DESCRIPTION
@@ -16,6 +16,7 @@ Depends:
     ellipse,
     dplyr,
     parallel,
+    GPfit,
     IDPmisc
 Imports:
     coda (>= 0.18),

--- a/modules/assim.batch/R/pda.emulator.R
+++ b/modules/assim.batch/R/pda.emulator.R
@@ -291,9 +291,8 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
     }
       
     logger.info(paste0("Using 'GPfit' package for Gaussian Process Model fitting."))
-    library(GPfit)
     ## Generate emulator on SS, return a list
-    GPmodel <- lapply(SS, function(x) GP_fit(X = x[, -ncol(x), drop = FALSE], Y = x[, ncol(x), drop = FALSE]))
+    GPmodel <- lapply(SS, function(x) GPfit::GP_fit(X = x[, -ncol(x), drop = FALSE], Y = x[, ncol(x), drop = FALSE]))
     gp <- GPmodel
       
   } else { # is this a "longer" type of extension run
@@ -364,7 +363,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
   
   # prepare for parallelization
   dcores <- parallel::detectCores() - 1
-  ncores <- min(dcores, settings$assim.batch$chain)
+  ncores <- min(max(dcores, 1), settings$assim.batch$chain)
   cl <- parallel::makeCluster(ncores, type="FORK")
   
   ## Sample posterior from emulator

--- a/modules/emulator/DESCRIPTION
+++ b/modules/emulator/DESCRIPTION
@@ -7,6 +7,7 @@ Author: Michael Dietze
 Maintainer: Michael Dietze <dietze@bu.edu>
 Depends:
     mvtnorm,
+    GPfit,
     MCMCpack
 Imports:
     coda (>= 0.18),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- Forgot the case for parallelization where detect cores can return 1.

- Also added `GPfit` package to the `Depends`, package was not installed to the VM. Do I need to put the package dependency somewhere else so that it will be installed while VM is created?

- And[ this file ](https://psql-pecan.bu.edu/bety/inputs/1000002080) needs to be in the VM I think, if we want to use it in the PDA @robkooper @mdietze?



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

