### PR TITLE
pda.emulator: history restart

### DIFF
--- a/models/fates/inst/template.job
+++ b/models/fates/inst/template.job
@@ -158,6 +158,7 @@ EOF
   # write tag so future execution knows run finished
   echo $(date) >> "@OUTDIR@/pecan.done"
 
+  sleep 60
 
 # all done
 echo -e "MODEL FINISHED\nLogfile is located at '@OUTDIR@/logfile.txt'" >&3

--- a/modules/assim.batch/R/pda.emulator.R
+++ b/modules/assim.batch/R/pda.emulator.R
@@ -134,7 +134,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
   print(names(knots.params))
   print(names(knots.probs))
   current.step <- "GENERATE KNOTS"
-  save.image(pda.restart.file)
+  save(list = ls(all.names = TRUE),envir=environment(),file=pda.restart.file)
   
   ## Run this block if this is a "round" extension
   if (run.round) {
@@ -193,7 +193,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
       knots.params <- lapply(knots.list, `[[`, "params")
       knots.probs  <- lapply(knots.list, `[[`, "probs")
       current.step <- "Generate Knots: round-if block"
-      save.image(pda.restart.file)
+      save(list = ls(all.names = TRUE),envir=environment(),file=pda.restart.file)
   } # end round-if block
   
   ## Run this block if this is normal run or a "round" extension
@@ -205,7 +205,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
                             run.names = paste0(settings$assim.batch$ensemble.id, ".knot.",
                                                1:settings$assim.batch$n.knot))   
       current.step <- "pda.init.run"
-      save.image(pda.restart.file)
+      save(list = ls(all.names = TRUE),envir=environment(),file=pda.restart.file)
       
       ## start model runs
       start.model.runs(settings, settings$database$bety$write)
@@ -220,7 +220,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
         model.out[[i]] <- pda.get.model.output(settings, run.ids[i], bety, inputs)
       }
       current.step <- "pda.get.model.output"
-      save.image(pda.restart.file)
+      save(list = ls(all.names = TRUE),envir=environment(),file=pda.restart.file)
       
       # handle bias parameters if multiplicative Gaussian is listed in the likelihoods
       if(any(unlist(any.mgauss) == "multipGauss")) {
@@ -248,7 +248,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
     
   } # end if-block
   current.step <- "pda.calc.error"
-  save.image(pda.restart.file)
+  save(list = ls(all.names = TRUE),envir=environment(),file=pda.restart.file)
   
   init.list <- list()
   jmp.list <- list()
@@ -388,7 +388,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
   ncores <- min(max(dcores, 1), settings$assim.batch$chain)
   cl <- parallel::makeCluster(ncores, type="FORK")
   current.step <- "pre-MCMC"
-  save.image(pda.restart.file)
+  save(list = ls(all.names = TRUE),envir=environment(),file=pda.restart.file)
   
   ## Sample posterior from emulator
   mcmc.out <- parallel::parLapply(cl, 1:settings$assim.batch$chain, function(chain) {
@@ -411,7 +411,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
   
   parallel::stopCluster(cl)
   current.step <- "post-MCMC"
-  save.image(pda.restart.file)
+  save(list = ls(all.names = TRUE),envir=environment(),file=pda.restart.file)
   
   mcmc.samp.list <- list()
   
@@ -453,7 +453,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
   
   ## ------------------------------------ Clean up ------------------------------------ 
   current.step <- "clean up"
-  save.image(pda.restart.file)
+  save(list = ls(all.names = TRUE),envir=environment(),file=pda.restart.file)
   
   ## Save emulator, outputs files
   settings$assim.batch$emulator.path <- file.path(settings$outdir,
@@ -525,7 +525,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
   
   ## Output an updated settings list
   current.step <- "pda.finish"
-  save.image(pda.restart.file)
+  save(list = ls(all.names = TRUE),envir=environment(),file=pda.restart.file)
   return(settings)
   
 }  ## end pda.emulator

--- a/modules/assim.batch/R/pda.emulator.R
+++ b/modules/assim.batch/R/pda.emulator.R
@@ -20,6 +20,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
     n.knot <- adapt <- adj.min <- ar.target <- jvar <- NULL
   }
   
+  
   ## -------------------------------------- Setup ------------------------------------- 
   ## Handle settings
   settings <- pda.settings(
@@ -27,6 +28,10 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
     prior.id=prior.id, chain=chain, iter=iter, adapt=adapt, 
     adj.min=adj.min, ar.target=ar.target, jvar=jvar, n.knot=n.knot)
   
+  ## history restart
+  pda.restart.file <- file.path(settings$outdir,paste0("history.pda", 
+                                                       settings$assim.batch$ensemble.id, ".Rdata"))
+  current.step <- "START"
   
   ## will be used to check if multiplicative Gaussian is requested
   any.mgauss <- sapply(settings$assim.batch$inputs, `[[`, "likelihood")
@@ -128,6 +133,8 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
   print(names(knots.list))
   print(names(knots.params))
   print(names(knots.probs))
+  current.step <- "GENERATE KNOTS"
+  save.image(pda.restart.file)
   
   ## Run this block if this is a "round" extension
   if (run.round) {
@@ -185,6 +192,8 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
       
       knots.params <- lapply(knots.list, `[[`, "params")
       knots.probs  <- lapply(knots.list, `[[`, "probs")
+      current.step <- "Generate Knots: round-if block"
+      save.image(pda.restart.file)
   } # end round-if block
   
   ## Run this block if this is normal run or a "round" extension
@@ -194,7 +203,10 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
       run.ids <- pda.init.run(settings, con, my.write.config, workflow.id, knots.params, 
                             n = settings$assim.batch$n.knot, 
                             run.names = paste0(settings$assim.batch$ensemble.id, ".knot.",
-                                               1:settings$assim.batch$n.knot))    
+                                               1:settings$assim.batch$n.knot))   
+      current.step <- "pda.init.run"
+      save.image(pda.restart.file)
+      
       ## start model runs
       start.model.runs(settings, settings$database$bety$write)
     
@@ -207,7 +219,9 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
       for (i in seq_len(settings$assim.batch$n.knot)) {
         model.out[[i]] <- pda.get.model.output(settings, run.ids[i], bety, inputs)
       }
-    
+      current.step <- "pda.get.model.output"
+      save.image(pda.restart.file)
+      
       # handle bias parameters if multiplicative Gaussian is listed in the likelihoods
       if(any(unlist(any.mgauss) == "multipGauss")) {
         # how many bias parameters per dataset requested
@@ -233,7 +247,8 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
       } 
     
   } # end if-block
-  
+  current.step <- "pda.calc.error"
+  save.image(pda.restart.file)
   
   init.list <- list()
   jmp.list <- list()
@@ -321,7 +336,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
       jmp.list[[c]] <- resume.list[[c]]$jump
     }
   }
-    
+  
   # add indice and increase n.param for bias
   if(any(unlist(any.mgauss) == "multipGauss")){
     prior.ind.all <- c(prior.ind.all, 
@@ -372,6 +387,8 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
   dcores <- parallel::detectCores() - 1
   ncores <- min(max(dcores, 1), settings$assim.batch$chain)
   cl <- parallel::makeCluster(ncores, type="FORK")
+  current.step <- "pre-MCMC"
+  save.image(pda.restart.file)
   
   ## Sample posterior from emulator
   mcmc.out <- parallel::parLapply(cl, 1:settings$assim.batch$chain, function(chain) {
@@ -393,6 +410,8 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
   })
   
   parallel::stopCluster(cl)
+  current.step <- "post-MCMC"
+  save.image(pda.restart.file)
   
   mcmc.samp.list <- list()
   
@@ -418,6 +437,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
     resume.list[[c]] <- mcmc.out[[c]]$chain.res
   }
   
+  
   if (FALSE) {
     gp     <- kernlab.gp
     x0     <- init.x
@@ -432,6 +452,9 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
   }
   
   ## ------------------------------------ Clean up ------------------------------------ 
+  current.step <- "clean up"
+  save.image(pda.restart.file)
+  
   ## Save emulator, outputs files
   settings$assim.batch$emulator.path <- file.path(settings$outdir,
                                                   paste0("emulator.pda", 
@@ -501,6 +524,8 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
   }
   
   ## Output an updated settings list
+  current.step <- "pda.finish"
+  save.image(pda.restart.file)
   return(settings)
   
 }  ## end pda.emulator

--- a/modules/assim.batch/inst/FATES_BCI_PDA_demo.Rmd
+++ b/modules/assim.batch/inst/FATES_BCI_PDA_demo.Rmd
@@ -38,3 +38,42 @@
 workflow.id <- 1000003054
 settings <- PEcAn.settings::read.settings(file.path("/fs/data2/output/",paste0("PEcAn_",workflow.id),"pecan.CONFIGS.xml"))
 ```
+
+
+Code snippet to reopen tunnels if loose the connection and/or have to restart from PDA history
+```{r}
+## connection settings
+## define 'pass' as Google Authenticator current password (string)
+pecan     <- "/home/dietze/pecan"
+sshtunnel <- file.path(pecan,"web","sshtunnel.sh")
+exe_host  <- settings$host$name
+data_host <- settings$host$data_hostname
+user      <- settings$host$user
+exeDir    <- dirname(settings$host$tunnel)
+dataDir   <- dirname(settings$host$data_tunnel)
+
+##open connections
+if(!is.null(exe_host)){
+  write(pass,file.path(exeDir,"password"))
+  Sys.sleep(3)
+  con1 <- system2(sshtunnel,c(exe_host,user,exeDir,">",file.path(exeDir,"log"),"&"))
+  file.remove(file.path(exeDir,"password"))
+}
+
+if(!is.null(data_host)){
+  write(pass,file.path(dataDir,"password"))
+  Sys.sleep(3)
+  con2 <- system2(sshtunnel,c(data_host,user,dataDir,">",file.path(dataDir,"log"),"&"))
+  file.remove(file.path(dataDir,"password"))
+}
+
+## check connections
+if(!file.exists(settings$host$tunnel)){
+  system2("more",file.path(exeDir,"log"))
+}
+if(!file.exists(settings$host$data_tunnel)){
+  system2("more",file.path(dataDir,"log"))
+}
+
+```
+

--- a/modules/assim.batch/inst/FATES_BCI_PDA_demo.Rmd
+++ b/modules/assim.batch/inst/FATES_BCI_PDA_demo.Rmd
@@ -35,16 +35,6 @@
 ```
 
 ```{r}
-workflow.id <- 1000003049
-settings <- PEcAn.settings::read.settings(file.path("/fs/data2/output/",paste0("PEcAn_",workflow.id),"pecan.xml"))
-params.id = NULL
-param.names = NULL
-prior.id = NULL
-chain = NULL
-iter = NULL
-adapt = NULL
-adj.min = NULL
-ar.target = NULL
-jvar = NULL
-n.knot = NULL
+workflow.id <- 1000003054
+settings <- PEcAn.settings::read.settings(file.path("/fs/data2/output/",paste0("PEcAn_",workflow.id),"pecan.CONFIGS.xml"))
 ```


### PR DESCRIPTION
Save the internal state of pda.emulator periodically, along with a flag indicating how far we got. Doesn't allow an automated restart from web interface, but does allow you to dive into the console and rerun/debug from that specific step.