### PR TITLE
Revised PDA prior handling

### DIFF
--- a/modules/assim.batch/R/pda.define.llik.R
+++ b/modules/assim.batch/R/pda.define.llik.R
@@ -54,7 +54,7 @@ pda.calc.error <-function(settings, con, model_out, run.id, inputs, bias.terms){
   
   if(anyNA(model_out, recursive = TRUE)) {   # Probably indicates model failed entirely
     NA.list <- as.list(rep(NA, length(inputs)))
-    return(list(NA.list))
+    return(NA.list)
   }
 
   n.input <- length(inputs)

--- a/modules/assim.batch/R/pda.define.llik.R
+++ b/modules/assim.batch/R/pda.define.llik.R
@@ -52,6 +52,10 @@ pda.define.llik.fn <- function(settings) {
 ##' @export
 pda.calc.error <-function(settings, con, model_out, run.id, inputs, bias.terms){
   
+  if(anyNA(model_out, recursive = TRUE)) {   # Probably indicates model failed entirely
+    NA.list <- as.list(rep(NA, length(inputs)))
+    return(list(NA.list))
+  }
 
   n.input <- length(inputs)
   pda.errors <- list()

--- a/modules/assim.batch/R/pda.emulator.R
+++ b/modules/assim.batch/R/pda.emulator.R
@@ -20,18 +20,6 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
     n.knot <- adapt <- adj.min <- ar.target <- jvar <- NULL
   }
   
-  ## -------------------------------------- Setup ------------------------------------- 
-  ## Handle settings
-  settings <- pda.settings(
-    settings=settings, params.id=params.id, param.names=param.names, 
-    prior.id=prior.id, chain=chain, iter=iter, adapt=adapt, 
-    adj.min=adj.min, ar.target=ar.target, jvar=jvar, n.knot=n.knot)
-  
-  
-  ## will be used to check if multiplicative Gaussian is requested
-  any.mgauss <- sapply(settings$assim.batch$inputs, `[[`, "likelihood")
-  isbias <- which(unlist(any.mgauss) == "multipGauss")
-  
   # handle extention flags
   # is this an extension run
   extension.check <- is.null(settings$assim.batch$extension) 
@@ -52,6 +40,19 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
     run.round <- FALSE
     run.longer <- TRUE
   }
+  
+  ## -------------------------------------- Setup ------------------------------------- 
+  ## Handle settings
+  settings <- pda.settings(
+    settings=settings, params.id=params.id, param.names=param.names, 
+    prior.id=prior.id, chain=chain, iter=iter, adapt=adapt, 
+    adj.min=adj.min, ar.target=ar.target, jvar=jvar, n.knot=n.knot, run.round)
+  
+  
+  ## will be used to check if multiplicative Gaussian is requested
+  any.mgauss <- sapply(settings$assim.batch$inputs, `[[`, "likelihood")
+  isbias <- which(unlist(any.mgauss) == "multipGauss")
+  
   
   ## Open database connection
   if (settings$database$bety$write) {

--- a/modules/assim.batch/R/pda.emulator.R
+++ b/modules/assim.batch/R/pda.emulator.R
@@ -128,11 +128,11 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
   ## Run this block if this is a "round" extension
   if (run.round) {
       
-      # loads the priors used in the previous emulator run
+      # loads the posteriors of the the previous emulator run
       temp <- pda.load.priors(settings, con, extension.check = TRUE) 
       prior.list <- temp$prior
       
-      ## set prior distribution functions for prior of the previous emulator run
+      ## set prior distribution functions for posterior of the previous emulator run
       prior.fn <- lapply(prior.list, pda.define.prior.fn)
       
       ## Propose a percentage (if not specified 75%) of the new parameter knots from the posterior of the previous run

--- a/modules/assim.batch/R/pda.emulator.R
+++ b/modules/assim.batch/R/pda.emulator.R
@@ -129,16 +129,16 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
   if (run.round) {
       
       # loads the priors used in the previous emulator run
-      temp.ext <- pda.load.priors(settings, con, run.normal) 
-      prior.ext.list <- temp.ext$prior
+      temp <- pda.load.priors(settings, con, extension.check = TRUE) 
+      prior.list <- temp$prior
       
       ## set prior distribution functions for prior of the previous emulator run
-      prior.ext.fn <- lapply(prior.ext.list, pda.define.prior.fn)
+      prior.fn <- lapply(prior.list, pda.define.prior.fn)
       
-      ## Propose a percentage (if not specified 25%) of the new parameter knots from the prior of previous run
+      ## Propose a percentage (if not specified 75%) of the new parameter knots from the posterior of the previous run
       knot.par        <- ifelse(!is.null(settings$assim.batch$knot.par), 
                                 as.numeric(settings$assim.batch$knot.par), 
-                                0.25)
+                                0.75)
       
       n.post.knots    <- floor(knot.par * settings$assim.batch$n.knot)
       
@@ -146,7 +146,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
                                 function(x) pda.generate.knots(n.post.knots, 
                                                                n.param.all[x], 
                                                                prior.ind[[x]],
-                                                               prior.ext.fn[[x]],
+                                                               prior.fn[[x]],
                                                                pname[[x]]))
       knots.params.temp <- lapply(knots.list.temp, `[[`, "params")
       
@@ -163,7 +163,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
       knots.list$probs <- knots.list$params
       for (pft in seq_along(settings$pfts)) {
         for (i in seq_len(n.param.all[[pft]])) {
-          knots.list[[pft]]$probs[, i] <- eval(prior.ext.fn[[pft]]$pprior[[i]], 
+          knots.list[[pft]]$probs[, i] <- eval(prior.fn[[pft]]$pprior[[i]], 
                                                list(q = knots.list[[pft]]$params[, i]))
         }
       }

--- a/modules/assim.batch/R/pda.emulator.R
+++ b/modules/assim.batch/R/pda.emulator.R
@@ -272,6 +272,8 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
           SS.list[[inputi]] <- cbind(X, error.statistics[[inputi]])
       } # if-block
         
+      # remove failed runs
+      SS.list[[inputi]] <- SS.list[[inputi]][!rowSums(is.na(SS.list[[inputi]])), ]
     } # for-loop
 
 
@@ -390,7 +392,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
   
   # Stop the clock
   ptm.finish <- proc.time() - ptm.start
-  logger.info(paste0("Emulator MCMC took ", paste0(round(ptm.finish[3])), " seconds."))
+  logger.info(paste0("Emulator MCMC took ", paste0(round(ptm.finish[3])), " seconds for ", paste0(settings$assim.batch$iter), " iterations."))
   
   
   mcmc.samp.list <- list()

--- a/modules/assim.batch/R/pda.emulator.R
+++ b/modules/assim.batch/R/pda.emulator.R
@@ -359,6 +359,9 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
     mix <- "each"
   }
   
+  # start the clock
+  ptm.start <- proc.time()
+  
   # prepare for parallelization
   dcores <- parallel::detectCores() - 1
   ncores <- min(max(dcores, 1), settings$assim.batch$chain)
@@ -384,6 +387,11 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
   })
   
   parallel::stopCluster(cl)
+  
+  # Stop the clock
+  ptm.finish <- proc.time() - ptm.start
+  logger.info(paste0("Emulator MCMC took ", paste0(round(ptm.finish[3])), " seconds."))
+  
   
   mcmc.samp.list <- list()
   

--- a/modules/assim.batch/R/pda.emulator.R
+++ b/modules/assim.batch/R/pda.emulator.R
@@ -267,14 +267,12 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
     SS.list <- list()
     bc <- 1
     
-    # check failed runs and remove them if you'll have a reasonable amount of param sets after removal
     # what percentage of runs is allowed to fail?
     if(!is.null(settings$assim.batch$allow.fail)){
       allow.fail <- as.numeric(settings$assim.batch$allow.fail)
     } else {
       allow.fail <- 0.5
     }
-    
     # what is it in number of runs?
     no.of.allowed <- floor(settings$assim.batch$n.knot * allow.fail)
     
@@ -299,6 +297,7 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
           SS.list[[inputi]] <- cbind(X, error.statistics[[inputi]])
       } # if-block
         
+      # check failed runs and remove them if you'll have a reasonable amount of param sets after removal
       # how many runs failed?
       no.of.failed <- sum(is.na(SS.list[[inputi]][, ncol(SS.list[[inputi]])]))
       

--- a/modules/assim.batch/R/pda.emulator.R
+++ b/modules/assim.batch/R/pda.emulator.R
@@ -126,6 +126,9 @@ pda.emulator <- function(settings, params.id = NULL, param.names = NULL, prior.i
                                                       pname[[x]]))
   names(knots.list) <- sapply(settings$pfts,"[[",'name')
   
+  knots.params <- lapply(knots.list, `[[`, "params")
+  knots.probs <- lapply(knots.list, `[[`, "probs")
+  
   current.step <- "GENERATE KNOTS"
   save(list = ls(all.names = TRUE),envir=environment(),file=pda.restart.file)
   

--- a/modules/assim.batch/R/pda.utils.R
+++ b/modules/assim.batch/R/pda.utils.R
@@ -92,14 +92,28 @@ pda.settings <- function(settings, params.id = NULL, param.names = NULL, prior.i
                          "] but these parameters are specified as constants in pecan.xml!"))
   }
   
-  # prior: Either null or an ID used to query for priors later
-  if (!is.null(prior.id)) {
-    settings$assim.batch$prior$posterior.id <- prior.id
+  # if settings$assim.batch$prior$prior.id is not null, it means a PDA run was already done
+  # store it to prev.prior.id, need it for extension runs
+  if (!is.null(settings$assim.batch$prior$prior.id)) {
+    settings$assim.batch$prior$prev.prior.id <- settings$assim.batch$prior$prior.id
   }
+  
+  # if settings$pfts$pft$posteriorid is not null, use it as new PDA prior:
+  
+  # (a) settings$pfts$pft$posteriorid can be full if you went through meta.analysis and write.configs
+  # if it's empty pda.load.priors will handle it later
+  
+  # (b) settings$pfts$pft$posteriorid will be full and overwritten by a PDA posterior id if a PDA was run
   if (!is.null(settings$pfts$pft$posteriorid)) {
     settings$assim.batch$prior$prior.id <- lapply(settings$pfts, `[[`, "posteriorid")
     names(settings$assim.batch$prior$prior.id) <- sapply(settings$pfts, `[[`, "name")
   }
+  
+  # if a prior.id is explicity passed to this function, overwrite and use it as PDA prior
+  if (!is.null(prior.id)) {
+    settings$assim.batch$prior$prior.id <- prior.id
+  }
+  
   
   # chain: An identifier for the MCMC chain.
   if (!is.null(chain)) {
@@ -192,104 +206,90 @@ pda.settings <- function(settings, params.id = NULL, param.names = NULL, prior.i
 ##'
 ##' @author Ryan Kelly, Istem Fer
 ##' @export
-pda.load.priors <- function(settings, con, path.flag = TRUE) {
+pda.load.priors <- function(settings, con, extension.check = TRUE) {
   
-  # Load a prior.distns or post.distns file directly by path
-  if (!is.null(settings$assim.batch$prior$path)) {
-    prior.out <- list()
-    for (i in seq_along(settings$pfts)) {
-      if (file.exists(settings$assim.batch$prior$path[[i]])) 
-        load(settings$assim.batch$prior$path[[i]])
-      if (exists("prior.distns")) {
-        logger.info(paste0("Loaded prior ",
-                           basename(settings$assim.batch$prior$path[[i]]), 
-                           " as PDA prior."))
-        prior.out[[i]] <- prior.distns
-        rm(prior.distns)
-      } else if (exists("post.distns")) {
-        logger.info(paste0("Loaded posterior ",
-                           basename(settings$assim.batch$prior$path[[i]]), 
-                           " as PDA prior."))
-        prior.out[[i]] <- post.distns
-        rm(post.distns)
-      } else {
-        logger.warn("Didn't find a valid PDA prior at ", settings$assim.batch$prior$path[[i]])
-      }
-    }
-  }
-  
-  # If no path given or didn't find a valid prior, proceed to using a posterior specified by ID,
-  # either as specified in settings or get the most recent as default
-  if (!exists("prior.out")) {
-    if (is.null(settings$assim.batch$prior$prior.id)) {
+  # settings$assim.batch$prior$prior.id is not NULL if you've done a PDA or meta.analysis and went through write.configs
+  # then you can proceed loading objects by querying their paths according to their ids
+  # if it's NULL get the most recent id from DB as default 
+
+  if (is.null(settings$assim.batch$prior$prior.id)) {
       
-      logger.info(paste0("Defaulting to most recent posterior/prior as PDA prior."))
-      ## by default, use the most recent posterior/prior as the prior
-      priorids <- list()
-      for (i in seq_along(settings$pfts)) {
+    logger.info(paste0("Defaulting to most recent posterior/prior as PDA prior."))
+    ## by default, use the most recent posterior/prior as the prior
+    priorids <- list()
+    for (i in seq_along(settings$pfts)) {
         
-        pft.id <- db.query(paste0("SELECT pfts.id FROM pfts, modeltypes WHERE pfts.name='", 
+      pft.id <- db.query(paste0("SELECT pfts.id FROM pfts, modeltypes WHERE pfts.name='", 
                                             settings$pfts[[i]]$name, 
                                             "' and pfts.modeltype_id=modeltypes.id and modeltypes.name='", 
                                             settings$model$type, "'"), 
                                      con)[["id"]]
-        priors <- db.query(paste0("SELECT * from posteriors where pft_id = ", pft.id), con)
+      priors <- db.query(paste0("SELECT * from posteriors where pft_id = ", pft.id), con)
         
-        prior.db <- db.query(paste0("SELECT * from dbfiles where container_type = 'Posterior' and container_id IN (", 
+      prior.db <- db.query(paste0("SELECT * from dbfiles where container_type = 'Posterior' and container_id IN (", 
                                     paste(priors$id, collapse = ","), ")"), con)
         
-        prior.db.grep <- prior.db[grep("^post\\.distns\\..*Rdata$", prior.db$file_name), ]
-        if (nrow(prior.db.grep) == 0) {
-          prior.db.grep <- prior.db[grep("^prior\\.distns\\..*Rdata$", prior.db$file_name), ]
-        }
+      prior.db.grep <- prior.db[grep("^post\\.distns\\..*Rdata$", prior.db$file_name), ]
+      if (nrow(prior.db.grep) == 0) {
+        prior.db.grep <- prior.db[grep("^prior\\.distns\\..*Rdata$", prior.db$file_name), ]
+      }
         
-        priorids[[i]] <- prior.db.grep$container_id[which.max(prior.db.grep$updated_at)]
-      }
-      settings$assim.batch$prior$prior.id <- priorids
+      priorids[[i]] <- prior.db.grep$container_id[which.max(prior.db.grep$updated_at)]
     }
-    logger.info(paste0("Using posterior ID(s) ", paste(unlist(settings$assim.batch$prior$prior.id), 
+    settings$assim.batch$prior$prior.id <- priorids
+  }
+  logger.info(paste0("Using posterior ID(s) ", paste(unlist(settings$assim.batch$prior$prior.id), 
                                                        collapse = ", "), " as PDA prior(s)."))
+
+  # if this is an extension run you want to use priors of the previous round
+  # extension.check == TRUE not an extension run
+  # extension.check == FALSE an extension run
+  if(!extension.check){
+    priorids <- settings$assim.batch$prior$prev.prior.id
+  }
+
+  prior.out <- list()
+  prior.paths <- list()
     
-    prior.out <- list()
-    prior.paths <- list()
-    
-    for (i in seq_along(settings$pfts)) {
+  # now that you filled priorids load the PDA prior objects
+  # if files becomes NULL try loading objects from workflow oft folders
+  for (i in seq_along(settings$pfts)) {
       
-      files <- dbfile.check("Posterior", settings$pfts[[i]]$posteriorid, con, settings$host$name)
+    files <- dbfile.check("Posterior", priorids[[i]], con, settings$host$name)
       
-      pid <- grep("post.distns.*Rdata", files$file_name)  ## is there a posterior file?
-      if (length(pid) == 0) {
-        pid <- grep("prior.distns.Rdata", files$file_name)  ## is there a prior file?
-      }
-      if (length(pid) > 0) {
-        prior.paths[[i]] <- file.path(files$file_path[pid], files$file_name[pid])
+    pid <- grep("post.distns.*Rdata", files$file_name)  ## is there a posterior file?
+    if (length(pid) == 0) {
+      pid <- grep("prior.distns.Rdata", files$file_name)  ## is there a prior file?
+    }
+    if (length(pid) > 0) {
+      prior.paths[[i]] <- file.path(files$file_path[pid], files$file_name[pid])
+    } else {
+      ## is there a posterior in the current workflow's PFT directory?
+      pft <- settings$pfts[[i]]
+      fname <- file.path(pft$outdir, "post.distns.Rdata")
+      if (file.exists(fname)) {
+        prior.paths[[i]] <- fname
       } else {
-        ## is there a posterior in the current workflow's PFT directory?
-        pft <- settings$pfts[[i]]
-        fname <- file.path(pft$outdir, "post.distns.Rdata")
+        ## is there a prior in the current workflow's PFT directory?
+        fname <- file.path(pft$outdir, "prior.distns.Rdata")
         if (file.exists(fname)) {
           prior.paths[[i]] <- fname
-        } else {
-          ## if no posterior can be found, skip to the next PFT
+        }else{
+          ## if no posterior or prior can be found, skip to the next PFT
           next
         }
       }
-      load(prior.paths[[i]])
-      if (!exists("post.distns")) {
-        prior.out[[i]] <- prior.distns
-      } else {
-        prior.out[[i]] <- post.distns
-        rm(post.distns)
-      }
+    }
+    load(prior.paths[[i]])
+    if (!exists("post.distns")) {
+      prior.out[[i]] <- prior.distns
+    } else {
+      prior.out[[i]] <- post.distns
+      rm(post.distns)
+    }
       
-    }
-    
-    # if this is the first PDA round, save the initial PDA prior to path
-    if (path.flag == TRUE) {
-      settings$assim.batch$prior$path <- prior.paths
-      names(settings$assim.batch$prior$path) <- sapply(settings$pfts, `[[`, "name")
-    }
   }
+    
   
   # Finally, check that PDA parameters requested are in the prior; can't assimilate them if not.
   # Could proceed with any valid params. But probably better to just bonk out now to avoid wasting

--- a/modules/assim.batch/R/pda.utils.R
+++ b/modules/assim.batch/R/pda.utils.R
@@ -246,8 +246,6 @@ pda.load.priors <- function(settings, con, extension.check = TRUE) {
     }
     settings$assim.batch$prior$prior.id <- priorids
   }
-  logger.info(paste0("Using posterior ID(s) ", paste(unlist(settings$assim.batch$prior$prior.id), 
-                                                       collapse = ", "), " as PDA prior(s)."))
 
   # if this is an extension run you want to use priors of the previous round
   # extension.check == TRUE not an extension run
@@ -257,6 +255,9 @@ pda.load.priors <- function(settings, con, extension.check = TRUE) {
   } else{
     priorids <- settings$assim.batch$prior$prior.id
   }
+  
+  logger.info(paste0("Using posterior ID(s) ", paste(unlist(priorids), collapse = ", "), " as PDA prior(s)."))
+  
 
   prior.out <- list()
   prior.paths <- list()

--- a/modules/assim.batch/man/pda.load.priors.Rd
+++ b/modules/assim.batch/man/pda.load.priors.Rd
@@ -4,7 +4,7 @@
 \alias{pda.load.priors}
 \title{Load Priors for Paramater Data Assimilation}
 \usage{
-pda.load.priors(settings, con, path.flag = TRUE)
+pda.load.priors(settings, con, extension.check = TRUE)
 }
 \arguments{
 \item{all}{params are the identically named variables in pda.mcmc / pda.emulator}

--- a/modules/assim.batch/man/pda.settings.Rd
+++ b/modules/assim.batch/man/pda.settings.Rd
@@ -6,7 +6,8 @@
 \usage{
 pda.settings(settings, params.id = NULL, param.names = NULL,
   prior.id = NULL, chain = NULL, iter = NULL, adapt = NULL,
-  adj.min = NULL, ar.target = NULL, jvar = NULL, n.knot = NULL)
+  adj.min = NULL, ar.target = NULL, jvar = NULL, n.knot = NULL,
+  run.round = FALSE)
 }
 \arguments{
 \item{all}{params are the identically named variables in pda.mcmc / pda.emulator}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed the bug and cleaned the prior handling some more. I tried to test it as much as I can (this can get a little complicated, because if you want to run emulator "longer" you need to load the priors used for the previous PDA whereas if you want to refine the emulator by proposing new "round" of knots you need both the priors used for the previous PDA and the posteriors came out of the previous PDA, and these extensions can come after one another, and be run more than twice etc.)

For now I tested these cases:
- normal run
- normal run followed by a "longer" extension run
- normal run followed by a "longer" extension run twice
- normal run followed by a "round" extension run
- normal run followed by a "round" extension run and then a "longer" extension


I also added back ability to handle failed runs, but we need to decide how many runs we can allow to fail.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
