### PR TITLE
Adding a site now need a right click instead of double click on the map.

### DIFF
--- a/web/02-modelsite.php
+++ b/web/02-modelsite.php
@@ -410,7 +410,7 @@ function mapsLoaded() {
     });
   });
 
-  map.addListener('dblclick', function(event) {
+  map.addListener('rightclick', function(event) {
     addMarker(event.latLng);
     $("#dialog-form").dialog("open");
     $("#txtlat").val(event.latLng.lat());
@@ -524,7 +524,7 @@ function goHome() {
       <input name="siteid" id="siteid" type="hidden" value="<?php echo $siteid; ?>"/>
       <input name="sitename" id="sitename" type="text" />
 <?php if ($betydb != "") { ?>
-      <span class="small">Add new site, double click map</span>
+      <span class="small">Add new site, right click map</span>
       <span class="small"><a href="<?php echo $betydb; ?>/sites/new" target="BETY">Remove Pins</a></span>
 <?php } ?>
       <div class="spacer"></div>


### PR DESCRIPTION
Site add right click feature

## Description
Changed adding a site from a map double click to a map right click so we don't interfere with the double click zoom and center functionality.

## Motivation and Context
Fixes issue detailed in ticket #1221 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue) #1221 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.



