### PR TITLE
Met.bug - Making queries for existing inputs more explicit/exhaustive and cleaning up some logic

### DIFF
--- a/db/R/dbfiles.R
+++ b/db/R/dbfiles.R
@@ -148,7 +148,6 @@ dbfile.input.insert <- function(in.path, in.prefix, siteid, startdate, enddate, 
 ##' @param hostname the name of the host where the file is stored, this will default to the name of the current machine
 ##' @param params database connection information
 ##' @param exact.dates setting to include start and end date in input query
-##' @param machine.check setting to have dbfile.check include machine in query
 ##' @return data.frame with the id, filename and pathname of the input that is requested
 ##' @export
 ##' @author Rob Kooper, Tony Gardella
@@ -192,11 +191,32 @@ dbfile.input.check <- function(siteid, startdate=NULL, enddate=NULL, mimetype, f
     return(data.frame())
   } else {
     if(length(inputid) > 1) {
-      logger.warn("Found multiple matching inputs. Checking for one with associate files are on host machine")
-      return(as.data.frame(dbfile.check('Input', inputid, con, hostname, machine.check)))
-      }
+      logger.warn("Found multiple matching inputs. Checking for one with associate files on host machine")
+      
+      dbfile <- dbfile.check('Input', inputid, con, hostname, machine.check = TRUE)
+      
+        if(nrow(dbfile) == 0){
+          ## With the possibility of dbfile.check returning nothing,
+          ## as.data.frame ensures a empty data.frame is returned 
+          ## rather than an empty list.
+          return(as.data.frame(dbfile.check('Input', inputid, con, hostname, machine.check = FALSE)))
+        }
+      
+      return(dbfile)
+      
+    }
+    
       logger.warn("Found possible matching input. Checking if its associate files are on host machine")
-      return(as.data.frame(dbfile.check('Input', inputid, con, hostname, machine.check)))
+      
+      dbfile <- dbfile.check('Input', inputid, con, hostname, machine.check = TRUE)
+      
+       if(nrow(dbfile) == 0){
+          ## With the possibility of dbfile.check returning nothing,
+          ## as.data.frame ensures an empty data.frame is returned 
+          ## rather than an empty list.
+          return(as.data.frame(dbfile.check('Input', inputid, con, hostname, machine.check = FALSE)))
+        }
+      return(dbfile)
     }
   
 }
@@ -369,7 +389,7 @@ dbfile.insert <- function(in.path, in.prefix, type, id, con, reuse = TRUE, hostn
 ##' @name dbfile.check
 ##' @title Check for a file in the dbfiles tables
 ##' @param type the type of dbfile (Input, Posterior)
-##' @param id the id of container type
+##' @param container.id the id of container type
 ##' @param con database connection object
 ##' @param hostname the name of the host where the file is stored, this will default to the name of the current machine
 ##' @param machine.check setting to check for file on named host, otherwise will check for any file given container id
@@ -380,7 +400,7 @@ dbfile.insert <- function(in.path, in.prefix, type, id, con, reuse = TRUE, hostn
 ##' \dontrun{
 ##'   dbfile.check('Input', 7, dbcon)
 ##' }
-dbfile.check <- function(type, id, con, hostname=fqdn(), machine.check = TRUE) {
+dbfile.check <- function(type, container.id, con, hostname=fqdn(), machine.check = TRUE) {
   if (hostname == "localhost") hostname <- fqdn()
   
   # find appropriate host
@@ -390,15 +410,25 @@ dbfile.check <- function(type, id, con, hostname=fqdn(), machine.check = TRUE) {
     return(data.frame())
   } else if (machine.check){
     
-    return(db.query(paste0("SELECT * FROM dbfiles WHERE container_type='", type, 
-                           "' AND container_id=", id, " AND machine_id=", hostid), con))
-  }else{
-    db.file <- list()
-    for(i in seq_along(id)){
-      db.file <- db.query(paste0("SELECT * FROM dbfiles WHERE container_type='", type, 
-                                 "' AND container_id=", id[i]), con)
+    dbfiles <- tbl(bety,"dbfiles") %>% filter(container_id %in% inputid) %>% 
+               filter(container_type == type) %>% filter(machine_id == hostid) %>% collect()
+    
+    if(nrow(dbfiles) > 1){
+      
+      logger.warn("Multiple Valid Files found on host machine. Returning last updated record")
+      return(dbfiles[dbfiles$updated_at == max(dbfiles$updated_at),])
+      
+    }else{
+      return(dbfiles)
     }
-    return(db.file)
+
+  }else{
+    
+    dbfiles <- tbl(bety,"dbfiles") %>% filter(container_id %in% inputid) %>% filter(container_type == type) %>% collect()
+    logger.info("Returning last updated record.")
+    
+    return(dbfiles[dbfiles$updated_at == max(dbfiles$updated_at),])
+    
   }
 }
 

--- a/db/man/dbfile.check.Rd
+++ b/db/man/dbfile.check.Rd
@@ -4,12 +4,13 @@
 \alias{dbfile.check}
 \title{Check for a file in the dbfiles tables}
 \usage{
-dbfile.check(type, id, con, hostname = fqdn(), machine.check = TRUE)
+dbfile.check(type, container.id, con, hostname = fqdn(),
+  machine.check = TRUE)
 }
 \arguments{
 \item{type}{the type of dbfile (Input, Posterior)}
 
-\item{id}{the id of container type}
+\item{container.id}{the id of container type}
 
 \item{con}{database connection object}
 

--- a/db/man/dbfile.input.check.Rd
+++ b/db/man/dbfile.input.check.Rd
@@ -5,8 +5,7 @@
 \title{Check for a file in the input/dbfiles tables}
 \usage{
 dbfile.input.check(siteid, startdate = NULL, enddate = NULL, mimetype,
-  formatname, parentid = NA, con, hostname = fqdn(), exact.dates = FALSE,
-  machine.check = FALSE)
+  formatname, parentid = NA, con, hostname = fqdn(), exact.dates = FALSE)
 }
 \arguments{
 \item{siteid}{the id of the site that this data is applicable to}
@@ -24,8 +23,6 @@ dbfile.input.check(siteid, startdate = NULL, enddate = NULL, mimetype,
 \item{hostname}{the name of the host where the file is stored, this will default to the name of the current machine}
 
 \item{exact.dates}{setting to include start and end date in input query}
-
-\item{machine.check}{setting to have dbfile.check include machine in query}
 
 \item{parent}{the id of the parent of the input}
 

--- a/modules/data.atmosphere/R/met.process.R
+++ b/modules/data.atmosphere/R/met.process.R
@@ -147,7 +147,7 @@ met.process <- function(site, input_met, start_date, end_date, model,
                                        site.id = raw.data.site.id, 
                                        lat.in = new.site$lat, lon.in = new.site$lon, 
                                        host = host, 
-                                       overwrite = FALSE,
+                                       overwrite = overwrite$download,
                                        site = site, username = username)
     
     if (met %in% c("CRUNCEP", "GFDL")) {
@@ -172,7 +172,7 @@ met.process <- function(site, input_met, start_date, end_date, model,
                             lat = new.site$lat, lon = new.site$lon, 
                             start_date = start_date, end_date = end_date, 
                             con = con, host = host, 
-                            overwrite = FALSE, 
+                            overwrite = overwrite$met2cf, 
                             format.vars = format.vars)
   }
   
@@ -193,7 +193,7 @@ met.process <- function(site, input_met, start_date, end_date, model,
                                      overwrite = overwrite$standardize)
     } else if (register$scale == "site") {
       ##### Site Level Processing
-      ready.id <- PEcAn.data.atmosphere:::.metgapfill.module(cf.id = cf.id, 
+      ready.id <- .metgapfill.module(cf.id = cf.id, 
                                      register = register,
                                      dir = dir,
                                      met = met, 

--- a/modules/data.atmosphere/R/met.process.R
+++ b/modules/data.atmosphere/R/met.process.R
@@ -147,8 +147,9 @@ met.process <- function(site, input_met, start_date, end_date, model,
                                        site.id = raw.data.site.id, 
                                        lat.in = new.site$lat, lon.in = new.site$lon, 
                                        host = host, 
-                                       overwrite = overwrite$download,
+                                       overwrite = FALSE,
                                        site = site, username = username)
+    
     if (met %in% c("CRUNCEP", "GFDL")) {
       ready.id <- raw.id
       stage$met2cf <- FALSE
@@ -168,10 +169,10 @@ met.process <- function(site, input_met, start_date, end_date, model,
                             dir = dir, 
                             machine = machine, 
                             site.id = new.site.id, 
-                            lat = site$lat, lon = site$lon, 
+                            lat = new.site$lat, lon = new.site$lon, 
                             start_date = start_date, end_date = end_date, 
                             con = con, host = host, 
-                            overwrite = overwrite$met2cf, 
+                            overwrite = FALSE, 
                             format.vars = format.vars)
   }
   
@@ -192,7 +193,7 @@ met.process <- function(site, input_met, start_date, end_date, model,
                                      overwrite = overwrite$standardize)
     } else if (register$scale == "site") {
       ##### Site Level Processing
-      ready.id <- .metgapfill.module(cf.id = cf.id, 
+      ready.id <- PEcAn.data.atmosphere:::.metgapfill.module(cf.id = cf.id, 
                                      register = register,
                                      dir = dir,
                                      met = met, 

--- a/utils/R/convert.input.R
+++ b/utils/R/convert.input.R
@@ -405,7 +405,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
     fcn.args$outfolder  <- outfolder
     fcn.args$start_date <- start_date
     fcn.args$end_date   <- end_date
-    # sitename='Niwot Ridge Forest/LTER NWT1 (US-NR1)', username='pecan', overwrite=FALSE, outfolder='/home/carya/output/dbfiles/Ameriflux_site_0-772/', start_date='2001-01-01', end_date='2012-12-31')
+    
     arg.string <- listToArgString(fcn.args)
     
     if (!missing(format.vars)) {

--- a/utils/R/convert.input.R
+++ b/utils/R/convert.input.R
@@ -42,8 +42,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                                           enddate = end_date, 
                                           con = con, 
                                           hostname = host$name, 
-                                          exact.dates = TRUE,
-                                          machine.check = TRUE
+                                          exact.dates = TRUE
                                           )
     
 
@@ -102,10 +101,32 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
       
     
 
-      # There's an existing input that matches desired start/end dates. Use that one.
-      logger.info("Skipping this input conversion because files are already available.")
+      #Grab machine info of file that exists
+      existing.machine <- db.query(paste0("SELECT * from machines where id  = '", 
+                                          existing.dbfile$machine_id, "'"), con)
       
-      return(list(input.id = existing.input$id, dbfile.id = existing.dbfile$id))
+      #Grab machine info of 
+      machine.host <- ifelse(host$name == "localhost", fqdn(), host$name)
+      machine <- db.query(paste0("SELECT * from machines where hostname = '", 
+                                 machine.host, "'"), con)
+      
+      if(existing.machine$id != machine$id){
+        
+        
+        logger.info("Valid Input record found that spans desired dates, but valid files do not exist on this machine.")
+        logger.info("Downloading all years of Valid input to ensure consistency")
+        insert.new.file <- TRUE
+        start_date <- existing.input$start_date
+        end_date   <- existing.input$end_date
+        
+      }else{
+        
+        # There's an existing input that spans desired start/end dates with files on this machine
+        
+        logger.info("Skipping this input conversion because files are already available.")
+        return(list(input.id = existing.input$id, dbfile.id = existing.dbfile$id))
+      }
+      
       
       
       } else{
@@ -125,8 +146,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                                             startdate = start_date,
                                             enddate = end_date, 
                                             con = con, 
-                                            hostname = host$name,
-                                            machine.check = FALSE
+                                            hostname = host$name
                                             )
       
     
@@ -134,7 +154,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
       logger.info(existing.dbfile)
       
      
-      logger.info("end CHECK for existing input record. May be on wrong machine. Checking now... ")
+      logger.info("end CHECK for existing input record.")
       
       
       if (nrow(existing.dbfile) > 0) {
@@ -225,7 +245,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
               "'/'",
               end_date,
               "' ",
-              "so that existing input can be updated while maintaining continuous time span."
+              " so that existing input can be updated while maintaining continuous time span."
             )
           )
           
@@ -385,7 +405,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
     fcn.args$outfolder  <- outfolder
     fcn.args$start_date <- start_date
     fcn.args$end_date   <- end_date
-    
+    # sitename='Niwot Ridge Forest/LTER NWT1 (US-NR1)', username='pecan', overwrite=FALSE, outfolder='/home/carya/output/dbfiles/Ameriflux_site_0-772/', start_date='2001-01-01', end_date='2012-12-31')
     arg.string <- listToArgString(fcn.args)
     
     if (!missing(format.vars)) {
@@ -408,12 +428,16 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
   
   ## insert new record into database
   if (write) {
+    
+    
     if (exists("existing.input") && nrow(existing.input) > 0 && 
         (existing.input$start_date != start_date || existing.input$end_date != end_date)) {
       # Updating record with new dates
       db.query(paste0("UPDATE inputs SET start_date='", start_date, "', end_date='", 
                       end_date, "', ", "updated_at=NOW() WHERE id=", existing.input$id), 
                con)
+      #Record has been updated and file downloaded so just return existing dbfile and input pair.
+     return(list(input.id = existing.input$id, dbfile.id = existing.dbfile$id))
     }
     
     if (overwrite) {
@@ -436,8 +460,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
       site.id <- input.args$newsite
     }
     
-    if(exact.dates){allow.conflicting.dates <- FALSE}
-    
+  
     
     if(insert.new.file){
       


### PR DESCRIPTION
Machine check needed to be better implemented and added to. It also needed to happen all the time and upon failure grab the last updated record as a tiebreaker if there are multiple valid inputs and only then return empty.

Also if a input record is being updated with new dates. We needed to return the existing input/file record pair after the download.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
