### PR TITLE
Change as.numeric to as.character in function to find timezone

### DIFF
--- a/modules/data.atmosphere/R/site.lst.R
+++ b/modules/data.atmosphere/R/site.lst.R
@@ -10,8 +10,9 @@ site.lst <- function(site.id, con) {
   library(geonames)
   
   time.zone <- db.query(paste("SELECT time_zone from SITES where id =", site.id), con)
-  if (!is.na(time.zone) && !is.na(as.numeric(time.zone))) {
-    lst <- as.numeric(time.zone)
+  
+  if (!is.na(time.zone) && !is.na(as.character(time.zone))) {
+    lst <- as.character(time.zone)
   } else {
     site <- db.query(paste("SELECT ST_X(ST_CENTROID(geometry)) AS lon, ST_Y(ST_CENTROID(geometry)) AS lat", 
       "FROM sites WHERE id =", site.id), con)


### PR DESCRIPTION
When querying  for time zone from a site in BETY it returns a list containing non numeric values (ex. America/Chicago) so when it checked if the query returned an "NA" value it would always return FALSE and force us to rely on geonames to get time zones.

The other dependence on geonames is in met2CF.Ameriflux but it's slightly different. There is not original query to see if a time zone exists for the site in BETY. Need to check that next.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

