### PR TITLE
Bugfixes to Shiny global sensitivity

### DIFF
--- a/shiny/global-sensitivity/load_ensemble.R
+++ b/shiny/global-sensitivity/load_ensemble.R
@@ -9,12 +9,33 @@ load_ensemble <- function(workflow_dir, settings, variable){
     ## ANS -- NOTE: There may be a faster/better way to do this using built-in PEcAn functions
     ## ANS -- or...should these be automatically stored somewhere?
     
-    ensemble.output.raw <- read.ensemble.output(ensemble.size = NULL,
-                                                pecandir = workflow_dir,
-                                                outdir = settings$modeloutdir,
-                                                start.year = as.numeric(settings$ensemble$start.year),
-                                                end.year = as.numeric(settings$ensemble$end.year),
-                                                variable = variable)
+    message("Workflow dir: ", workflow_dir)
+    message("Model outdir: ", settings$modeloutdir)
+    message("Start year: ", settings$ensemble$start.year)
+    message("End year: ", settings$ensemble$end.year)
+    message("Read ensemble output...")
+    
+    # Read samples file
+    samples.file <- file.path(workflow_dir, "samples.Rdata")
+    if (file.exists(samples.file)) {
+      load(samples.file)
+      ens.run.ids <- runs.samples$ensemble
+    } else {
+      stop(samples.file, "not found required by read.ensemble.output")
+    }
+
+    ensemble.output.raw <- list()
+    for (row in rownames(ens.run.ids)) {
+      run.id <- ens.run.ids[row, "id"]
+      logger.info("reading ensemble output from run id: ", run.id)
+      ensemble.output.raw[[row]] <- sapply(read.output(run.id, 
+                                               file.path(settings$modeloutdir, run.id),
+                                               as.numeric(settings$ensemble$start.year),
+                                               as.numeric(settings$ensemble$end.year),
+                                               variable), mean, na.rm = TRUE)
+    }
+
+    message("Rbind ensemble output...")
     ensemble.output <- data.frame(do.call(rbind, ensemble.output.raw))
     
     ## NOTE: read.ensemble.output only returns the mean value at each timestep.
@@ -22,7 +43,9 @@ load_ensemble <- function(workflow_dir, settings, variable){
     ## or read.ensemble.output needs to be modified.
     
     # Load parameter values
+    message("Load parameter values...")
     load(file.path(workflow_dir, "samples.Rdata"))
+
     ## "samples.RData" contains the following:
     ##    ensemble.samples -- For each PFT, data.frame of sampled parameter values. Not linked to run IDs, but presumably in same order
     ##    pft.names -- Names of each PFT
@@ -31,8 +54,13 @@ load_ensemble <- function(workflow_dir, settings, variable){
     ##    trait.names -- Names of parameters (traits) sampled; list by PFT.
     ##    trait.samples -- Samples from meta-analysis? 5004 samples per trait.
     
+    message("Get run samples...")
     ensemble.output$runid <- runs.samples$ensemble$id
+
+    message('Cbind ensemble samples...')
     ensemble.samples.cbind <- do.call(cbind, ensemble.samples[pft.names])
+
+    message('Cbind ensemble output and samples...')
     ensemble.output.full <- cbind(ensemble.output, ensemble.samples.cbind)
     
     return(ensemble.output.full)

--- a/shiny/global-sensitivity/plotEnsemble.R
+++ b/shiny/global-sensitivity/plotEnsemble.R
@@ -4,6 +4,8 @@
 #' @param pdfs Display probability density functions outside plots. Default=TRUE.
 #' @param fit.method Method for regression fit. Either "lm" for linear OLS regression (default) or "spline" for `smooth.spline` fit.
 plotEnsemble <- function(ensemble.out, x, y, pdfs=TRUE, fit.method="lm", ...){
+  message('plotEnsemble x: ', x)
+  message('plotEnsemble y: ', y)
   error_plot <- function(err){
     plot.new()
     text(0.5, 0.5, err[1])
@@ -69,6 +71,9 @@ plotAllVars <- function(ensemble.out, param, var_names, plot_cols = 3){
 }
 
 fitSummary <- function(ensemble.out, x, y) {
+  message('Ensemble out names: ', paste(names(ensemble.out), collapse = ', '))
+  message('fitSummary x: ', x)
+  message('fitSummary y: ', y)
   form <- formula(sprintf("%s ~ %s", y, x))
   fitline <- lm(form, data=ensemble.out)
   fit_summary <- summary(fitline)

--- a/shiny/global-sensitivity/server.R
+++ b/shiny/global-sensitivity/server.R
@@ -1,8 +1,11 @@
+library(PEcAn.DB)
 library(PEcAn.visualization)
+library(ncdf4)
 
 source("plotEnsemble.R")
 source("load_ensemble.R")
 
+message("Debugging!")
 message("Starting shiny server...")
 # Define server logic
 server <- shinyServer(function(input, output, session) {
@@ -46,13 +49,14 @@ server <- shinyServer(function(input, output, session) {
         updateSelectInput(session, "variable", choices=var_names())
     })
     
+    message("Loading ensemble output...")
     ensemble.out <- reactive({
         req(current_workflow())
         workflow <- current_workflow()
         if(nrow(workflow) > 0) {
             workflow_dir <- workflow$folder
             output_dir <- file.path(workflow_dir, "out")
-            settings <- XML::xmlToList(XML::xmlParse(file.path(workflow_dir, "pecan.xml")))
+            settings <- XML::xmlToList(XML::xmlParse(file.path(workflow_dir, "pecan.CHECKED.xml")))
             # Load ensemble samples
             ensemble.out <- load_ensemble(workflow_dir = workflow_dir, settings = settings, variable = var_names())
             return(ensemble.out)


### PR DESCRIPTION
Replaced `read.ensemble.output` with manual loop to avoid the 'expressions' pitfall. Might be a good idea to add expression back in eventually for even more powerful plotting, but this is just to get this working for now.

Added a lot of `message` statements throughout to assist in debugging. Anything that gets passed to `stderr` will be printed in the Shiny log, which allows for debugging Shiny runs in the web interface.