### PR TITLE
Change repository to push html  bookdown files to.

### DIFF
--- a/book_source/deploy.sh
+++ b/book_source/deploy.sh
@@ -14,8 +14,8 @@ USER=${TRAVIS_REPO_SLUG%/*}
 git config --global user.email "pecanproj@gmail.com"
 git config --global user.name "TRAVIS-DOC-BUILD"
 
-git clone https://${GITHUB_PAT}@github.com/${USER}/pecan_bookdown.git book_hosted
-#git clone https://${GITHUB_PAT}/${USER}/pecan_bookdown.git book_hosted
+git clone https://${GITHUB_PAT}@github.com/${USER}/pecan-documentation.git book_hosted
+
 
 cp -r _book/* book_hosted
 


### PR DESCRIPTION
Deprecated the old gitbook repository, and changed "pecan_bookdown" to "pecan-documentation". So I made requisite changes to the name of repository where html files are pushed to in the deploy.sh script.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
