### PR TITLE
Replace ifelse with if because of multi-element return value

### DIFF
--- a/modules/data.atmosphere/R/metgapfill.R
+++ b/modules/data.atmosphere/R/metgapfill.R
@@ -164,12 +164,12 @@ metgapfill <- function(in.path, in.prefix, outfolder, start_date, end_date, lst 
     dt <- ifelse(lubridate::leap_year(year), 
                  (366 * 24 * 60 * 60) / length(sec), 
                  (365 * 24 * 60 * 60) / length(sec))
-    doy <- ifelse(lubridate::leap_year(year) == TRUE,
-                  rep(1:366, each = 86400 / dt), 
-                  rep(1:365, each = 86400 / dt))
-    hr <- ifelse(lubridate::leap_year(year) == TRUE,
-                 rep(seq(0, length = 86400 / dt, by = dt / 86400 * 24), 366), 
-                 rep(seq(0, length = 86400 / dt, by = dt / 86400 * 24), 365))
+    doy <- if (lubridate::leap_year(year) == TRUE)
+                  { rep(1:366, each = 86400 / dt) }  
+                  else { rep(1:365, each = 86400 / dt) }
+    hr <- if (lubridate::leap_year(year) == TRUE)
+                 { rep(seq(0, length = 86400 / dt, by = dt / 86400 * 24), 366) } 
+                 else { rep(seq(0, length = 86400 / dt, by = dt / 86400 * 24), 365) }
     
     f      <- pi / 180 * (279.5 + 0.9856 * doy)
     et     <- (-104.7 * sin(f) + 596.2 * sin(2 * f) + 4.3 * 


### PR DESCRIPTION
Bug fix 
## Description
ifelse statements do not return more than one element if the conditional is only one element. 

## Motivation and Context
Makes metgapfill crash. Now it works

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)