### PR TITLE
Fix biocro test run

### DIFF
--- a/models/biocro/R/run.biocro.R
+++ b/models/biocro/R/run.biocro.R
@@ -34,9 +34,9 @@ run.biocro <- function(lat, lon, metfile, soil.nc = NULL, config = config, coppi
       met <- met[year %in% years]
     }
     
-    dt <- as.numeric(mean(diff(met$date)))
+    dt <- lubridate::as.period(mean(diff(met$date)))
     
-    if (dt > 1) {
+    if (dt > lubridate::days(1)) {
       met <- cfmet.downscale.time(cfmet = met, output.dt = 1)
     }
     

--- a/models/biocro/R/run.biocro.R
+++ b/models/biocro/R/run.biocro.R
@@ -14,8 +14,8 @@ run.biocro <- function(lat, lon, metfile, soil.nc = NULL, config = config, coppi
                        met.uncertainty = FALSE, irrigation = FALSE) {
   library(data.table)
   l2n <- function(x) lapply(x, as.numeric)
-  start.date <- ceiling_date(as.POSIXct(config$run$start.date), "day")
-  end.date   <- floor_date(as.POSIXct(config$run$end.date), "day")
+  start.date <- lubridate::ceiling_date(as.POSIXct(config$run$start.date), "day")
+  end.date   <- lubridate::floor_date(as.POSIXct(config$run$end.date), "day")
   genus <- config$pft$type$genus
   years <- lubridate::year(start.date):lubridate::year(end.date)
   ## Meteorology
@@ -66,8 +66,8 @@ run.biocro <- function(lat, lon, metfile, soil.nc = NULL, config = config, coppi
     WetDat <- biocro.met[biocro.met$year == yeari, ]
     
     if (!is.null(config$simulationPeriod)) {
-      day1 <- yday(config$simulationPeriod$dateofplanting)
-      dayn <- yday(config$simulationPeriod$dateofharvest)
+      day1 <- lubridate::yday(config$simulationPeriod$dateofplanting)
+      dayn <- lubridate::yday(config$simulationPeriod$dateofharvest)
     } else if (lat > 0) {
       day1 <- as.numeric(as.data.table(WetDat)[doy < 180 & Temp < -2, list(day1 = max(doy))])
       dayn <- as.numeric(as.data.table(WetDat)[doy > 180 & Temp < -2, list(day1 = min(doy))])

--- a/models/biocro/inst/biocro.Rscript
+++ b/models/biocro/inst/biocro.Rscript
@@ -1,5 +1,4 @@
-#!/usr/local/bin/Rscript
-#  !/usr/bin/env Rscript
+#!/usr/bin/env Rscript
 
 args   <- commandArgs(trailingOnly = TRUE)
 rundir <- args[1]

--- a/models/biocro/inst/pointbiocro.Rscript
+++ b/models/biocro/inst/pointbiocro.Rscript
@@ -1,5 +1,4 @@
-#!/usr/local/bin/Rscript
-#  !/usr/bin/env Rscript
+#!/usr/bin/env Rscript
 
 args   <- commandArgs(trailingOnly = TRUE)
 rundir <- args[1]

--- a/modules/data.atmosphere/R/load.cfmet.R
+++ b/modules/data.atmosphere/R/load.cfmet.R
@@ -35,7 +35,7 @@ load.cfmet <- function(met.nc, lat, lon, start.date, end.date) {
 
   ## confirm that time units are PEcAn standard
   basetime.string <- ncdf4::ncatt_get(met.nc, "time", "units")$value
-  base.date       <- lubridate::parse_date_time(basetime.string, c("ymd_hms", "ymd_h", "ymd"))
+  base.date       <- lubridate::parse_date_time(basetime.string, c("ymd_HMS", "ymd_H", "ymd"))
   base.units      <- strsplit(basetime.string, " since ")[[1]][1]
 
   ## convert to days

--- a/modules/data.atmosphere/R/load.cfmet.R
+++ b/modules/data.atmosphere/R/load.cfmet.R
@@ -28,8 +28,8 @@ load.cfmet <- function(met.nc, lat, lon, start.date, end.date) {
   lati <- which.min(abs(Lat - lat))
   loni <- which.min(abs(Lon - lon))
 
-  start.date <- lubridate::ymd(as.Date(start.date), tz = "UTC")
-  end.date <- lubridate::ymd(as.Date(end.date), tz = "UTC")
+  start.date <- lubridate::ymd(start.date, tz = "UTC")
+  end.date <- lubridate::ymd(end.date, tz = "UTC")
 
   time.idx <- ncdf4::ncvar_get(met.nc, "time")
 

--- a/modules/data.atmosphere/R/load.cfmet.R
+++ b/modules/data.atmosphere/R/load.cfmet.R
@@ -19,8 +19,8 @@ load.cfmet <- function(met.nc, lat, lon, start.date, end.date) {
   library(PEcAn.utils)
   
   ## Lat and Lon
-  ncdf4::Lat <- ncvar_get(met.nc, "latitude")
-  ncdf4::Lon <- ncvar_get(met.nc, "longitude")
+  Lat <- ncdf4::ncvar_get(met.nc, "latitude")
+  Lon <- ncdf4::ncvar_get(met.nc, "longitude")
 
   if(min(abs(Lat-lat)) > 2.5 | min(abs(Lon-lon)) > 2.5){
     logger.error("lat / lon (", lat, ",", lon, ") outside range of met file (", range(Lat), ",", range(Lon))
@@ -50,7 +50,7 @@ load.cfmet <- function(met.nc, lat, lon, start.date, end.date) {
     logger.error("run start date", ymd(as.Date(start.date)), "before met data starts", min(all.dates$date))
   }
   if (ymd(as.Date(end.date)) > max(all.dates$date)) {
-    logger.error("run end date", ymd(as.Date(start.date)), "after met data ends", min(all.dates$date))
+    logger.error("run end date", ymd(as.Date(end.date)), "after met data ends", max(all.dates$date))
   }
   
   run.dates <- all.dates[date > ymd(as.Date(start.date)) & date < ymd(as.Date(end.date)),

--- a/modules/data.atmosphere/R/load.cfmet.R
+++ b/modules/data.atmosphere/R/load.cfmet.R
@@ -28,6 +28,9 @@ load.cfmet <- function(met.nc, lat, lon, start.date, end.date) {
   lati <- which.min(abs(Lat - lat))
   loni <- which.min(abs(Lon - lon))
 
+  start.date <- lubridate::ymd(as.Date(start.date), tz = "UTC")
+  end.date <- lubridate::ymd(as.Date(end.date), tz = "UTC")
+
   time.idx <- ncdf4::ncvar_get(met.nc, "time")
 
   ## confirm that time units are PEcAn standard
@@ -46,14 +49,14 @@ load.cfmet <- function(met.nc, lat, lon, start.date, end.date) {
   ## but POSIXlt moves times off by a second
   suppressWarnings(all.dates <- data.table(index = seq(time.idx), date = round(date)))
   
-  if (ymd(as.Date(start.date)) + days(1) < min(all.dates$date)) {
-    logger.error("run start date", ymd(as.Date(start.date)), "before met data starts", min(all.dates$date))
+  if (start.date + days(1) < min(all.dates$date)) {
+    logger.error("run start date", start.date, "before met data starts", min(all.dates$date))
   }
-  if (ymd(as.Date(end.date)) > max(all.dates$date)) {
-    logger.error("run end date", ymd(as.Date(end.date)), "after met data ends", max(all.dates$date))
+  if (end.date > max(all.dates$date)) {
+    logger.error("run end date", end.date, "after met data ends", max(all.dates$date))
   }
   
-  run.dates <- all.dates[date > ymd(as.Date(start.date)) & date < ymd(as.Date(end.date)),
+  run.dates <- all.dates[date > start.date & date < end.date,
                          list(index, 
                               date = date, 
                               doy = lubridate::yday(date),

--- a/modules/data.atmosphere/R/load.cfmet.R
+++ b/modules/data.atmosphere/R/load.cfmet.R
@@ -49,7 +49,7 @@ load.cfmet <- function(met.nc, lat, lon, start.date, end.date) {
   ## but POSIXlt moves times off by a second
   suppressWarnings(all.dates <- data.table(index = seq(time.idx), date = round(date)))
   
-  if (start.date + days(1) < min(all.dates$date)) {
+  if (start.date + lubridate::days(1) < min(all.dates$date)) {
     logger.error("run start date", start.date, "before met data starts", min(all.dates$date))
   }
   if (end.date > max(all.dates$date)) {

--- a/tests/pecan64.biocro.xml
+++ b/tests/pecan64.biocro.xml
@@ -23,6 +23,13 @@
     <variable>StemBiom</variable>
   </ensemble>
 
+  <meta.analysis>
+    <iter>3000</iter>
+    <random.effects>FALSE</random.effects>
+    <threshold>1.2</threshold>
+    <update>AUTO</update>
+  </meta.analysis>
+
   <sensitivity.analysis>
     <quantiles>
       <sigma>-1</sigma>


### PR DESCRIPTION

## Description

* Fixed a bunch of typos and copy/paste errors
* Added missing meta-analysis block to settings file
* Preserve time units when computing whether to downscale
* Added `lubridate::` where missing to make existing `data.atmosphere` tests pass

## Motivation and Context

Goal: make `$(web/workflow.R tests --settings pecan64.biocro.xml)` run without errors, as a first step toward making BioCro work with the PEcAn met conversion workflow (#1266).


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
