### PR TITLE
(WIP, PROPOSAL) Change build mechanism to devtools::remotes

### DIFF
--- a/all/DESCRIPTION
+++ b/all/DESCRIPTION
@@ -35,8 +35,21 @@ Suggests:
     PEcAn.LINKAGES,
     PEcAn.allometry,
     PEcAn.photosythesis
+Remotes:
+    local::../db,
+    local::../settings,
+    local::../modules/meta.analysis,
+    local::../utils,
+    local::../modules/uncertainty,
+    local::../modules/data.atmosphere,
+    local::../modules/data.land,
+    local::../modules/data.remote,
+    local::../modules/assim.batch,
+    local::../modules/emulator,
+    local::../modules/priors,
+    local::../modules/benchmark
 License: FreeBSD + file LICENSE
 Copyright: Authors
 LazyLoad: yes
 LazyData: FALSE
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1


### PR DESCRIPTION
The `devtools::install` function provides a convenient, more R-centric
way to manage package [dependencies][deps]. In the first commit, I
demonstrate the way this works for the `PEcAn.all` package, namely by
specifying the dependencies in the `DESCRIPTION` file. Once those are
set, running `devtools::install('/path/to/pecan/all')` will install all
dependencies, and, in a `make`-like fashion, _skip packages that haven't
been modified_.

**Advantages over current "make" system**:
    - May bypass some compatibility issues and paths. Because `make` is
    external and uses `sh` for POSIX compliance, it may understand
    different environment variables than R.
    - Dependencies are internal to package, and are more logically
    nested. No need to set all dependencies in a central, external
    makefile.

What do you all think?

[deps]: https://cran.r-project.org/web/packages/devtools/vignettes/dependencies.html