### PR TITLE
BioCro: complain on failure in job.sh

### DIFF
--- a/models/biocro/R/write.configs.BIOCRO.R
+++ b/models/biocro/R/write.configs.BIOCRO.R
@@ -96,6 +96,10 @@ write.config.BIOCRO <- function(defaults = NULL, trait.values, settings, run.id)
                paste("mkdir -p", outdir), 
                paste("cd", rundir), 
                paste(settings$model$binary, normalizePath(rundir, mustWork = FALSE), normalizePath(outdir, mustWork = FALSE)),
+               "if [ $? -ne 0 ]; then",
+               "    echo ERROR IN MODEL RUN >&2",
+               "    exit 1",
+               "fi",
                paste("cp ", file.path(rundir, "README.txt"), file.path(outdir, "README.txt"))),
              con = file.path(settings$rundir, run.id, "job.sh"))
   Sys.chmod(file.path(settings$rundir, run.id, "job.sh"))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
First pass at a fix for #1307. Ensures that users can see errors, but does not format them very nicely or check for recoverability. 

For discussion: 

* This patch makes `job.sh` bail immediately on error, without copying `README.txt` back to `outdir`. Is this correct, or should the copy happen unconditionally?
* Note that a nonzero script exit status <del>isn't sufficient to make the PEcAn workflow notice the failure</del> <ins>produces a warning but does not stop execution of the PEcAn workflow</ins>: `PEcAn.utils::start.model.runs` reports success unless `job.sh` output contains the exact phrase "ERROR IN MODEL RUN". Should this be changed?

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 