### PR TITLE
fixed mkdir -b error in documentation build

### DIFF
--- a/documentation/tutorials/deploy.sh
+++ b/documentation/tutorials/deploy.sh
@@ -22,7 +22,7 @@ if [ ! -d book_hosted ]; then
 fi
 
 # Create tutorial directory
-mkdir -b book_hosted/tutorials
+mkdir -p book_hosted/tutorials
 
 # Copy all HTML files into target folder
 while read f; do


### PR DESCRIPTION
 My recent PR https://github.com/PecanProject/pecan/pull/1312 seems to be failing because of the documentation deploy https://travis-ci.org/PecanProject/pecan/builds/218209098#L867 the error is `mkdir: invalid option --b`

https://github.com/PecanProject/pecan/blob/9ddca745e26bc60cf7b11726d5a82f72594e6be4/documentation/tutorials/deploy.sh#L25

Is there a reason this wasn't caught by Travis CI when it was submitted as a PR?