### PR TITLE
load.cfmet stop on lat/lon mismatch

### DIFF
--- a/modules/data.atmosphere/R/load.cfmet.R
+++ b/modules/data.atmosphere/R/load.cfmet.R
@@ -23,7 +23,7 @@ load.cfmet <- function(met.nc, lat, lon, start.date, end.date) {
   Lon <- ncdf4::ncvar_get(met.nc, "longitude")
 
   if(min(abs(Lat-lat)) > 2.5 | min(abs(Lon-lon)) > 2.5){
-    logger.error("lat / lon (", lat, ",", lon, ") outside range of met file (", range(Lat), ",", range(Lon))
+    logger.severe("lat / lon (", lat, ",", lon, ") outside range of met file (", range(Lat), ",", range(Lon))
   }
   lati <- which.min(abs(Lat - lat))
   loni <- which.min(abs(Lon - lon))

--- a/modules/data.atmosphere/tests/testthat/test.load.cfmet.R
+++ b/modules/data.atmosphere/tests/testthat/test.load.cfmet.R
@@ -1,5 +1,7 @@
 context("loading data from PEcAn-CF met drivers")
 
+logger.setLevel("OFF")
+
 daily_file <- "data/urbana_daily_test.nc"
 subdaily_file <- "data/urbana_subdaily_test.nc"
 
@@ -42,7 +44,6 @@ test_that("load.cfmet throws error if start/end date out of range",{
 
   skip("Broken test #1343")
 
-  PEcAn.utils::logger.setLevel("OFF")
   expect_error(load.cfmet(met.nc = subdaily.nc, lat = 39, lon = -88,
                           start.date = "9999-01-01", end.date = "9999-02-02"))
   expect_error(load.cfmet(met.nc = subdaily.nc, lat = 39, lon = -88,
@@ -56,17 +57,10 @@ test_that("load.cfmet throws error if start/end date out of range",{
 })
 
 test_that("load.cfmet enforces lat/lon matching",{
-
-  skip("Broken test #1344")
-
-  expect_is(load.cfmet(met.nc = daily.nc, lat = 39, lon = -88,
-                       start.date = "1951-01-01", end.date = "1951-01-07"),
-            "data.frame")
   expect_error(load.cfmet(met.nc = daily.nc, lat = 39, lon = 20,
                           start.date = "1951-01-01", end.date = "1951-01-07"),
                "lat / lon .* outside range of met file")
   expect_error(load.cfmet(met.nc = daily.nc, lat = 9, lon = -88,
                           start.date = "1951-01-01", end.date = "1951-01-07"),
                "lat / lon .* outside range of met file")
-
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes #1344: If load.cfmet detects more than 2.5° lat/lon mismatch between site and met file, it now exits with logger.severe (previously logged an error and kept going).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 