### PR TITLE
PEcAnRTM: Initialisze RNG on parallel cluster

### DIFF
--- a/modules/rtm/R/invert.auto.R
+++ b/modules/rtm/R/invert.auto.R
@@ -145,6 +145,11 @@ invert.auto <- function(observed, invert.options,
     }
     cl <- parallel::makeCluster(parallel.cores, "FORK", outfile = parallel.output)
     on.exit(parallel::stopCluster(cl))
+
+    # Initialize random seeds on cluster. 
+    # Otherwise, chains may start on same seed and end up identical.
+    parallel::clusterSetRNGStream(cl)
+
     message(sprintf("Running %d chains in parallel. ", nchains), 
             "Progress bar unavailable")
   }


### PR DESCRIPTION
Otherwise, chains start with same seed and can end up identical if their initial conditions are the same.
This uses `parallel::setClusterRNGSeed` to set a different seed on each chain.

This hasn't been a problem for PROSPECT inversions because initial conditions are almost always generated randomly.
It has become a problem for EDR because it is often convenient to set static initial conditions.