### PR TITLE
Create seperate documentation for different branches

### DIFF
--- a/book_source/deploy.sh
+++ b/book_source/deploy.sh
@@ -37,21 +37,20 @@ if [ $PUBLISH == yes ]; then
 
   git clone https://${GITHUB_PAT}@github.com/${USER}/pecan-documentation.git book_hosted
 
-
   cp -r _book/* book_hosted
 
   cd book_hosted
   
-  ## CHECK if branch exists in pecan-documentation
-  if [ `git branch --list $BRANCH `]; then
-    git checkout $BRANCH
+  ## Check if branch named directory exists 
+  if [ -d $BRANCH]; then
+    mkdir $BRANCH
   else
-    git checkout -b $BRANCH
+    cd $BRANCH
   fi
   
   git add --all *
   git commit -m "Update the book `date`" || true
-  git push -q origin $BRANCH
+  git push -q origin master
 
 else [$PUBLISH == no]; then
   echo "Not Master, Develop, or Release Branch. Will not render Book."

--- a/book_source/deploy.sh
+++ b/book_source/deploy.sh
@@ -6,28 +6,48 @@ set -e
 #check for environment variable
 [ -z "${GITHUB_PAT}" ] && exit 0
 
-# only deploy if this is the master branch build
-branch_name=$(git symbolic-ref -q HEAD)
-branch_name=${branch_name##refs/heads/}
-branch_name=${branch_name:-HEAD}
-[ "${branch_name}" != "master" ] && exit 0
+# find version if we are develop/latest/release and if should be pushed
 
-#set USER 
-USER=${TRAVIS_REPO_SLUG%/*}
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+PUBLISH="NOPE"
+if [ "$BRANCH" = "master" ]; then
+  PUBLISH="yes"
+  VERSION="latest"
+elif [ "$BRANCH" = "develop" ]; then
+  PUBLISH="yes"
+  VERSION="develop"
+elif [ "$( echo $BRANCH | sed -e 's#^release/.*$#release#')" = "release" ]; then
+  PUBLISH="yes"
+  VERSION="$( echo $BRANCH | sed -e 's#^release/\(.*\)$#\1#' )"
+else
+  PUBLISH="no"
+  VERSION="local"
+fi
+
+## ID Publish=yes push to pecan-documentation/branch
+
+if [ $PUBLISH == yes ]; then
+
+  #set USER 
+  USER=${TRAVIS_REPO_SLUG%/*}
+
+  # configure your name and email if you have not done so
+  git config --global user.email "pecanproj@gmail.com"
+  git config --global user.name "TRAVIS-DOC-BUILD"
+
+  git clone https://${GITHUB_PAT}@github.com/${USER}/pecan-documentation.git book_hosted
 
 
-# configure your name and email if you have not done so
-git config --global user.email "pecanproj@gmail.com"
-git config --global user.name "TRAVIS-DOC-BUILD"
+  cp -r _book/* book_hosted
 
-git clone https://${GITHUB_PAT}@github.com/${USER}/pecan-documentation.git book_hosted
+  cd book_hosted
+  git add --all *
+  git commit -m "Update the book `date`" || true
+  git push -q origin $BRANCH
 
+else [$PUBLISH == no]; then
+ 
+  exit 0
+  echo "Not Master, Develop, or Release Branch. Will not render Book."
 
-cp -r _book/* book_hosted
-
-
-cd book_hosted
-git add --all *
-git commit -m"Update the book `date`" || true
-git push -q origin master
-
+fi

--- a/book_source/deploy.sh
+++ b/book_source/deploy.sh
@@ -41,12 +41,19 @@ if [ $PUBLISH == yes ]; then
   cp -r _book/* book_hosted
 
   cd book_hosted
-  git checkout -b $BRANCH
+  
+  ## CHECK if branch exists in pecan-documentation
+  if [ `git branch --list $BRANCH `]; then
+    git checkout $BRANCH
+  else
+    git checkout -b $BRANCH
+  fi
+  
   git add --all *
   git commit -m "Update the book `date`" || true
   git push -q origin $BRANCH
 
 else [$PUBLISH == no]; then
   echo "Not Master, Develop, or Release Branch. Will not render Book."
-  exit 0
+  exit
 fi

--- a/book_source/deploy.sh
+++ b/book_source/deploy.sh
@@ -48,7 +48,7 @@ if [ $PUBLISH == yes ]; then
     cd $BRANCH
   fi
   
-  cp -r _book/* book_hosted/$BRANCH
+  rsync -a --delete ../../_book/* .
   
   git add --all *
   git commit -m "Update the book `date`" || true

--- a/book_source/deploy.sh
+++ b/book_source/deploy.sh
@@ -41,13 +41,12 @@ if [ $PUBLISH == yes ]; then
   cp -r _book/* book_hosted
 
   cd book_hosted
+  git checkout -b $BRANCH
   git add --all *
   git commit -m "Update the book `date`" || true
   git push -q origin $BRANCH
 
 else [$PUBLISH == no]; then
- 
-  exit 0
   echo "Not Master, Develop, or Release Branch. Will not render Book."
-
+  exit 0
 fi

--- a/book_source/deploy.sh
+++ b/book_source/deploy.sh
@@ -48,7 +48,7 @@ if [ $PUBLISH == yes ]; then
     cd $BRANCH
   fi
   
-  cp -r _book/* .
+  cp -r _book/* book_hosted/$BRANCH
   
   git add --all *
   git commit -m "Update the book `date`" || true

--- a/book_source/deploy.sh
+++ b/book_source/deploy.sh
@@ -44,6 +44,7 @@ if [ $PUBLISH == yes ]; then
   ## Check if branch named directory exists 
   if [ -d $BRANCH]; then
     mkdir $BRANCH
+    cd $BRANCH
   else
     cd $BRANCH
   fi

--- a/book_source/deploy.sh
+++ b/book_source/deploy.sh
@@ -42,9 +42,9 @@ if [ $PUBLISH == yes ]; then
   
   ## Check if branch named directory exists 
   if [ -d $BRANCH]; then
-    mkdir $BRANCH
     cd $BRANCH
   else
+    mkdir $BRANCH
     cd $BRANCH
   fi
   

--- a/book_source/deploy.sh
+++ b/book_source/deploy.sh
@@ -41,7 +41,7 @@ if [ $PUBLISH == yes ]; then
   cd book_hosted
   
   ## Check if branch named directory exists 
-  if [ -d $BRANCH]; then
+  if [ -d $BRANCH ]; then
     cd $BRANCH
   else
     mkdir $BRANCH
@@ -54,7 +54,14 @@ if [ $PUBLISH == yes ]; then
   git commit -m "Update the book `date`" || true
   git push -q origin master
 
-else [$PUBLISH == no]; then
+elif [ $PUBLISH == no ]; then
+
   echo "Not Master, Develop, or Release Branch. Will not render Book."
   exit
+
+else
+
+  echo "Publish status not found. What did you do?"
+  exit 
+  
 fi

--- a/book_source/deploy.sh
+++ b/book_source/deploy.sh
@@ -37,7 +37,6 @@ if [ $PUBLISH == yes ]; then
 
   git clone https://${GITHUB_PAT}@github.com/${USER}/pecan-documentation.git book_hosted
 
-  cp -r _book/* book_hosted
 
   cd book_hosted
   
@@ -48,6 +47,8 @@ if [ $PUBLISH == yes ]; then
   else
     cd $BRANCH
   fi
+  
+  cp -r _book/* .
   
   git add --all *
   git commit -m "Update the book `date`" || true


### PR DESCRIPTION
In response to #1351 I'm trying to have deploy.sh handle different versions of documentation. Still need to figure out how to have different urls for different versions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
