### PR TITLE
1351 deploy branches

### DIFF
--- a/book_source/deploy.sh
+++ b/book_source/deploy.sh
@@ -6,28 +6,39 @@ set -e
 #check for environment variable
 [ -z "${GITHUB_PAT}" ] && exit 0
 
-# only deploy if this is the master branch build
-branch_name=$(git symbolic-ref -q HEAD)
-branch_name=${branch_name##refs/heads/}
-branch_name=${branch_name:-HEAD}
-[ "${branch_name}" != "master" ] && exit 0
+# find version if we are develop/latest/release and if should be pushed
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$BRANCH" = "master" ]; then
+  VERSION="master"
+elif [ "$BRANCH" = "develop" ]; then
+  VERSION="develop"
+elif [ "$( echo $BRANCH | sed -e 's#^release/.*$#release#')" = "release" ]; then
+  VERSION="$( echo $BRANCH | sed -e 's#^release/\(.*\)$#\1#' )"
+else
+  echo "Not Master, Develop, or Release Branch. Will not render Book."
+  exit 0
+fi
 
 #set USER 
 USER=${TRAVIS_REPO_SLUG%/*}
-
 
 # configure your name and email if you have not done so
 git config --global user.email "pecanproj@gmail.com"
 git config --global user.name "TRAVIS-DOC-BUILD"
 
+# clone documentation git repo
 git clone https://${GITHUB_PAT}@github.com/${USER}/pecan-documentation.git book_hosted
-
-
-cp -r _book/* book_hosted
-
-
 cd book_hosted
-git add --all *
-git commit -m"Update the book `date`" || true
-git push -q origin master
 
+## Check if branch named directory exists 
+if [ ! -d $VERSION ]; then
+  mkdir $VERSION
+fi
+
+# copy new documentation
+rsync -a --delete ../_book/ $VERSION/
+
+# push updated documentation back up
+git add --all *
+git commit -m "Update the book `date`" || true
+git push -q origin master


### PR DESCRIPTION
This is a continuation from https://github.com/PecanProject/pecan/pull/1363

In response to #1351 I'm trying to have deploy.sh handle different versions of documentation.

The documentation locations will be:

master = https://pecanproject.github.io/pecan-documentation/master/
develop = https://pecanproject.github.io/pecan-documentation/develop/
release/1.4.10.1 = https://pecanproject.github.io/pecan-documentation/1.4.10.1
etc

Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.