### PR TITLE
skip cruncep tests on travis to reduce timeouts

### DIFF
--- a/modules/data.atmosphere/tests/testthat/test.download.CRUNCEP.R
+++ b/modules/data.atmosphere/tests/testthat/test.download.CRUNCEP.R
@@ -1,27 +1,30 @@
 context("Checking CRUNCEP download")
 
-logger.setLevel("WARN")
 
-tmpdir <- tempdir()
-on.exit(unlink(tmpdir, recursive = TRUE))
+test_that("download works and returns a valid CF file", {
+  # download is slow and was causing lots of Travis timeouts
+  skip_on_travis()
 
-result <- download.CRUNCEP(outfolder = tmpdir,
-                           start_date = "2000-01-01",
-                           end_date = "2000-12-31",
-                           site_id = 753,
-                           lat.in = 40,
-                           lon.in = -88)
-cf <- ncdf4::nc_open(result$file)
-cf_units <- cf$dim$time$units
-ncdf4::nc_close(cf)
+  logger.setLevel("WARN")
 
+  tmpdir <- tempdir()
+  on.exit(unlink(tmpdir, recursive = TRUE))
 
-test_that("reference times are present", {
+  result <- download.CRUNCEP(outfolder = tmpdir,
+                             start_date = "2000-01-01",
+                             end_date = "2000-12-31",
+                             site_id = 753,
+                             lat.in = 40,
+                             lon.in = -88)
+  cf <- ncdf4::nc_open(result$file)
+  cf_units <- cf$dim$time$units
+  ncdf4::nc_close(cf)
+
+  # Expect that reference times are present and set to start date
   expect_equal(cf_units, "days since 2000-01-01T00:00:00Z")
-})
 
-test_that("overwrite argument is respected", {
-  # Skip message comes from logger.error,
+  # Expect that overwrite argument is respected
+  # The skip message comes from logger.error,
   # which writes to stderr but does not use message().
   # If it did, this test would reduce to expect_message(download.CRUNCEP(...), "foo")
   msg <- capture.output(download.CRUNCEP(outfolder = tmpdir,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Skips `test.download.CRUNCEP` when built on Travis, but should still test it when run locally. Note that skip_on_travis() only works without producing a Travis error if it's inside a `test_that`, so I also rearranged all expectations to go inside one test group.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Should help mitigate the recent rash of failed Travis builds -- many of them have been timing out waiting for the CRUNCEP server. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 