### PR TITLE
Remove temporary files generated by testthat tests

### DIFF
--- a/modules/rtm/tests/testthat/test.invert_simple.R
+++ b/modules/rtm/tests/testthat/test.invert_simple.R
@@ -67,3 +67,5 @@ samp_series <- invert.auto(observed = y,
                            save.samples = save.samples, 
                            parallel = FALSE)
 output_tests(samp_series)
+
+file.remove(fname_expect, save.samples)


### PR DESCRIPTION
Some of the PEcAnRTM unit tests generate temporary files that are fairly large, and are prone to being accidentally stored in with the package library. This commit adds a `file.remove` call at the end of the offending tests.