### PR TITLE
load_data() unconvertible units catch

### DIFF
--- a/modules/benchmark/R/load_data.R
+++ b/modules/benchmark/R/load_data.R
@@ -90,8 +90,10 @@ load_data <- function(data.path, format, start_year = NA, end_year = NA, site = 
         out[col] <- misc.convert(x, u1, u2)
         colnames(out)[col] <- vars_used$pecan_name[i]
       } else {
-        PEcAn.utils::logger.error("Units cannot be converted")
-      }  # This error should probably be thrown much earlier, like in query.format.vars - will move it eventually
+        PEcAn.utils::logger.warn(paste("Units cannot be converted. Removing variable. please check the units of",vars_used$input_name[i]))
+        out<-out[,!names(out) %in% c(vars_used$input_name[i])] 
+        vars_used<-vars_used[!names(vars_used) %in% c(vars_used$input_name[i],vars_used$pecan_name[i]),]
+      }
     }
   }
   


### PR DESCRIPTION
load_data() now will not pass any variables that haven't be converted into pecan names and units, or already match pecan names and units. 

## Motivation and Context
This resolves part of [issue #1415.](https://github.com/PecanProject/pecan/issues/1415) 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
