### PR TITLE
Typo bug I made in last PR

### DIFF
--- a/book_source/models/variables.Rmd
+++ b/book_source/models/variables.Rmd
@@ -5,7 +5,9 @@ Note: initial table derived from [MsTMIP](http://nacp.ornl.gov/MsTMIP_variables.
 ```{r,echo=FALSE}
 var.file <- system.file("data","mstmip_vars.csv",package = "PEcAn.utils")
 
-mstmipvars = read.csv(varsfile, header = TRUE, row.names = NULL, sep = ";")
+mstmipvars = read.csv(var.file, header = TRUE, row.names = NULL, sep = ";")
 
 knitr::kable(mstmipvars, align = "c" , booktabs = TRUE)
+
+
 ```


### PR DESCRIPTION
Pasted a typo in last PR that should have introduced a failure to render that table. Odd though that the table was still there in documentation when it should have not been rendered at all. Need to check if things are actually being run properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
