### PR TITLE
add sites_cultivars to dump / load bety scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - Added PEcAn.utils::download.file() to allow for use of alternative FTP programs
 - Updated downloadAmeriflux and downloadNARR to make use of PEcAn.utils::download.file()
 - Added -w flag to load.bety.sh script to specify the URL to fetch the data from
+- add new table sites_cultivars to betydb sync scripts (dump and load)
 
 ### Changed
 - upscale_met now accepts ~any valid CF file (not just full years), retains correct time units, and respects the previously ignored `overwrite` parameter

--- a/scripts/dump.bety.sh
+++ b/scripts/dump.bety.sh
@@ -121,7 +121,7 @@ MANY_TABLES="${MANY_TABLES} formats_variables inputs_runs"
 MANY_TABLES="${MANY_TABLES} managements_treatments modeltypes_formats"
 MANY_TABLES="${MANY_TABLES} pfts_priors pfts_species"
 MANY_TABLES="${MANY_TABLES} posterior_samples posteriors_ensembles"
-MANY_TABLES="${MANY_TABLES} sitegroups_sites trait_covariate_associations"
+MANY_TABLES="${MANY_TABLES} sitegroups_sites sites_cultivars trait_covariate_associations"
 
 # tables that should NOT be dumped
 IGNORE_TABLES="sessions"

--- a/scripts/load.bety.sh
+++ b/scripts/load.bety.sh
@@ -207,7 +207,7 @@ MANY_TABLES="${MANY_TABLES} formats_variables inputs_runs"
 MANY_TABLES="${MANY_TABLES} managements_treatments modeltypes_formats"
 MANY_TABLES="${MANY_TABLES} pfts_priors pfts_species"
 MANY_TABLES="${MANY_TABLES} posterior_samples posteriors_ensembles"
-MANY_TABLES="${MANY_TABLES} sitegroups_sites trait_covariate_associations"
+MANY_TABLES="${MANY_TABLES} sitegroups_sites sites_cultivars trait_covariate_associations"
 
 # tables that should NOT be dumped
 IGNORE_TABLES="sessions"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

need to dump new many-to-many table sites_cultivars

## Motivation and Context

This is a new table that has not been added to the dump/load scripts so it is missing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
