### PR TITLE
Replace logger.error with logger.warn on met source missing fix

### DIFF
--- a/modules/data.atmosphere/R/met.process.R
+++ b/modules/data.atmosphere/R/met.process.R
@@ -33,12 +33,15 @@ met.process <- function(site, input_met, start_date, end_date, model,
       PEcAn.utils::logger.warn("met.process only has a path provided, assuming path is model driver and skipping processing")
       return(input_met$path)
     }else {
-      logger.error("Must specify met source")
+      logger.warn("No met source specified")
       if(!is.null(input_met$id) & !is.null(input_met$path)){
+        logger.warn("Assuming source CFmet")
         met <- input_met$source <- "CFmet" ## this case is normally hit when the use provides an existing file that has already been
         ## downloaded, processed, and just needs conversion to model-specific format.
         ## setting a 'safe' (global) default
-      }   
+      } else {
+        logger.error("Cannot process met without source information")
+      }  
     }
   } else {
     met <-input_met$source


### PR DESCRIPTION
Met.process needs to specific met source when met already converted. But logger.error statement was stopping execution.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
