### PR TITLE
Registration file needed to match met.process CFmet generic

### DIFF
--- a/modules/data.atmosphere/inst/registration/register.CFmet.xml
+++ b/modules/data.atmosphere/inst/registration/register.CFmet.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<CFmet>
+<scale>regional</scale>
+<format>
+  <id>33</id>
+  <name>CF Meteorology</name>
+  <mimetype>application/x-netcdf</mimetype>
+  <inputtype>nc</inputtype>
+</format>
+</CFmet>


### PR DESCRIPTION
Forgot to add the needed XML file to the last fix #1438 . Sorry.
## Description
register.CFmet.xml needs to exist in inst for met.process to actually accept CFmet as valid.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
