### PR TITLE
Print who made GITHUB_PAT variable 

### DIFF
--- a/book_source/deploy.sh
+++ b/book_source/deploy.sh
@@ -6,6 +6,9 @@ set -e
 #check for environment variable
 [ -z "${GITHUB_PAT}" ] && exit 0
 
+#Print who made GITHUB_PAT variable
+echo "GITHHUB_PAT variable made by Tony Gardella"
+
 # don't run on pull requests
 [ "$TRAVIS_PULL_REQUEST" != "false" ]  && exit 0
 

--- a/book_source/deploy.sh
+++ b/book_source/deploy.sh
@@ -7,7 +7,7 @@ set -e
 [ -z "${GITHUB_PAT}" ] && exit 0
 
 #Print who made GITHUB_PAT variable
-echo "GITHHUB_PAT variable made by Tony Gardella"
+echo "GITHUB_PAT variable made by Tony Gardella"
 
 # don't run on pull requests
 [ "$TRAVIS_PULL_REQUEST" != "false" ]  && exit 0


### PR DESCRIPTION
Need to keep track of who made/owns the Github authentication token used as environment variable `GITHUB_PAT` in TRAVIS to build and push documentation. 

## Motivation and Context
Added a line to print a comment about who owns it. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
