### PR TITLE
Bugfix in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,12 +72,15 @@ clean:
 
 .install/devtools:
 	Rscript -e "if(!require('devtools')) install.packages('devtools', repos = 'http://cran.rstudio.com', Ncpus = ${NCPUS})"
+	echo `date` > $@
 
 .install/roxygen2:
 	Rscript -e "if(!require('roxygen2')) install.packages('roxygen2', repos = 'http://cran.rstudio.com', Ncpus = ${NCPUS})"
+	echo `date` > $@
 
 .install/testthat:
 	Rscript -e "if(!require('testthat')) install.packages('testthat', repos = 'http://cran.rstudio.com', Ncpus = ${NCPUS})"
+	echo `date` > $@
 
 install_R_pkg = Rscript -e "devtools::install('$(strip $(1))', Ncpus = ${NCPUS});"
 check_R_pkg = Rscript scripts/check_with_errors.R $(strip $(1))

--- a/modules/assim.batch/DESCRIPTION
+++ b/modules/assim.batch/DESCRIPTION
@@ -15,6 +15,7 @@ Depends:
     PEcAn.DB,
     ellipse,
     dplyr,
+    dbplyr,
     parallel,
     GPfit,
     IDPmisc,

--- a/modules/benchmark/DESCRIPTION
+++ b/modules/benchmark/DESCRIPTION
@@ -15,7 +15,8 @@ Imports:
     ncdf4 (>= 1.15),
     udunits2 (>= 0.11),
     XML (>= 3.98-1.4),
-    dplyr
+    dplyr,
+    dbplyr
 Suggests:
     testthat (>= 1.0.2)
 License: FreeBSD + file LICENSE

--- a/modules/data.atmosphere/DESCRIPTION
+++ b/modules/data.atmosphere/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
     data.table,
     REddyProc,
     dplyr,
+    dbplyr,
     geonames,
     abind (>= 1.4.5),
     lubridate (>= 1.6.0),

--- a/modules/data.land/DESCRIPTION
+++ b/modules/data.land/DESCRIPTION
@@ -18,7 +18,8 @@ Imports:
     ncdf4 (>= 1.15),
     udunits2 (>= 0.11),
     traits,
-    dplyr
+    dplyr,
+    dbplyr
 Suggests:
     fields,
     rgdal,

--- a/visualization/DESCRIPTION
+++ b/visualization/DESCRIPTION
@@ -27,7 +27,8 @@ Depends:
     shiny,
     PEcAn.DB,
     RPostgreSQL,
-    dplyr
+    dplyr,
+    dbplyr
 Imports:
     lubridate (>= 1.6.0),
     ncdf4 (>= 1.15),


### PR DESCRIPTION
`make` was not creating the files used to check if devtools, roxygen,
and testthat had been performed. This was causing `make` to run in full
_every_ time for pecan intsalls that didn't already have the
.install/devtools, etc. files existing, which of course defeats that
point.