### PR TITLE
Update met2CF.csv to be consistent with load.data

### DIFF
--- a/db/R/query.format.vars.R
+++ b/db/R/query.format.vars.R
@@ -19,15 +19,17 @@ query.format.vars <- function(bety,input.id=NA,format.id=NA,var.ids=NA){
   site.id <- NULL
   site.lat <- NULL
   site.lon <- NULL
+  site.time_zone <- NULL
   
   if (is.na(format.id)) {
     f <- db.query(paste("SELECT * from formats as f join inputs as i on f.id = i.format_id where i.id = ", input.id),con)
     site.id <- db.query(paste("SELECT site_id from inputs where id =",input.id),con)
     if (is.data.frame(site.id) && nrow(site.id)>0) {
       site.id <- site.id$site_id
-      site.info <- db.query(paste("SELECT id, ST_X(ST_CENTROID(geometry)) AS lon, ST_Y(ST_CENTROID(geometry)) AS lat FROM sites WHERE id =",site.id),con)
+      site.info <- db.query(paste("SELECT id, time_zone, ST_X(ST_CENTROID(geometry)) AS lon, ST_Y(ST_CENTROID(geometry)) AS lat FROM sites WHERE id =",site.id),con)
       site.lat <- site.info$lat
       site.lon <- site.info$lon
+      site.time_zone <- site.info$time_zone
     } 
   } else {
     f <- db.query(paste("SELECT * from formats where id = ", format.id),con)
@@ -110,7 +112,8 @@ query.format.vars <- function(bety,input.id=NA,format.id=NA,var.ids=NA){
                    time.row = time.row,
                    site = site.id,
                    lat = site.lat,
-                   lon = site.lon
+                   lon = site.lon,
+                   time_zone = site.time_zone
     )
     
     # Check that all bety units are convertible. If not, throw a warning. 

--- a/db/R/query.format.vars.R
+++ b/db/R/query.format.vars.R
@@ -138,7 +138,8 @@ query.format.vars <- function(bety,input.id=NA,format.id=NA,var.ids=NA){
                    time.row = NULL,
                    site = site.id,
                    lat = site.lat,
-                   lon = site.lon
+                   lon = site.lon,
+                   time_zone = site.time_zone
     )
   }
   return(format)

--- a/modules/data.atmosphere/R/download.Fluxnet2015.R
+++ b/modules/data.atmosphere/R/download.Fluxnet2015.R
@@ -48,7 +48,6 @@ download.Fluxnet2015 <- function(sitename, outfolder, start_date, end_date,
   # get start and end year of data from filename
   syear <- as.numeric(substr(ftplink, nchar(ftplink) - 16, nchar(ftplink) - 13))
   eyear <- as.numeric(substr(ftplink, nchar(ftplink) - 11, nchar(ftplink) - 8))
-  
   if (start_year > eyear) {
     PEcAn.utils::logger.severe("Start_Year", start_year, "exceeds end of record ", eyear, " for ", site)
   }

--- a/modules/data.atmosphere/man/met2CF.csv.Rd
+++ b/modules/data.atmosphere/man/met2CF.csv.Rd
@@ -29,23 +29,21 @@ Units for datetime field are the lubridate function that will be used to parse t
 }
 \examples{
 \dontrun{
-library(PEcAn.DB)
-library(lubridate)
-library(RPostgreSQL)
-bety = list(user='bety', password='bety',
-            host='localhost', dbname='bety', driver='PostgreSQL',
-            write=TRUE)
-con <- db.open(bety)
-in.path <- '/home/carya/sites/willow/'
-in.prefix <- 'FLX_US-WCr_FLUXNET2015_SUBSET_HH_1999-2014_1-1'
+bety = list(user='bety', password='bety',host='localhost', dbname='bety', driver='PostgreSQL',write=TRUE)
+con <- PEcAn.DB::db.open(bety)
+bety$con <- con
+start_date <- lubridate::ymd_hm('200401010000')
+end_date <- lubridate::ymd_hm('200412312330')
+file<-PEcAn.data.atmosphere::download.Fluxnet2015('US-WCr','~/',start_date,end_date)
+in.path <- '~/'
+in.prefix <- file$dbfile.name 
 outfolder <- '~/'
-input.id <- 5000000005
-format <- query.format.vars(input.id=input.id,bety = bety)
-start_date <- ymd_hm('200401010000')
-end_date <- ymd_hm('200412312330')
-PEcAn.data.atmosphere::met2CF.csv(in.path, in.prefix, outfolder,
-                                  start_date, end_date,
-                                  format, overwrite=TRUE)
+format.id <- 5000000001
+format <- PEcAn.DB::query.format.vars(format.id=format.id,bety = bety)
+format$lon <- -92.0
+format$lat <- 45.0
+format$time_zone <- "America/Chicago"
+results<-PEcAn.data.atmosphere::met2CF.csv(in.path, in.prefix, outfolder,start_date, end_date,format, overwrite=TRUE)
 }
 }
 \author{


### PR DESCRIPTION
Changes to met2CF.csv.R and related functions to work with time formatting convention used in storage_type instead of variable units. 

## Description
Function now uses same method as load.data.R in benchmark for time converseion. query.format.vars also return site time zone to use as default time zone for CSV files.

## Motivation and Context
Deals with #1459  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
