### PR TITLE
Allow toggle (line and scatter plots) for visualization

### DIFF
--- a/shiny/workflowPlot/helper.R
+++ b/shiny/workflowPlot/helper.R
@@ -9,4 +9,4 @@ checkAndDownload<-function(packageNames) {
 isInstalled <- function(mypkg){
   is.element(mypkg, installed.packages()[,1])
 }
-checkAndDownload(c('plotly','scales','dplyr'))
+# checkAndDownload(c('plotly','scales','dplyr'))

--- a/shiny/workflowPlot/server.R
+++ b/shiny/workflowPlot/server.R
@@ -4,7 +4,7 @@ library(shiny)
 library(ncdf4)
 library(ggplot2)
 # Helper allows to load functions and variables that could be shared both by server.R and ui.R 
-source('helper.R')
+# source('helper.R')
 library(plotly)
 library(scales)
 library(dplyr)
@@ -65,8 +65,8 @@ server <- shinyServer(function(input, output, session) {
     }
     return(globalDF)
   }  
-  # Update variable names  
-  observe({
+  # Update variable names observeEvent on input$load 
+  observeEvent(input$load,{
     req(input$all_run_id)
     # All information about a model is contained in 'all_run_id' string
     ids_DF <- parse_ids_from_input_runID(input$all_run_id)
@@ -95,7 +95,7 @@ server <- shinyServer(function(input, output, session) {
     validate(
       need(input$all_workflow_id, 'Select workflow id'),
       need(input$all_run_id, 'Select Run id'),
-      need(input$variable_name, 'Click the button to load data')
+      need(input$variable_name, 'Click the button to load data. Please allow some time')
     )
     # Load data
     masterDF <- loadNewData()
@@ -112,12 +112,21 @@ server <- shinyServer(function(input, output, session) {
     ylab <- unique(df$ylab)
     # ggplot function for now scatter plots.
     # TODO Shubham allow line plots as well
-    plt <- ggplot(df, aes(x=dates, y=vals, color=run_id)) + 
-      geom_point() +
+    plt <- ggplot(df, aes(x=dates, y=vals, color=run_id)) 
+    # Toggle chart type using switch
+      switch(input$plotType,
+             "scatterPlot"  = {
+               plt <- plt + geom_point()
+             },
+             "lineChart"  = {
+               plt <- plt + geom_line()
+             }
+      )
+      # geom_point() +
       # Earlier smoothing and y labels
       # geom_smooth(aes(fill = "Spline fit")) +
       # scale_y_continuous(labels=fancy_scientific) +
-      labs(title=title, x=xlab, y=ylab) 
+    plt <- plt + labs(title=title, x=xlab, y=ylab) 
       # Earlier color and fill values
       # scale_color_manual(name = "", values = "black") +
       # scale_fill_manual(name = "", values = "grey50") 

--- a/shiny/workflowPlot/ui.R
+++ b/shiny/workflowPlot/ui.R
@@ -1,5 +1,6 @@
 library(shiny)
-source('helper.R')
+# Helper allows to load functions and variables that could be shared both by server.R and ui.R 
+# source('helper.R')
 # Define UI
 ui <- shinyUI(fluidPage(
   # Application title
@@ -12,7 +13,8 @@ ui <- shinyUI(fluidPage(
       p("Please select the run IDs. You can select multiple IDs"),
       selectizeInput("all_run_id", "Mutliple Run IDs", c(),multiple=TRUE),
       actionButton("load", "Load Model outputs"),
-      selectInput("variable_name", "Variable Name", "")
+      selectInput("variable_name", "Variable Name", ""),
+      radioButtons("plotType", "Plot Type", c("Scatter Plot" = "scatterPlot", "Line Chart" = "lineChart"), selected="scatterPlot")
     ),
     mainPanel(
       plotlyOutput("outputPlot")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. pecan/shiny/workflowPlot/server.R
Switch to allow both type of plots.
Commenting helper.R
observeEvent while loading variable names
2. pecan/shiny/workflowPlot/helper.R
Commenting helper.R
3. pecan/shiny/workflowPlot/ui.R
Commenting helper.R
Allow radio buttons for selecting the choice. Default scatter plot

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Feature required to show line charts as well scatter plots. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
