### PR TITLE
Stop convert.inputs after failed data conversion 

### DIFF
--- a/utils/R/convert.input.R
+++ b/utils/R/convert.input.R
@@ -44,7 +44,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                                           con = con, 
                                           hostname = host$name, 
                                           exact.dates = TRUE
-    )
+                                         )
     
     
     logger.info(paste0("File id =", existing.dbfile$id,
@@ -86,15 +86,15 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
         # Schedule files to be replaced or deleted on exiting the function
         successful <- FALSE
         on.exit(if (exists("successful") && successful) {
-          logger.info("Conversion successful, with overwrite=TRUE. Deleting old files.")
-          remote.execute.R( file.deletion.commands$delete.tmp, 
-                            host, user = NA, 
-                            verbose = TRUE,  R = Rbinary, scratchdir = outfolder )
+                logger.info("Conversion successful, with overwrite=TRUE. Deleting old files.")
+                remote.execute.R( file.deletion.commands$delete.tmp, 
+                                  host, user = NA, 
+                                  verbose = TRUE,  R = Rbinary, scratchdir = outfolder )
         } else {
-          logger.info("Conversion failed. Replacing old files.")
-          remote.execute.R( file.deletion.commands$replace.from.tmp, 
-                            host, user = NA, 
-                            verbose = TRUE, R = Rbinary, scratchdir = outfolder )
+                logger.info("Conversion failed. Replacing old files.")
+                remote.execute.R( file.deletion.commands$replace.from.tmp, 
+                                  host, user = NA, 
+                                  verbose = TRUE, R = Rbinary, scratchdir = outfolder )
         }
         )#Close on.exit
       }
@@ -141,7 +141,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                                           enddate = end_date, 
                                           con = con, 
                                           hostname = host
-    )
+                                         )
     
     logger.info(paste0("File id =", existing.dbfile$id,
                        " File name =", existing.dbfile$file_name,

--- a/utils/R/convert.input.R
+++ b/utils/R/convert.input.R
@@ -146,7 +146,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
     logger.debug("File id =", existing.dbfile$id,
                  " File name =", existing.dbfile$file_name,
                  " File path =", existing.dbfile$file_path,
-                 " Input id =", existing.dbfile$container_id),
+                 " Input id =", existing.dbfile$container_id,
                  digits = 10)
     
     logger.info("end CHECK for existing input record.")

--- a/utils/R/convert.input.R
+++ b/utils/R/convert.input.R
@@ -50,8 +50,8 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
     logger.debug("File id =", existing.dbfile$id,
                  " File name =", existing.dbfile$file_name,
                  " File path =", existing.dbfile$file_path,
-                 " Input id =", existing.dbfile$container_id),
-                digits = 10)
+                 " Input id =", existing.dbfile$container_id,
+                 digits = 10)
     
     logger.info("end CHECK for existing input record")
     
@@ -147,7 +147,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                  " File name =", existing.dbfile$file_name,
                  " File path =", existing.dbfile$file_path,
                  " Input id =", existing.dbfile$container_id),
-                digits = 10)
+                 digits = 10)
     
     logger.info("end CHECK for existing input record.")
     

--- a/utils/R/convert.input.R
+++ b/utils/R/convert.input.R
@@ -26,7 +26,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
   outname <- tail(unlist(strsplit(outfolder, "/")), n = 1)
   
   logger.info(paste("start CHECK Convert.Inputs", fcn, input.id, host$name, outfolder, 
-              formatname, mimetype, site.id, start_date, end_date))
+                    formatname, mimetype, site.id, start_date, end_date))
   
   
   ##----------------------------------------------------------------------------------------------------------------##  
@@ -44,10 +44,14 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                                           con = con, 
                                           hostname = host$name, 
                                           exact.dates = TRUE
-                                          )
+    )
     
-
-    logger.info(existing.dbfile, digits = 10)
+    
+    logger.info(paste0("File id =", existing.dbfile$id,
+                       " File name =", existing.dbfile$file_name,
+                       " File path =", existing.dbfile$file_path,
+                       " Input id =", existing.dbfile$container_id),
+                digits = 10)
     
     logger.info("end CHECK for existing input record")
     
@@ -66,46 +70,46 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
       
       ## Do overwrite if set to TRUE
       if(overwrite){
-         # collect files to flag for deletion
+        # collect files to flag for deletion
         files.to.delete <- remote.execute.R( paste0("list.files('",
-                                             existing.dbfile[["file_path"]],
-                                             "', full.names=TRUE)"),
+                                                    existing.dbfile[["file_path"]],
+                                                    "', full.names=TRUE)"),
                                              host, user = NA, verbose = TRUE,R = Rbinary, scratchdir = outfolder)
-
+        
         file.deletion.commands <- .get.file.deletion.commands(files.to.delete)
-
+        
         remote.execute.R( file.deletion.commands$move.to.tmp,
                           host, user = NA, 
                           verbose = TRUE,R = Rbinary, scratchdir = outfolder)
-
-       
+        
+        
         # Schedule files to be replaced or deleted on exiting the function
         successful <- FALSE
         on.exit(if (exists("successful") && successful) {
-                  logger.info("Conversion successful, with overwrite=TRUE. Deleting old files.")
-                  remote.execute.R( file.deletion.commands$delete.tmp, 
-                                    host, user = NA, 
-                                    verbose = TRUE,  R = Rbinary, scratchdir = outfolder )
-                } else {
-                  logger.info("Conversion failed. Replacing old files.")
-                  remote.execute.R( file.deletion.commands$replace.from.tmp, 
-                                    host, user = NA, 
-                                    verbose = TRUE, R = Rbinary, scratchdir = outfolder )
-                }
+          logger.info("Conversion successful, with overwrite=TRUE. Deleting old files.")
+          remote.execute.R( file.deletion.commands$delete.tmp, 
+                            host, user = NA, 
+                            verbose = TRUE,  R = Rbinary, scratchdir = outfolder )
+        } else {
+          logger.info("Conversion failed. Replacing old files.")
+          remote.execute.R( file.deletion.commands$replace.from.tmp, 
+                            host, user = NA, 
+                            verbose = TRUE, R = Rbinary, scratchdir = outfolder )
+        }
         )#Close on.exit
       }
       
-    
-
+      
+      
       #Grab machine info of file that exists
       existing.machine <- db.query(paste0("SELECT * from machines where id  = '", 
-                                   existing.dbfile$machine_id, "'"), con)
-           
+                                          existing.dbfile$machine_id, "'"), con)
+      
       #Grab machine info of host machine
       machine.host <- ifelse(host$name == "localhost", fqdn(), host$name)
       machine <- db.query(paste0("SELECT * from machines where hostname = '", 
-                          machine.host, "'"), con)
-           
+                                 machine.host, "'"), con)
+      
       if (existing.machine$id != machine$id) {
         
         logger.info("Valid Input record found that spans desired dates, but valid files do not exist on this machine.")
@@ -113,22 +117,22 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
         insert.new.file <- TRUE
         start_date <- existing.input$start_date
         end_date   <- existing.input$end_date
-    
+        
       } else {      
         # There's an existing input that spans desired start/end dates with files on this machine        
         logger.info("Skipping this input conversion because files are already available.")
         return(list(input.id = existing.input$id, dbfile.id = existing.dbfile$id))
       }
-    
+      
       
     } else {
       # No existing record found. Should be good to go with regular conversion.
     }
     
     ##-------------------------end of exact.dates chunk------------------------------------#
-  
+    
   } else {
-
+    
     existing.dbfile <- dbfile.input.check(siteid = site.id,
                                           mimetype = mimetype, 
                                           formatname = formatname,
@@ -136,14 +140,19 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                                           startdate = start_date,
                                           enddate = end_date, 
                                           con = con, 
-                                          hostname = host$name
-                                          )
-      
-    logger.info(existing.dbfile)
+                                          hostname = host
+    )
+    
+    logger.info(paste0("File id =", existing.dbfile$id,
+                       " File name =", existing.dbfile$file_name,
+                       " File path =", existing.dbfile$file_path,
+                       " Input id =", existing.dbfile$container_id),
+                digits = 10)
+    
     logger.info("end CHECK for existing input record.")
-
+    
     if (nrow(existing.dbfile) > 0) {
-
+      
       existing.input <- db.query(paste0("SELECT * FROM inputs WHERE id=", existing.dbfile[["container_id"]]),con)
       
       
@@ -154,50 +163,50 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
       
       existing.input$start_date <- lubridate::force_tz(lubridate::as_date(existing.input$start_date), "UTC")
       existing.input$end_date   <- lubridate::force_tz(lubridate::as_date(existing.input$end_date), "UTC")
-        
+      
       if (overwrite) {
         # collect files to flag for deletion
-
+        
         files.to.delete <- remote.execute.R( paste0("list.files('",
                                                     existing.dbfile[["file_path"]],
                                                     "', full.names=TRUE)"),
-                                                     host, user = NA, verbose = TRUE,R = Rbinary, scratchdir = outfolder)
-
+                                             host, user = NA, verbose = TRUE,R = Rbinary, scratchdir = outfolder)
+        
         file.deletion.commands <- .get.file.deletion.commands(files.to.delete)
-
+        
         remote.execute.R( file.deletion.commands$move.to.tmp,
                           host, user = NA, 
                           verbose = TRUE,R = Rbinary, scratchdir = outfolder)
-
+        
         # Schedule files to be replaced or deleted on exiting the function
         successful <- FALSE
         on.exit(if (exists("successful") && successful) {
-                  logger.info("Conversion successful, with overwrite=TRUE. Deleting old files.")
-                  remote.execute.R( file.deletion.commands$delete.tmp,
-                                    host, user = NA, 
-                                    verbose = TRUE,  R = Rbinary, scratchdir = outfolder )
-
-                } else {
-                      
-                logger.info("Conversion failed. Replacing old files.")
-                remote.execute.R( file.deletion.commands$replace.from.tmp,
-                                  host, user = NA,
-                                  verbose = TRUE, R = Rbinary, scratchdir = outfolder )
-                } 
+          logger.info("Conversion successful, with overwrite=TRUE. Deleting old files.")
+          remote.execute.R( file.deletion.commands$delete.tmp,
+                            host, user = NA, 
+                            verbose = TRUE,  R = Rbinary, scratchdir = outfolder )
+          
+        } else {
+          
+          logger.info("Conversion failed. Replacing old files.")
+          remote.execute.R( file.deletion.commands$replace.from.tmp,
+                            host, user = NA,
+                            verbose = TRUE, R = Rbinary, scratchdir = outfolder )
+        } 
         )#close on on.exit
-
+        
       } else if ((start_date >= existing.input$start_date) &&
                  (end_date <= existing.input$end_date)) {
-
+        
         #Grab machine info of file that exists
         existing.machine <- db.query(paste0("SELECT * from machines where id  = '", 
-                                    existing.dbfile$machine_id, "'"), con)
-
+                                            existing.dbfile$machine_id, "'"), con)
+        
         #Grab machine info of 
         machine.host <- ifelse(host$name == "localhost", fqdn(), host$name)
         machine <- db.query(paste0("SELECT * from machines where hostname = '", 
-                            machine.host, "'"), con)
-
+                                   machine.host, "'"), con)
+        
         if(existing.machine$id != machine$id){
           logger.info("Valid Input record found that spans desired dates, but valid files do not exist on this machine.")
           logger.info("Downloading all years of Valid input to ensure consistency")
@@ -205,11 +214,11 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
           start_date <- existing.input$start_date
           end_date   <- existing.input$end_date
         } else {
-             # There's an existing input that spans desired start/end dates with files on this machine           
-              logger.info("Skipping this input conversion because files are already available.")
-              return(list(input.id = existing.input$id, dbfile.id = existing.dbfile$id))
+          # There's an existing input that spans desired start/end dates with files on this machine           
+          logger.info("Skipping this input conversion because files are already available.")
+          return(list(input.id = existing.input$id, dbfile.id = existing.dbfile$id))
         }
-
+        
       } else {
         # Start/end dates need to be updated so that the input spans a continuous
         # timeframe
@@ -235,7 +244,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
       # No existing record found. Should be good to go.
     }
   }
-    
+  
   #---------------------------------------------------------------------------------------------------------------#
   # Get machine information
   
@@ -384,7 +393,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
     fcn.args$end_date   <- end_date
     
     arg.string <- listToArgString(fcn.args)
-
+    
     if (!missing(format.vars)) {
       arg.string <- paste0(arg.string, ", format=", paste0(list(format.vars)))
     }
@@ -398,6 +407,11 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
   logger.info("RESULTS: Convert.Input")
   logger.info(result)
   logger.info(names(result))
+  
+  if (length(result) == 1){
+    logger.debug(paste0("Processing data failed, please check validity of args:", arg.string))
+    logger.severe(paste0("Unable to process data using this function:",fcn))
+  }
   
   #--------------------------------------------------------------------------------------------------#
   # Insert into Database
@@ -435,7 +449,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
     if ("newsite" %in% names(input.args) && !is.null(input.args[["newsite"]])) {
       site.id <- input.args$newsite
     }
-
+    
     if (insert.new.file) {
       dbfile.id <- dbfile.insert(in.path = dirname(result$file[1]), 
                                  in.prefix = result$dbfile.name[1], 
@@ -457,7 +471,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                                       hostname = machine$hostname,
                                       allow.conflicting.dates = allow.conflicting.dates)  
     }
-
+    
     successful <- TRUE
     return(newinput)
   } else {

--- a/utils/R/convert.input.R
+++ b/utils/R/convert.input.R
@@ -47,10 +47,10 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                                          )
     
     
-    logger.info(paste0("File id =", existing.dbfile$id,
-                       " File name =", existing.dbfile$file_name,
-                       " File path =", existing.dbfile$file_path,
-                       " Input id =", existing.dbfile$container_id),
+    logger.debug("File id =", existing.dbfile$id,
+                 " File name =", existing.dbfile$file_name,
+                 " File path =", existing.dbfile$file_path,
+                 " Input id =", existing.dbfile$container_id),
                 digits = 10)
     
     logger.info("end CHECK for existing input record")
@@ -143,10 +143,10 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                                           hostname = host
                                          )
     
-    logger.info(paste0("File id =", existing.dbfile$id,
-                       " File name =", existing.dbfile$file_name,
-                       " File path =", existing.dbfile$file_path,
-                       " Input id =", existing.dbfile$container_id),
+    logger.debug("File id =", existing.dbfile$id,
+                 " File name =", existing.dbfile$file_name,
+                 " File path =", existing.dbfile$file_path,
+                 " Input id =", existing.dbfile$container_id),
                 digits = 10)
     
     logger.info("end CHECK for existing input record.")
@@ -408,7 +408,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
   logger.info(result)
   logger.info(names(result))
   
-  if (length(result) == 1){
+  if (length(result) <= 1){
     logger.debug(paste0("Processing data failed, please check validity of args:", arg.string))
     logger.severe(paste0("Unable to process data using this function:",fcn))
   }


### PR DESCRIPTION
Within convert.inputs, if a conversion of data (i.e. download of raw met data) failed there was not a check for whether or not the `result` object was actually valid and it would continue on to update input records. Lines 411-415 should fix that.

I also added more explicit logger info at lines 51 and 146 to help debugging.

This closes #1500 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
