### PR TITLE
Update plantWood IC in write.configs.SIPNET

### DIFF
--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -364,8 +364,11 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
     IC.nc <- try(ncdf4::nc_open(IC.path)) 
     if(class(IC.nc) != "try-error"){
         ## plantWoodInit gC/m2
-      plantWood <- try(ncdf4::ncvar_get(IC.nc,"AbvGrndWood"),silent = TRUE)
-      if (!is.na(plantWood) && is.numeric(plantWood)) {
+      AbvGrndWood <- try(ncdf4::ncvar_get(IC.nc,"AbvGrndWood"),silent = TRUE)
+      if (!is.na(AbvGrndWood) && is.numeric(AbvGrndWood)) {
+        fineRootFrac <- param[which(param[, 1] == "fineRootFrac"), 2] 
+        coarseRootFrac <- param[which(param[, 1] == "coarseRootFrac"), 2] 
+        plantWood <- AbvGrndWood/(1-(fineRootFrac+coarseRootFrac)) #inflate plantWood to include belowground 
         param[which(param[, 1] == "plantWoodInit"), 2] <- plantWood * 1000 #PEcAn standard AbvGrndWood kgC/m2
       }
       else{
@@ -407,6 +410,9 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
       
       #close file
       ncdf4::nc_close(IC.nc)
+    }
+    else{
+      PEcAn.utils::logger.error("Bad initial conditions filepath")
     }
   }else{
     #some stuff about IC file that we can give in lieu of actual ICs

--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -361,52 +361,53 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
   }
   else if (!is.null(settings$run$inputs$poolinitcond$path)) {
     IC.path <- settings$run$inputs$poolinitcond$path
-    IC.nc <- ncdf4::nc_open(IC.path) #check for successful open?
-    
-    ## plantWoodInit gC/m2
-    plantWood <- try(ncdf4::ncvar_get(IC.nc,"AbvGrndWood"),silent = TRUE)
-    if (!is.na(plantWood) && is.numeric(plantWood)) {
-      param[which(param[, 1] == "plantWoodInit"), 2] <- plantWood * 1000 #PEcAn standard AbvGrndWood kgC/m2
+    IC.nc <- try(ncdf4::nc_open(IC.path)) 
+    if(class(IC.nc) != "try-error"){
+        ## plantWoodInit gC/m2
+      plantWood <- try(ncdf4::ncvar_get(IC.nc,"AbvGrndWood"),silent = TRUE)
+      if (!is.na(plantWood) && is.numeric(plantWood)) {
+        param[which(param[, 1] == "plantWoodInit"), 2] <- plantWood * 1000 #PEcAn standard AbvGrndWood kgC/m2
+      }
+      else{
+        #try back-calculate from LAI,sla, and total biomass? where is total biomass?
+      }
+      ## laiInit m2/m2
+      lai <- try(ncdf4::ncvar_get(IC.nc,"LAI"),silent = TRUE)
+      if (!is.na(lai) && is.numeric(lai)) {
+        param[which(param[, 1] == "laiInit"), 2] <- lai
+      }
+      ## litterInit gC/m2
+      litter <- try(ncdf4::ncvar_get(IC.nc,"litter_carbon_content"),silent = TRUE)
+      if (!is.na(litter) && is.numeric(litter)) {
+        param[which(param[, 1] == "litterInit"), 2] <- litter * 1000 #PEcAn standard litter_carbon_content kg/m2
+      }
+      ## soilInit gC/m2
+      soil <- try(ncdf4::ncvar_get(IC.nc,"soil_carbon_content"),silent = TRUE)
+      if (!is.na(soil) && is.numeric(soil)) {
+        param[which(param[, 1] == "soilInit"), 2] <- sum(soil) * 1000 #PEcAn standard TotSoilCarb kg C/m2
+      }
+      ## soilWFracInit fraction
+      soilWFrac <- try(ncdf4::ncvar_get(IC.nc,"SoilMoistFrac"),silent = TRUE)
+      if (!is.na(soilWFrac) && is.numeric(soilWFrac)) {
+        param[which(param[, 1] == "soilWFracInit"), 2] <- sum(soilWFrac)
+      }
+      ## litterWFracInit fraction
+      litterWFrac <- soilWFrac
+      
+      ## snowInit cm water equivalent
+      snow = try(ncdf4::ncvar_get(IC.nc,"SWE"),silent = TRUE)
+      if (!is.na(snow) && is.numeric(snow)) {
+        param[which(param[, 1] == "snowInit"), 2] <- snow*0.1 #PEcAn standard SWE kg/m2 (1kg = 1mm)
+      }
+      ## microbeInit mgC/g soil
+      microbe <- try(ncdf4::ncvar_get(IC.nc,"Microbial Biomass C"),silent = TRUE)
+      if (!is.na(microbe) && is.numeric(microbe)) {
+        param[which(param[, 1] == "microbeInit"), 2] <- microbe * .001 #BETY Microbial Biomass C mg C kg-1 soil
+      }
+      
+      #close file
+      ncdf4::nc_close(IC.nc)
     }
-    else{
-      #try back-calculate from LAI,sla, and total biomass? where is total biomass?
-    }
-    ## laiInit m2/m2
-    lai <- try(ncdf4::ncvar_get(IC.nc,"LAI"),silent = TRUE)
-    if (!is.na(lai) && is.numeric(lai)) {
-      param[which(param[, 1] == "laiInit"), 2] <- lai
-    }
-    ## litterInit gC/m2
-    litter <- try(ncdf4::ncvar_get(IC.nc,"litter_carbon_content"),silent = TRUE)
-    if (!is.na(litter) && is.numeric(litter)) {
-      param[which(param[, 1] == "litterInit"), 2] <- litter * 1000 #PEcAn standard litter_carbon_content kg/m2
-    }
-    ## soilInit gC/m2
-    soil <- try(ncdf4::ncvar_get(IC.nc,"soil_carbon_content"),silent = TRUE)
-    if (!is.na(soil) && is.numeric(soil)) {
-      param[which(param[, 1] == "soilInit"), 2] <- sum(soil) * 1000 #PEcAn standard TotSoilCarb kg C/m2
-    }
-    ## soilWFracInit fraction
-    soilWFrac <- try(ncdf4::ncvar_get(IC.nc,"SoilMoistFrac"),silent = TRUE)
-    if (!is.na(soilWFrac) && is.numeric(soilWFrac)) {
-      param[which(param[, 1] == "soilWFracInit"), 2] <- sum(soilWFrac)
-    }
-    ## litterWFracInit fraction
-    litterWFrac <- soilWFrac
-    
-    ## snowInit cm water equivalent
-    snow = try(ncdf4::ncvar_get(IC.nc,"SWE"),silent = TRUE)
-    if (!is.na(snow) && is.numeric(snow)) {
-      param[which(param[, 1] == "snowInit"), 2] <- snow*0.1 #PEcAn standard SWE kg/m2 (1kg = 1mm)
-    }
-    ## microbeInit mgC/g soil
-    microbe <- try(ncdf4::ncvar_get(IC.nc,"Microbial Biomass C"),silent = TRUE)
-    if (!is.na(microbe) && is.numeric(microbe)) {
-      param[which(param[, 1] == "microbeInit"), 2] <- microbe * .001 #BETY Microbial Biomass C mg C kg-1 soil
-    }
-    
-    #close file
-    ncdf4::nc_close(IC.nc)
   }else{
     #some stuff about IC file that we can give in lieu of actual ICs
   }

--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -412,7 +412,7 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
       ncdf4::nc_close(IC.nc)
     }
     else{
-      PEcAn.utils::logger.error("Bad initial conditions filepath")
+      PEcAn.utils::logger.error("Bad initial conditions filepath; kept defaults")
     }
   }else{
     #some stuff about IC file that we can give in lieu of actual ICs


### PR DESCRIPTION
Sipnet's initial condition for plantWood includes both above ground woody C and roots, but our IC workflow/standard variables are equipped to pass in AbvGrndWood. This change estimates total wood by incorporating the fineRootFrac and coarseRootFrac parameters. Also added a check on the IC netcdf file opening.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
