### PR TITLE
Always name files as "Geostreams" not "Clowder"

### DIFF
--- a/modules/data.atmosphere/R/download.Geostreams.R
+++ b/modules/data.atmosphere/R/download.Geostreams.R
@@ -75,7 +75,7 @@ download.Geostreams <- function(outfolder, sitename,
     dir.create(outfolder, showWarnings = FALSE, recursive = TRUE)
     out_file <- file.path(
       outfolder,
-      paste("Clowder", sitename, start_date, end_date, year, "json", sep="."))
+      paste("Geostreams", sitename, start_date, end_date, year, "json", sep="."))
     write(x = combined_result, file=out_file)
     result_files = append(result_files, out_file)
   }
@@ -86,7 +86,7 @@ download.Geostreams <- function(outfolder, sitename,
                     formatname = "Geostreams met",
                     startdate = start_date,
                     enddate = end_date,
-                    dbfile.name = paste("Clowder", sitename, start_date, end_date, sep = "."),
+                    dbfile.name = paste("Geostreams", sitename, start_date, end_date, sep = "."),
                     stringsAsFactors = FALSE))
 }
 

--- a/web/03-inputs.php
+++ b/web/03-inputs.php
@@ -160,7 +160,7 @@ foreach($modeltypes as $type) {
       // Geostreams sites have no systematic naming scheme yet. For now, enumerating known patterns
       if (preg_match("/Full Field/", $siteinfo["sitename"]) // Maricopa AZ
           || preg_match("/UIUC Energy Farm/", $siteinfo["sitename"])){ // Urbana IL (3 sites)
-        $x['files'][] = array("id"=>"Clowder." . $type, "name"=>"Use Clowder-Geostreams");
+        $x['files'][] = array("id"=>"Geostreams." . $type, "name"=>"Use Clowder-Geostreams");
       }
       if (preg_match("/ \(US-.*\)$/", $siteinfo["sitename"])) {
         $x['files'][] = array("id"=>"AmerifluxLBL." . $type, "name"=>"Use AmerifluxLBL");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Was saving Geostreams downloads as "Clowder.<dates>.json", but workflow expects the met name to match what's declared in register.<metname>.xml. This resulted in a confusing web workflow error (`XML content does not seem to be XML: ''`), which turns out to really mean "I'm looking for a `register.Clowder.xml` and not finding one."

Fixed by always naming the files "Geostreams".

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
