### PR TITLE
Fix to differentiate GFDL 

### DIFF
--- a/db/R/dbfiles.R
+++ b/db/R/dbfiles.R
@@ -195,6 +195,11 @@ dbfile.input.check <- function(siteid, startdate=NULL, enddate=NULL, mimetype, f
     
     ## parent check when NA
     if(is.na(parentid)){
+      
+      if (pattern == "GFDL"){
+        ##GFDL Special case
+        inputs <-inputs[grepl(pattern, inputs$name),]
+      }
       inputs <- inputs[is.na(inputs$parent_id),]
     }
     

--- a/modules/data.atmosphere/R/download.raw.met.module.R
+++ b/modules/data.atmosphere/R/download.raw.met.module.R
@@ -21,7 +21,8 @@
                             lat.in = lat.in, lon.in = lon.in, 
                             model = input_met$model, 
                             scenario = input_met$scenario, 
-                            ensemble_member = input_met$ensemble_member)
+                            ensemble_member = input_met$ensemble_member,
+                            met = met)
     
   } else if (register$scale == "site") {
     # Site-level met

--- a/utils/R/convert.input.R
+++ b/utils/R/convert.input.R
@@ -43,7 +43,8 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                                           enddate = end_date, 
                                           con = con, 
                                           hostname = host$name, 
-                                          exact.dates = TRUE
+                                          exact.dates = TRUE,
+                                          pattern = met
                                          )
     
     
@@ -140,7 +141,8 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                                           startdate = start_date,
                                           enddate = end_date, 
                                           con = con, 
-                                          hostname = host
+                                          hostname = host,
+                                          pattern = met
                                          )
     
     logger.debug("File id =", existing.dbfile$id,


### PR DESCRIPTION
Within the checks for met, GFDL was being confused for CRUNCEP because they have the same formats. To alleviate this a special check was added to look for the string "GFDL" in the valid inputs that are found and return only rows with "GFDL" in them.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
