### PR TITLE
Default for met source setting in convert.inputs

### DIFF
--- a/db/R/dbfiles.R
+++ b/db/R/dbfiles.R
@@ -196,10 +196,11 @@ dbfile.input.check <- function(siteid, startdate=NULL, enddate=NULL, mimetype, f
     ## parent check when NA
     if(is.na(parentid)){
       
-      if (pattern == "GFDL"){
-        ##GFDL Special case
+      if (!is.null(pattern)){
+        ## Case where pattern is not NULL
         inputs <-inputs[grepl(pattern, inputs$name),]
       }
+      
       inputs <- inputs[is.na(inputs$parent_id),]
     }
     

--- a/modules/data.atmosphere/R/download.raw.met.module.R
+++ b/modules/data.atmosphere/R/download.raw.met.module.R
@@ -22,7 +22,7 @@
                             model = input_met$model, 
                             scenario = input_met$scenario, 
                             ensemble_member = input_met$ensemble_member,
-                            met = met)
+                            pattern = met)
     
   } else if (register$scale == "site") {
     # Site-level met

--- a/utils/R/convert.input.R
+++ b/utils/R/convert.input.R
@@ -9,7 +9,7 @@
 convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, start_date, 
                           end_date, pkg, fcn, con = con, host, browndog, write = TRUE, 
                           format.vars, overwrite = FALSE, exact.dates = FALSE, 
-                          allow.conflicting.dates = TRUE, insert.new.file = FALSE, met = NULL,...) {
+                          allow.conflicting.dates = TRUE, insert.new.file = FALSE, pattern = NULL,...) {
   input.args <- list(...)
   
   logger.debug(paste("Convert.Inputs", fcn, input.id, host$name, outfolder, formatname, 
@@ -44,7 +44,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                                           con = con, 
                                           hostname = host$name, 
                                           exact.dates = TRUE,
-                                          pattern = met
+                                          pattern = pattern
                                          )
     
     
@@ -142,7 +142,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                                           enddate = end_date, 
                                           con = con, 
                                           hostname = host,
-                                          pattern = met
+                                          pattern = pattern
                                          )
     
     logger.debug("File id =", existing.dbfile$id,

--- a/utils/R/convert.input.R
+++ b/utils/R/convert.input.R
@@ -9,7 +9,7 @@
 convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, start_date, 
                           end_date, pkg, fcn, con = con, host, browndog, write = TRUE, 
                           format.vars, overwrite = FALSE, exact.dates = FALSE, 
-                          allow.conflicting.dates = TRUE, insert.new.file = FALSE,...) {
+                          allow.conflicting.dates = TRUE, insert.new.file = FALSE, met = NULL,...) {
   input.args <- list(...)
   
   logger.debug(paste("Convert.Inputs", fcn, input.id, host$name, outfolder, formatname, 

--- a/utils/man/convert.input.Rd
+++ b/utils/man/convert.input.Rd
@@ -7,7 +7,7 @@
 convert.input(input.id, outfolder, formatname, mimetype, site.id, start_date,
   end_date, pkg, fcn, con = con, host, browndog, write = TRUE, format.vars,
   overwrite = FALSE, exact.dates = FALSE, allow.conflicting.dates = TRUE,
-  insert.new.file = FALSE, ...)
+  insert.new.file = FALSE, met = NULL, ...)
 }
 \description{
 Convert input by applying fcn and insert new record into database

--- a/utils/man/convert.input.Rd
+++ b/utils/man/convert.input.Rd
@@ -7,7 +7,7 @@
 convert.input(input.id, outfolder, formatname, mimetype, site.id, start_date,
   end_date, pkg, fcn, con = con, host, browndog, write = TRUE, format.vars,
   overwrite = FALSE, exact.dates = FALSE, allow.conflicting.dates = TRUE,
-  insert.new.file = FALSE, met = NULL, ...)
+  insert.new.file = FALSE, pattern = NULL, ...)
 }
 \description{
 Convert input by applying fcn and insert new record into database


### PR DESCRIPTION
Without setting the met as Null, it was messing up run that did not require that argument so it needed a default setting.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
