### PR TITLE
install PEcAn packages before resolving dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ALL_PKGS_D := $(BASE_D) $(MODELS_D) $(MODULES_D) .doc/models/template
 
 .PHONY: all install check test document
 
-all: document install
+all: install document
 
 document: .doc/all
 install: .install/all
@@ -60,8 +60,9 @@ $(call depends,modules/meta.analysis): .install/utils .install/db
 $(call depends,modules/priors): .install/utils
 $(call depends,modules/assim.batch): .install/utils .install/db .install/modules/meta.analysis 
 $(call depends,modules/rtm): .install/modules/assim.batch
+$(call depends,modules/uncertainty): .install/utils .install/modules/priors
 $(call depends,models/template): .install/utils
-$(call depends,models/biocro): .install/utils .install/modules/data.atmosphere .install/modules/data.land
+$(call depends,models/biocro): .install/utils .install/settings .install/db .install/modules/data.atmosphere .install/modules/data.land
 
 $(MODELS_I): .install/models/template
 
@@ -85,7 +86,7 @@ clean:
 	mkdir -p $(@D)
 	echo `date` > $@
 
-depends_R_pkg = Rscript -e "devtools::install_deps('$(strip $(1))', Ncpus = ${NCPUS});"
+depends_R_pkg = Rscript -e "devtools::install_deps('$(strip $(1))', threads = ${NCPUS});"
 install_R_pkg = Rscript -e "devtools::install('$(strip $(1))', Ncpus = ${NCPUS});"
 check_R_pkg = Rscript scripts/check_with_errors.R $(strip $(1))
 test_R_pkg = Rscript -e "devtools::test('"$(strip $(1))"', reporter = 'stop')"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Prevent build errors by ensuring that all PEcAn packages are installed before `devtools::install_deps` is invoked

## Description
<!--- Describe your changes in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Make was failing after clean R installations, but succeeding when older versions of all dependency packages were available. There appear to be two simultaneous issues here: 

* the Makefile's dependency lists for Biocro and uncertainty were out of date*
* `devtools::install_deps` tries to resolve dependencies by installing them from one specified repository, so it doesn't know what to do with a package that Depends on, say, both `PEcAn.db` (local) and `ncdf4` (CRAN).

Switching the `all` recipe from `document install` to `install document` seems to make everything happen in the correct order on my system, but please check my assumptions.


*P.S. While I'm looking at Make dependencies, I suspect the BioCro line is in practice acting as the depends for all the models -- all of them at least import `PEcAn.util`, but most models have no dependency line in the Makefile. If the current arrangement works, is there any problem with that?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 