### PR TITLE
fix order of dims to prevent nc_create error

### DIFF
--- a/models/dalec/R/model2netcdf.DALEC.R
+++ b/models/dalec/R/model2netcdf.DALEC.R
@@ -78,7 +78,7 @@ model2netcdf.DALEC <- function(outdir, sitelat, sitelon, start_date, end_date) {
     lat <- ncdim_def("lat", "degrees_north", vals = as.numeric(sitelat), longname = "station_latitude")
     lon <- ncdim_def("lon", "degrees_east", vals = as.numeric(sitelon), longname = "station_longitude")
    
-    dims <- list(time = t, lon = lon, lat = lat)
+    dims <- list(lon = lon, lat = lat, time = t)
     ## ***** Need to dynamically update the UTC offset here *****
     
     for (i in seq_along(output)) {


### PR DESCRIPTION
When I updated model2netcdf.DALEC to use the new standard variables and a new to_ncvar function, I put the dimensions in the wrong order, causing an error in nc_create. Now the model output should successfully write to netcdf.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
