### PR TITLE
Bugfix: Passing host list, when should be hostname

### DIFF
--- a/utils/R/convert.input.R
+++ b/utils/R/convert.input.R
@@ -141,7 +141,7 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
                                           startdate = start_date,
                                           enddate = end_date, 
                                           con = con, 
-                                          hostname = host,
+                                          hostname = host$name,
                                           pattern = pattern
                                          )
     


### PR DESCRIPTION
This was causing #1522. Based on preliminary tests, this is no longer hitting that particular bug. Can't speak to other bugs yet.
