### PR TITLE
Fix broken error message in jagify

### DIFF
--- a/modules/meta.analysis/R/jagify.R
+++ b/modules/meta.analysis/R/jagify.R
@@ -36,9 +36,11 @@ jagify <- function(result) {
               select = c("stat", "n", "site_id", "trt_id", "mean", "citation_id", "greenhouse"))
   
   if (length(r$stat[!is.na(r$stat) & r$stat <= 0]) > 0) {
+    varswithbadstats <- unique(result$vname[which(r$stat <= 0)])
     citationswithbadstats <- unique(r$citation_id[which(r$stat <= 0)])
+    
     logger.warn("there are implausible values of SE: SE <= 0 \n",
-                "for", names(result)[i], 
+                "for", varswithbadstats, 
                 "result from citation", citationswithbadstats, "\n", 
                 "SE <=0 set to NA \n")
     r$stat[r$stat <= 0] <- NA


### PR DESCRIPTION
The jagify function in meta-analysis had an error message for unreasonable standard errors which had an uninitialized variable (probably from an old copy and paste from a for loop) which prevented the error message from showing. Replaced the broken part.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
