### PR TITLE
Add jagify stat=0 check 

### DIFF
--- a/modules/meta.analysis/R/jagify.R
+++ b/modules/meta.analysis/R/jagify.R
@@ -60,6 +60,9 @@ jagify <- function(result) {
 ##' 
 ##' @return A data frame NAs sensibly replaced 
 transform.nas <- function(data) {
+  #set stat to NA if 0 (uncertainties can only asymptotically approach 0)
+  data$stat[data$stat == 0] <- NA
+  
   # control defaults to 1
   data$control[is.na(data$control)] <- 1
   


### PR DESCRIPTION
Add jagify check to change stat=0 to stat=NA. Uncertainty stats can't be 0. Before, the illogical case of stat being nonNA (set as 0 in some raw field data) when n = 1 led to n being set to 2. See pr #1574 for discussion.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
