### PR TITLE
Improve read.output

### DIFF
--- a/utils/R/read.output.R
+++ b/utils/R/read.output.R
@@ -107,6 +107,7 @@ read.output <- function(runid, outdir, start.year = NA, end.year = NA, variables
     keep <- which(nc.years >= as.numeric(start.year) & nc.years <= as.numeric(end.year))
     ncfiles <- ncfiles[keep]
   } else if(length(nc.years) != 0){
+      PEcAn.utils::logger.info("No start or end year provided; reading output for all years")
       start.year <- min(nc.years)
       end.year <- max(nc.years)
   }
@@ -115,7 +116,7 @@ read.output <- function(runid, outdir, start.year = NA, end.year = NA, variables
   nofiles <- FALSE
   if (length(ncfiles) == 0) {
     logger.warn("read.output: no netCDF files of model output present for runid = ", 
-                runid, " in ", outdir, "will return NA")
+                runid, " in ", outdir, " for years requested; will return NA")
     if (length(nc.years) > 0) {
       logger.info("netCDF files for other years present", nc.years)
     }

--- a/utils/R/read.output.R
+++ b/utils/R/read.output.R
@@ -100,10 +100,17 @@ read.output <- function(runid, outdir, start.year = NA, end.year = NA, variables
   # create list of *.nc years
   nc.years <- as.vector(unlist(strsplit(list.files(path = outdir, pattern = "\\.nc$", 
                                                    full.names = FALSE), ".nc")))
-  # select only those *.nc years requested by user
-  keep <- which(nc.years >= as.numeric(start.year) & nc.years <= as.numeric(end.year))
   ncfiles <- list.files(path = outdir, pattern = "\\.nc$", full.names = TRUE)
-  ncfiles <- ncfiles[keep]
+  
+  if(!is.na(start.year) && !is.na(end.year)){
+    # select only those *.nc years requested by user
+    keep <- which(nc.years >= as.numeric(start.year) & nc.years <= as.numeric(end.year))
+    ncfiles <- ncfiles[keep]
+  } else if(length(nc.years) != 0){
+      start.year <- min(nc.years)
+      end.year <- max(nc.years)
+  }
+  
   # throw error if no *.nc files selected/availible
   nofiles <- FALSE
   if (length(ncfiles) == 0) {


### PR DESCRIPTION
Currently read.output has start.year and end.year arguments that default to NA. However, this results in no output and several warning messages. @ashiklom suggested it would make more sense to have the function return all years if no limits are passed in. Added a simple check for NA start or end years. Could be more complex, e.g. accepting a start or end year without the other, but this will at least allow the no years provided case to work.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
