### PR TITLE
update CHANGELOG for past PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 
 ### Fixes
 - Fixed remote code execution #1545
+- Added check for NA end/start year in read.output
+- Fixed jagify bug for raw field data
+- Fixed bug (order of dims in nc_create) introduced in model2netcdf.DALEC by standard_vars changes
+
+### Added
+- Expanded initial conditions workflow for pool-based models, including PEcAn.data.land::prepare_pools to calculate pools from IC file (to be coupled with write.configs)
 
 ## [1.5.10] - Prerelease
 ### Added
@@ -19,6 +25,8 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - added docker container scrips (.yml) to create docker container for PEcAn
 - added the configuration edit page to allow easy modification of config via web interface
 - thredds server documentation and catlog generating script
+- added new standard variables table (standard_vars.csv) and to_ncvar and to_ncdim functions in PEcAn.utils
+- added initial conditions file io functions for pool-based models in data.land
 
 ### Changed
 - upscale_met now accepts ~any valid CF file (not just full years), retains correct time units, and respects the previously ignored `overwrite` parameter


### PR DESCRIPTION
Retroactive notes in CHANGELOG.md for my past pull requests. I'm assuming it's still useful to add notes to the past release as well as the current pre-release?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
