### PR TITLE
Improve makefile logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 ## [Unreleased]
 
 ### Fixes
+- Improved make install logic (#1558)
 - Fixed remote code execution #1545
 - Added check for NA end/start year in read.output
 - Fixed jagify bug for raw field data

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NCPUS ?= 1
 
-BASE := logger utils db settings visualization
+BASE := utils db settings visualization
 
 MODELS := biocro clm45 dalec ed fates gday jules linkages \
 				lpjguess maat maespa preles sipnet
@@ -10,7 +10,6 @@ MODULES := allometry assim.batch assim.sequential benchmark \
 				 data.mining data.remote emulator meta.analysis \
 				 photosynthesis priors rtm uncertainty
 
-BASE := $(BASE:%=base/%)
 MODELS := $(MODELS:%=models/%)
 MODULES := $(MODULES:%=modules/%)
 ALL_PKGS := $(BASE) $(MODELS) $(MODULES) models/template
@@ -30,46 +29,39 @@ MODELS_T := $(MODELS:%=.test/%)
 MODULES_T := $(MODULES:%=.test/%)
 ALL_PKGS_T := $(BASE_T) $(MODELS_T) $(MODULES_T) .test/models/template
 
-BASE_D := $(BASE:%=.doc/%)
-MODELS_D := $(MODELS:%=.doc/%)
-MODULES_D := $(MODULES:%=.doc/%)
-ALL_PKGS_D := $(BASE_D) $(MODELS_D) $(MODULES_D) .doc/models/template
+.PHONY: all install check test
 
-.PHONY: all install check test document
+all: install
 
-all: install document
-
-document: .doc/base/all
-install: .install/base/all
-check: .check/base/all
-test: .test/base/all 
+install: .install/all
+check: .check/all
+test: .test/all 
 
 ### Dependencies
-.doc/base/all: $(ALL_PKGS_D)
-.install/base/all: $(ALL_PKGS_I)
-.check/base/all: $(ALL_PKGS_C)
-.test/base/all: $(ALL_PKGS_T)
+.install/all: $(ALL_PKGS_I)
+.check/all: $(ALL_PKGS_C)
+.test/all: $(ALL_PKGS_T)
 
-depends = .check/$(1) .test/$(1)
+depends = .install/$(1) .check/$(1) .test/$(1)
 
-$(call depends,base/db): .install/base/logger .install/base/utils
-$(call depends,base/settings): .install/base/logger .install/base/utils .install/base/db
-$(call depends,base/visualization): .install/base/logger .install/base/db
-$(call depends,modules/data.atmosphere): .install/base/logger .install/base/utils
-$(call depends,modules/data.land): .install/base/logger .install/base/db .install/base/utils
-$(call depends,modules/meta.analysis): .install/base/logger .install/base/utils .install/base/db
-$(call depends,modules/priors): .install/base/logger .install/base/utils
-$(call depends,modules/assim.batch): .install/base/logger .install/base/utils .install/base/db .install/modules/meta.analysis 
-$(call depends,modules/rtm): .install/base/logger .install/modules/assim.batch
-$(call depends,modules/uncertainty): .install/base/logger .install/base/utils .install/modules/priors
-$(call depends,models/template): .install/base/logger .install/base/utils
-$(call depends,models/biocro): .install/base/logger .install/base/utils .install/base/settings .install/base/db .install/modules/data.atmosphere .install/modules/data.land
+$(call depends,db): .install/utils
+$(call depends,settings): .install/utils .install/db
+$(call depends,visualization): .install/db
+$(call depends,modules/data.atmosphere): .install/utils
+$(call depends,modules/data.land): .install/db .install/utils
+$(call depends,modules/meta.analysis): .install/utils .install/db
+$(call depends,modules/priors): .install/utils
+$(call depends,modules/assim.batch): .install/utils .install/db .install/modules/meta.analysis 
+$(call depends,modules/rtm): .install/modules/assim.batch
+$(call depends,modules/uncertainty): .install/utils .install/modules/priors
+$(call depends,models/template): .install/utils
+$(call depends,models/biocro): .install/utils .install/settings .install/db .install/modules/data.atmosphere .install/modules/data.land
 
 $(MODELS_I): .install/models/template
 
 
 clean:
-	rm -rf .install .check .test .doc
+	rm -rf .install .check .test
 	find modules/rtm/src \( -name \*.mod -o -name \*.o -o -name \*.so \) -delete
 
 .install/devtools:
@@ -93,16 +85,12 @@ check_R_pkg = Rscript scripts/check_with_errors.R $(strip $(1))
 test_R_pkg = Rscript -e "devtools::test('"$(strip $(1))"', reporter = 'stop')"
 doc_R_pkg = Rscript -e "devtools::document('"$(strip $(1))"')"
 
-$(ALL_PKGS_I) $(ALL_PKGS_C) $(ALL_PKGS_T) $(ALL_PKGS_D): .install/devtools .install/roxygen2 .install/testthat
+$(ALL_PKGS_I) $(ALL_PKGS_C) $(ALL_PKGS_T): .install/devtools .install/roxygen2 .install/testthat
 
 .SECONDEXPANSION:
-.doc/%: $$(wildcard %/**/*) $$(wildcard %/*)
+.install/%: $$(wildcard %/**/*) $$(wildcard %/*)
 	$(call depends_R_pkg, $(subst .doc/,,$@))
 	$(call doc_R_pkg, $(subst .doc/,,$@))
-	mkdir -p $(@D)
-	echo `date` > $@
-
-.install/%: $$(wildcard %/**/*) $$(wildcard %/*)
 	$(call install_R_pkg, $(subst .install/,,$@))
 	mkdir -p $(@D)
 	echo `date` > $@

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NCPUS ?= 1
 
-BASE := utils db settings visualization
+BASE := logger utils db settings visualization
 
 MODELS := biocro clm45 dalec ed fates gday jules linkages \
 				lpjguess maat maespa preles sipnet
@@ -10,6 +10,7 @@ MODULES := allometry assim.batch assim.sequential benchmark \
 				 data.mining data.remote emulator meta.analysis \
 				 photosynthesis priors rtm uncertainty
 
+BASE := $(BASE:%=base/%)
 MODELS := $(MODELS:%=models/%)
 MODULES := $(MODULES:%=modules/%)
 ALL_PKGS := $(BASE) $(MODELS) $(MODULES) models/template
@@ -29,39 +30,46 @@ MODELS_T := $(MODELS:%=.test/%)
 MODULES_T := $(MODULES:%=.test/%)
 ALL_PKGS_T := $(BASE_T) $(MODELS_T) $(MODULES_T) .test/models/template
 
-.PHONY: all install check test
+BASE_D := $(BASE:%=.doc/%)
+MODELS_D := $(MODELS:%=.doc/%)
+MODULES_D := $(MODULES:%=.doc/%)
+ALL_PKGS_D := $(BASE_D) $(MODELS_D) $(MODULES_D) .doc/models/template
 
-all: install
+.PHONY: all install check test document
 
-install: .install/all
-check: .check/all
-test: .test/all 
+all: install document
+
+document: $(ALL_PKGS_D) .doc/base/all
+install: $(ALL_PKGS_I) .install/base/all
+check: $(ALL_PKGS_C) .check/base/all
+test: $(ALL_PKGS_T) .test/base/all 
 
 ### Dependencies
-.install/all: $(ALL_PKGS_I)
-.check/all: $(ALL_PKGS_C)
-.test/all: $(ALL_PKGS_T)
+.doc/base/all: $(ALL_PKGS_D)
+.install/base/all: $(ALL_PKGS_I)
+.check/base/all: $(ALL_PKGS_C)
+.test/base/all: $(ALL_PKGS_T)
 
-depends = .install/$(1) .check/$(1) .test/$(1)
+depends = .check/$(1) .test/$(1)
 
-$(call depends,db): .install/utils
-$(call depends,settings): .install/utils .install/db
-$(call depends,visualization): .install/db
-$(call depends,modules/data.atmosphere): .install/utils
-$(call depends,modules/data.land): .install/db .install/utils
-$(call depends,modules/meta.analysis): .install/utils .install/db
-$(call depends,modules/priors): .install/utils
-$(call depends,modules/assim.batch): .install/utils .install/db .install/modules/meta.analysis 
-$(call depends,modules/rtm): .install/modules/assim.batch
-$(call depends,modules/uncertainty): .install/utils .install/modules/priors
-$(call depends,models/template): .install/utils
-$(call depends,models/biocro): .install/utils .install/settings .install/db .install/modules/data.atmosphere .install/modules/data.land
+$(call depends,base/db): .install/base/logger .install/base/utils
+$(call depends,base/settings): .install/base/logger .install/base/utils .install/base/db
+$(call depends,base/visualization): .install/base/logger .install/base/db
+$(call depends,modules/data.atmosphere): .install/base/logger .install/base/utils
+$(call depends,modules/data.land): .install/base/logger .install/base/db .install/base/utils
+$(call depends,modules/meta.analysis): .install/base/logger .install/base/utils .install/base/db
+$(call depends,modules/priors): .install/base/logger .install/base/utils
+$(call depends,modules/assim.batch): .install/base/logger .install/base/utils .install/base/db .install/modules/meta.analysis 
+$(call depends,modules/rtm): .install/base/logger .install/modules/assim.batch
+$(call depends,modules/uncertainty): .install/base/logger .install/base/utils .install/modules/priors
+$(call depends,models/template): .install/base/logger .install/base/utils
+$(call depends,models/biocro): .install/base/logger .install/base/utils .install/base/settings .install/base/db .install/modules/data.atmosphere .install/modules/data.land
 
 $(MODELS_I): .install/models/template
 
 
 clean:
-	rm -rf .install .check .test
+	rm -rf .install .check .test .doc
 	find modules/rtm/src \( -name \*.mod -o -name \*.o -o -name \*.so \) -delete
 
 .install/devtools:
@@ -85,12 +93,16 @@ check_R_pkg = Rscript scripts/check_with_errors.R $(strip $(1))
 test_R_pkg = Rscript -e "devtools::test('"$(strip $(1))"', reporter = 'stop')"
 doc_R_pkg = Rscript -e "devtools::document('"$(strip $(1))"')"
 
-$(ALL_PKGS_I) $(ALL_PKGS_C) $(ALL_PKGS_T): .install/devtools .install/roxygen2 .install/testthat
+$(ALL_PKGS_I) $(ALL_PKGS_C) $(ALL_PKGS_T) $(ALL_PKGS_D): .install/devtools .install/roxygen2 .install/testthat
 
 .SECONDEXPANSION:
-.install/%: $$(wildcard %/**/*) $$(wildcard %/*)
+.doc/%: $$(wildcard %/**/*) $$(wildcard %/*)
 	$(call depends_R_pkg, $(subst .doc/,,$@))
 	$(call doc_R_pkg, $(subst .doc/,,$@))
+	mkdir -p $(@D)
+	echo `date` > $@
+
+.install/%: $$(wildcard %/**/*) $$(wildcard %/*) .doc/%
 	$(call install_R_pkg, $(subst .install/,,$@))
 	mkdir -p $(@D)
 	echo `date` > $@


### PR DESCRIPTION
## Description
Installation of each package depends on its documentation being compiled. This means that it's now much harder to install a package with outdated documentation, _and_ that complete package installation now proceeds one package at a time (i.e. `document package1, install package1, document package2, install package2`) rather than doing all the `document` and `install` steps at once, as before (i.e. `document package1, document package2, install package1, install package2`). This should make installation on new machines much more robust.

This PR addresses #1558.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
