### PR TITLE
Cleanup missing or wrong package references

### DIFF
--- a/base/db/R/query.file.path.R
+++ b/base/db/R/query.file.path.R
@@ -7,7 +7,7 @@
 ##' 
 ##' @author Betsy Cowdery 
 query.file.path <- function(input.id, host_name, con){
-  machine.host <- ifelse(host_name == "localhost",fqdn(),host_name)
+  machine.host <- ifelse(host_name == "localhost", PEcAn.utils::fqdn(), host_name)
   machine = db.query(paste0("SELECT * from machines where hostname = '",machine.host,"'"),con)
   dbfile = db.query(paste("SELECT file_name,file_path from dbfiles where container_id =",input.id," and container_type = 'Input' and machine_id =",machine$id),con)
   path <- file.path(dbfile$file_path,dbfile$file_name)

--- a/base/db/R/utils.R
+++ b/base/db/R/utils.R
@@ -116,7 +116,7 @@ db.close <- function(con, showWarnings=TRUE) {
   
   id <- attr(con, "pecanid")
   if (showWarnings && is.null(id)) {
-    PEcAn.logger::logger.warn("Connection created outside of PEcAn.db package")
+    PEcAn.logger::logger.warn("Connection created outside of PEcAn.DB package")
   } else {
     deleteme <- which(.db.utils$connections$id==id)
     if (showWarnings && length(deleteme) == 0) {

--- a/base/db/tests/testthat/db.setup.R
+++ b/base/db/tests/testthat/db.setup.R
@@ -5,7 +5,7 @@ check_db_test <- function() {
     con <- NULL
     if (!is_ci) {
         try({
-            if(fqdn() == "pecan2.bu.edu") {
+            if(PEcAn.utils::fqdn() == "pecan2.bu.edu") {
                 con <- db.open(list(host="psql-pecan.bu.edu", driver = "PostgreSQL", user = "bety", dbname = "bety", password = "bety"))
             } else {
                 con <- db.open(list(host="localhost", driver = "PostgreSQL", user = "bety", dbname = "bety", password = "bety"))

--- a/base/settings/tests/testthat/get.test.settings.R
+++ b/base/settings/tests/testthat/get.test.settings.R
@@ -1,7 +1,7 @@
 .get.test.settings = function() {
   settings <- NULL
   try({
-    if(fqdn() == "pecan2.bu.edu") {
+    if(PEcAn.utils::fqdn() == "pecan2.bu.edu") {
       settings <- read.settings("testinput.pecan2.bu.edu.xml")
     } else {
       settings <- read.settings("testinput.xml")

--- a/models/biocro/R/met2model.BIOCRO.R
+++ b/models/biocro/R/met2model.BIOCRO.R
@@ -83,7 +83,7 @@ met2model.BIOCRO <- function(in.path, in.prefix, outfolder, overwrite = FALSE,
 
     res[[as.character(year)]] <- data.frame(
       file = csvfile,
-      host = fqdn(),
+      host = PEcAn.utils::fqdn(),
       mimetype = "text/csv",
       formatname = "biocromet",
       startdate = yrstart,

--- a/models/dalec/R/met2model.DALEC.R
+++ b/models/dalec/R/met2model.DALEC.R
@@ -65,7 +65,7 @@ met2model.DALEC <- function(in.path, in.prefix, outfolder, start_date, end_date,
   out.file.full <- file.path(outfolder, out.file)
   
   results <- data.frame(file = c(out.file.full), 
-                        host = c(fqdn()),
+                        host = c(PEcAn.utils::fqdn()),
                         mimetype = c("text/plain"), 
                         formatname = c("DALEC meteorology"), 
                         startdate = c(start_date), 

--- a/models/ed/R/met2model.ED2.R
+++ b/models/ed/R/met2model.ED2.R
@@ -46,7 +46,7 @@ met2model.ED2 <- function(in.path, in.prefix, outfolder, start_date, end_date, l
   met_header <- file.path(met_folder, "ED_MET_DRIVER_HEADER")
   
   results <- data.frame(file = c(met_header), 
-                        host = c(fqdn()), 
+                        host = c(PEcAn.utils::fqdn()), 
                         mimetype = c("text/plain"), 
                         formatname = c("ed.met_driver_header files format"), 
                         startdate = c(start_date), 

--- a/models/fates/R/met2model.FATES.R
+++ b/models/fates/R/met2model.FATES.R
@@ -154,7 +154,7 @@ met2model.FATES <- function(in.path, in.prefix, outfolder, start_date, end_date,
   PEcAn.logger::logger.info("Done with met2model.FATES")
   
   return(data.frame(file = paste0(outfolder, "/"), 
-                    host = c(fqdn()), 
+                    host = c(PEcAn.utils::fqdn()), 
                     mimetype = c("application/x-netcdf"), 
                     formatname = c("CLM met"), 
                     startdate = c(start_date), 

--- a/models/linkages/R/met2model.LINKAGES.R
+++ b/models/linkages/R/met2model.LINKAGES.R
@@ -31,7 +31,7 @@ met2model.LINKAGES <- function(in.path, in.prefix, outfolder, start_date, end_da
   # strptime(end_date, '%Y-%m-%d'), 'dat', sep='.'))
   
   results <- data.frame(file = c(out.file),
-                        host = c(fqdn()), 
+                        host = c(PEcAn.utils::fqdn()), 
                         mimetype = c("text/plain"), 
                         formatname = c("LINKAGES meteorology"), 
                         startdate = c(start_date), 

--- a/models/lpjguess/R/met2model.LPJGUESS.R
+++ b/models/lpjguess/R/met2model.LPJGUESS.R
@@ -56,7 +56,7 @@ met2model.LPJGUESS <- function(in.path, in.prefix, outfolder, start_date, end_da
   }
   
   results <- data.frame(file = unlist(out.files.full), 
-                        host = fqdn(), 
+                        host = PEcAn.utils::fqdn(), 
                         mimetype = "application/x-netcdf", 
                         formatname = "lpj-guess.metfile", 
                         startdate = start_date, 

--- a/models/maat/R/met2model.MAAT.R
+++ b/models/maat/R/met2model.MAAT.R
@@ -52,7 +52,7 @@ met2model.MAAT <- function(in.path, in.prefix, outfolder, start_date, end_date,
   out.file.full <- file.path(outfolder, out.file)
   
   results <- data.frame(file = out.file.full, 
-                        host = fqdn(), 
+                        host = PEcAn.utils::fqdn(), 
                         mimetype = "text/csv", 
                         formatname = "MAAT meteorology", 
                         startdate = start_date, 

--- a/models/maespa/R/met2model.MAESPA.R
+++ b/models/maespa/R/met2model.MAESPA.R
@@ -45,7 +45,7 @@ met2model.MAESPA <- function(in.path, in.prefix, outfolder, start_date, end_date
   out.file.full <- file.path(outfolder, out.file)
   
   results <- data.frame(file = out.file.full,
-                        host = fqdn(),
+                        host = PEcAn.utils::fqdn(),
                         mimetype = "text/plain", 
                         formatname = "maespa.met", 
                         startdate = start_date,

--- a/models/sipnet/R/met2model.SIPNET.R
+++ b/models/sipnet/R/met2model.SIPNET.R
@@ -39,7 +39,7 @@ met2model.SIPNET <- function(in.path, in.prefix, outfolder, start_date, end_date
   out.file.full <- file.path(outfolder, out.file)
   
   results <- data.frame(file = out.file.full, 
-                        host = fqdn(), 
+                        host = PEcAn.utils::fqdn(), 
                         mimetype = "text/csv", 
                         formatname = "Sipnet.climna", 
                         startdate = start_date, 

--- a/modules/benchmark/R/create_BRR.R
+++ b/modules/benchmark/R/create_BRR.R
@@ -11,9 +11,9 @@
 
 create_BRR <- function(ens_wf, con, user_id = ""){
   
-  cnd1 <- ens_wf$hostname == fqdn() 
-  cnd2 <- ens_wf$hostname == 'test-pecan.bu.edu' & fqdn() == 'pecan2.bu.edu'
-  cnd3 <- ens_wf$hostname == 'pecan2.bu.edu' & fqdn() == 'test-pecan.bu.edu'
+  cnd1 <- ens_wf$hostname == PEcAn.utils::fqdn() 
+  cnd2 <- ens_wf$hostname == 'test-pecan.bu.edu' & PEcAn.utils::fqdn() == 'pecan2.bu.edu'
+  cnd3 <- ens_wf$hostname == 'pecan2.bu.edu' & PEcAn.utils::fqdn() == 'test-pecan.bu.edu'
   db.query <- PEcAn.DB::db.query
   
  # if(cnd1|cnd2|cnd3){  # If the ensemble run was done on localhost, turn into a BRR

--- a/modules/data.atmosphere/R/download.Ameriflux.R
+++ b/modules/data.atmosphere/R/download.Ameriflux.R
@@ -71,7 +71,7 @@ download.Ameriflux <- function(sitename, outfolder, start_date, end_date,
     # create array with results
     row                     <- year - start_year + 1
     results$file[row]       <- outputfile
-    results$host[row]       <- fqdn()
+    results$host[row]       <- PEcAn.utils::fqdn()
     results$startdate[row]  <- paste0(year, "-01-01 00:00:00")
     results$enddate[row]    <- paste0(year, "-12-31 23:59:59")
     results$mimetype[row]   <- "application/x-netcdf"

--- a/modules/data.atmosphere/R/download.FACE.R
+++ b/modules/data.atmosphere/R/download.FACE.R
@@ -38,7 +38,7 @@ download.FACE <- function(sitename, outfolder, start_date, end_date, overwrite =
 
   # return file info
   return(invisible(data.frame(file = out.file, 
-                              host = fqdn(), 
+                              host = PEcAn.utils::fqdn(), 
                               mimetype = "application/x-netcdf", 
                               formatname = "FACE", 
                               startdate = start_date, 

--- a/modules/data.atmosphere/R/download.GLDAS.R
+++ b/modules/data.atmosphere/R/download.GLDAS.R
@@ -165,7 +165,7 @@ download.GLDAS <- function(outfolder, start_date, end_date, site_id, lat.in, lon
     ncdf4::nc_close(loc)
     
     results$file[i]       <- loc.file
-    results$host[i]       <- fqdn()
+    results$host[i]       <- PEcAn.utils::fqdn()
     results$startdate[i]  <- paste0(year, "-01-01 00:00:00")
     results$enddate[i]    <- paste0(year, "-12-31 23:59:59")
     results$mimetype[i]   <- "application/x-netcdf"

--- a/modules/data.atmosphere/R/download.Geostreams.R
+++ b/modules/data.atmosphere/R/download.Geostreams.R
@@ -80,7 +80,7 @@ download.Geostreams <- function(outfolder, sitename,
   }
 
   return(data.frame(file = result_files,
-                    host = fqdn(),
+                    host = PEcAn.utils::fqdn(),
                     mimetype = "application/json",
                     formatname = "Geostreams met",
                     startdate = start_date,

--- a/modules/data.atmosphere/R/download.MACA.R
+++ b/modules/data.atmosphere/R/download.MACA.R
@@ -142,7 +142,7 @@ download.MACA <- function(outfolder, start_date, end_date, site_id, lat.in, lon.
     ncdf4::nc_close(loc)
     
     results$file[i] <- loc.file
-    results$host[i] <- fqdn()
+    results$host[i] <- PEcAn.utils::fqdn()
     results$startdate[i] <- paste0(year,"-01-01 00:00:00")
     results$enddate[i] <- paste0(year,"-12-31 23:59:59")
     results$mimetype[i] <- 'application/x-netcdf'

--- a/modules/data.atmosphere/R/download.MsTMIP_NARR.R
+++ b/modules/data.atmosphere/R/download.MsTMIP_NARR.R
@@ -98,7 +98,7 @@ download.MsTMIP_NARR <- function(outfolder, start_date, end_date, site_id, lat.i
     ncdf4::nc_close(loc)
     
     results$file[i]       <- loc.file
-    results$host[i]       <- fqdn()
+    results$host[i]       <- PEcAn.utils::fqdn()
     results$startdate[i]  <- paste0(year, "-01-01 00:00:00")
     results$enddate[i]    <- paste0(year, "-12-31 23:59:59")
     results$mimetype[i]   <- "application/x-netcdf"

--- a/modules/data.atmosphere/R/download.NLDAS.R
+++ b/modules/data.atmosphere/R/download.NLDAS.R
@@ -166,7 +166,7 @@ download.NLDAS <- function(outfolder, start_date, end_date, site_id, lat.in, lon
     ncdf4::nc_close(loc)
     
     results$file[i] <- loc.file
-    results$host[i] <- fqdn()
+    results$host[i] <- PEcAn.utils::fqdn()
     results$startdate[i] <- paste0(year, "-01-01 00:00:00")
     results$enddate[i] <- paste0(year, "-12-31 23:59:59")
     results$mimetype[i] <- "application/x-netcdf"

--- a/modules/data.atmosphere/R/download.PalEON.R
+++ b/modules/data.atmosphere/R/download.PalEON.R
@@ -72,7 +72,7 @@ download.PalEON <- function(sitename, outfolder, start_date, end_date, overwrite
           row <- (which(vlist == v) - 1) * Y * M + (which(ylist == y) - 1) * M + m
           # print(row)
           results$file[row] <- dirname(file)
-          results$host[row] <- fqdn()
+          results$host[row] <- PEcAn.utils::fqdn()
           results$startdate[row] <- paste0(y, "-01-01 00:00:00")
           results$enddate[row] <- paste0(y, "-12-31 23:59:59")
           results$mimetype[row] <- "application/x-netcdf"

--- a/modules/data.atmosphere/R/download.PalEON_ENS.R
+++ b/modules/data.atmosphere/R/download.PalEON_ENS.R
@@ -43,7 +43,7 @@ download.PalEON_ENS <- function(sitename, outfolder, start_date, end_date, overw
                  })
     
     results[[i]] <- data.frame(file = ens_files, 
-                          host = rep(fqdn(),rows), 
+                          host = rep(PEcAn.utils::fqdn(),rows), 
                           mimetype = rep("application/x-netcdf",rows), 
                           formatname = rep("ALMA",rows),  ## would really like to switch to CF
                           startdate = paste0(ens_years, "-01-01 00:00:00"), 

--- a/modules/data.atmosphere/R/extract.nc.R
+++ b/modules/data.atmosphere/R/extract.nc.R
@@ -53,7 +53,7 @@ extract.nc <- function(in.path, in.prefix, outfolder, start_date, end_date, slat
     # create array with results
     row <- year - start_year + 1
     results$file[row]       <- outfile
-    results$host[row]       <- fqdn()
+    results$host[row]       <- PEcAn.utils::fqdn()
     results$startdate[row]  <- paste0(year, "-01-01 00:00:00")
     results$enddate[row]    <- paste0(year, "-12-31 23:59:59")
     results$mimetype[row]   <- "application/x-netcdf"

--- a/modules/data.atmosphere/R/met.process.R
+++ b/modules/data.atmosphere/R/met.process.R
@@ -88,7 +88,7 @@ met.process <- function(site, input_met, start_date, end_date, model,
   con <- bety$con
   on.exit(db.close(con))
   username <- ifelse(is.null(input_met$username), "pecan", input_met$username)
-  machine.host <- ifelse(host == "localhost" || host$name == "localhost", fqdn(), host$name)
+  machine.host <- ifelse(host == "localhost" || host$name == "localhost", PEcAn.utils::fqdn(), host$name)
   machine <- db.query(paste0("SELECT * from machines where hostname = '", machine.host, "'"), con)
 
   # special case Brown Dog
@@ -335,7 +335,7 @@ browndog.met <- function(browndog, source, site, start_date, end_date, model, di
     formatname <- "clim"
     outputfile <- file.path(folder, "sipnet.clim")
     results <- data.frame(file = outputfile, 
-                          host = fqdn(), 
+                          host = PEcAn.utils::fqdn(), 
                           mimetype = "text/csv",
                           formatname = "Sipnet.climna", 
                           startdate = start_date, enddate = end_date, 
@@ -345,7 +345,7 @@ browndog.met <- function(browndog, source, site, start_date, end_date, model, di
     formatname <- "ed.zip"
     outputfile <- file.path(folder, "ed.zip")
     results <- data.frame(file = file.path(folder, "ED_MET_DRIVER_HEADER"), 
-                          host = fqdn(), 
+                          host = PEcAn.utils::fqdn(), 
                           mimetype = "text/plain", 
                           formatname = "ed.met_driver_header files format",
                           startdate = start_date, enddate = end_date, 
@@ -355,7 +355,7 @@ browndog.met <- function(browndog, source, site, start_date, end_date, model, di
     formatname <- "dalec"
     outputfile <- file.path(folder, "dalec.dat")
     results <- data.frame(file = outputfile, 
-                          host = fqdn(), 
+                          host = PEcAn.utils::fqdn(), 
                           mimetype = "text/plain", 
                           formatname = "DALEC meteorology", 
                           startdate = start_date, enddate = end_date, 
@@ -365,7 +365,7 @@ browndog.met <- function(browndog, source, site, start_date, end_date, model, di
     formatname <- "linkages"
     outputfile <- file.path(folder, "climate.txt")
     results <- data.frame(file = outputfile, 
-                          host = fqdn(), 
+                          host = PEcAn.utils::fqdn(), 
                           mimetype = "text/plain", 
                           formatname = "LINKAGES meteorology", 
                           startdate = start_date, enddate = end_date,

--- a/modules/data.atmosphere/R/met2CF.ALMA.R
+++ b/modules/data.atmosphere/R/met2CF.ALMA.R
@@ -58,7 +58,7 @@ met2CF.PalEONregional <- function(in.path, in.prefix, outfolder, start_date, end
     
     row <- year - start_year + 1
     results$file[row]       <- new.file
-    results$host[row]       <- fqdn()
+    results$host[row]       <- PEcAn.utils::fqdn()
     results$startdate[row]  <- paste0(year, "-01-01 00:00:00")
     results$enddate[row]    <- paste0(year, "-12-31 23:59:59")
     results$mimetype[row]   <- "application/x-netcdf"
@@ -224,7 +224,7 @@ met2CF.PalEON <- function(in.path, in.prefix, outfolder, start_date, end_date, l
     
     row <- year - start_year + 1
     results$file[row]       <- new.file
-    results$host[row]       <- fqdn()
+    results$host[row]       <- PEcAn.utils::fqdn()
     results$startdate[row]  <- paste0(year, "-01-01 00:00:00")
     results$enddate[row]    <- paste0(year, "-12-31 23:59:59")
     results$mimetype[row]   <- "application/x-netcdf"
@@ -397,7 +397,7 @@ met2CF.ALMA <- function(in.path, in.prefix, outfolder, start_date, end_date, ove
     
     row <- year - start_year + 1
     results$file[row]       <- new.file
-    results$host[row]       <- fqdn()
+    results$host[row]       <- PEcAn.utils::fqdn()
     results$startdate[row]  <- paste0(year, "-01-01 00:00:00")
     results$enddate[row]    <- paste0(year, "-12-31 23:59:59")
     results$mimetype[row]   <- "application/x-netcdf"

--- a/modules/data.atmosphere/R/met2CF.Ameriflux.R
+++ b/modules/data.atmosphere/R/met2CF.Ameriflux.R
@@ -113,7 +113,7 @@ met2CF.Ameriflux <- function(in.path, in.prefix, outfolder, start_date, end_date
     # create array with results
     row <- year - start_year + 1
     results$file[row]       <- new.file
-    results$host[row]       <- fqdn()
+    results$host[row]       <- PEcAn.utils::fqdn()
     results$startdate[row]  <- paste0(year, "-01-01 00:00:00")
     results$enddate[row]    <- paste0(year, "-12-31 23:59:59")
     results$mimetype[row]   <- "application/x-netcdf"

--- a/modules/data.atmosphere/R/met2CF.csv.R
+++ b/modules/data.atmosphere/R/met2CF.csv.R
@@ -96,7 +96,7 @@ met2CF.csv <- function(in.path, in.prefix, outfolder, start_date, end_date, form
                       ".nc")
   
   results$file <- all_files
-  results$host <- fqdn()
+  results$host <- PEcAn.utils::fqdn()
   
   # The For below loop updates the start/end date once file is read in
   results$startdate  <- paste0(all_years, "-01-01 00:00:00")

--- a/modules/data.atmosphere/R/met2cf.module.R
+++ b/modules/data.atmosphere/R/met2cf.module.R
@@ -75,7 +75,7 @@
                              exact.dates = FALSE)
     } else if (exists(fcn2)) {
       fcn <- fcn2
-      format <- PEcAn.db::query.format.vars(input.id = input.id, bety = bety)
+      format <- PEcAn.DB::query.format.vars(input.id = input.id, bety = bety)
       cf.id <- PEcAn.utils::convert.input(input.id = input.id,
                              outfolder = outfolder,
                              formatname = formatname,

--- a/modules/data.atmosphere/R/met2model.module.R
+++ b/modules/data.atmosphere/R/met2model.module.R
@@ -3,7 +3,7 @@
                               browndog, new.site, overwrite = FALSE, exact.dates,spin) {
   
   # Determine output format name and mimetype
-  model_info <- PEcAn.db::db.query(paste0("SELECT f.name, f.id, mt.type_string from modeltypes as m", " join modeltypes_formats as mf on m.id = mf.modeltype_id", 
+  model_info <- PEcAn.DB::db.query(paste0("SELECT f.name, f.id, mt.type_string from modeltypes as m", " join modeltypes_formats as mf on m.id = mf.modeltype_id", 
                                 " join formats as f on mf.format_id = f.id", " join mimetypes as mt on f.mimetype_id = mt.id", 
                                 " where m.name = '", model, "' AND mf.tag='met'"), con)
   

--- a/modules/data.atmosphere/inst/scripts/met2CF.R
+++ b/modules/data.atmosphere/inst/scripts/met2CF.R
@@ -28,7 +28,7 @@ query.base.con <- function(settings,...){
 # required steps:
 # 1) query database using dbfile.input.check
 # check to see if file exists as an input in dbfile
-dbfile.input.check(siteid, startdate, enddate, mimetype, formatname, con, hostname=fqdn())
+dbfile.input.check(siteid, startdate, enddate, mimetype, formatname, con, hostname = PEcAn.utils::fqdn())
 #   a) query input table select * where input.id = id
 #     i) check to make sure there is only 1 match
 #   b) query dbfiles table to get all rows that match the id
@@ -51,5 +51,5 @@ dbfile.input.check(siteid, startdate, enddate, mimetype, formatname, con, hostna
 #      connection, hostname is localhost
 
   # insert into db as input
-dbfile.input.insert <- function(filename, siteid, startdate, enddate, mimetype, formatname, con, hostname=fqdn()) {
+dbfile.input.insert <- function(filename, siteid, startdate, enddate, mimetype, formatname, con, hostname=PEcAn.utils::fqdn()) {
     

--- a/modules/data.land/R/ic_process.R
+++ b/modules/data.land/R/ic_process.R
@@ -69,7 +69,7 @@ ic_process <- function(settings, input, dir, overwrite = FALSE){
   
   
   # set up host information
-  machine.host <- ifelse(host == "localhost" || host$name == "localhost", fqdn(), host$name)
+  machine.host <- ifelse(host == "localhost" || host$name == "localhost", PEcAn.utils::fqdn(), host$name)
   machine <- db.query(paste0("SELECT * from machines where hostname = '", machine.host, "'"), con)
   
   # retrieve model type info

--- a/modules/data.land/R/write_ic.R
+++ b/modules/data.land/R/write_ic.R
@@ -43,7 +43,7 @@ write_ic <- function(in.path, in.name, start_date, end_date,
 
   # Build results dataframe for convert.input
   results <- data.frame(file = out$filepath, 
-                        host = c(fqdn()), 
+                        host = c(PEcAn.utils::fqdn()), 
                         mimetype = out$mimetype, 
                         formatname = out$formatname, 
                         startdate = start_date, 

--- a/modules/data.remote/R/NLCD.R
+++ b/modules/data.remote/R/NLCD.R
@@ -28,9 +28,9 @@ download.NLCD <- function(outdir, year = 2011, con = NULL) {
         if (nrow(chk) > 0) {
             machines <- db.query(paste("SELECT * from machines where id in (", 
                                        paste(chk$machine_id, sep = ","), ")"), con)
-            if (fqdn() %in% machines$hostname) {
+            if (PEcAn.utils::fqdn() %in% machines$hostname) {
                 ## record already exists on this host
-                return(chk$id[fqdn() == machines$hostname])
+                return(chk$id[PEcAn.utils::fqdn() == machines$hostname])
             }
         }
     }
@@ -84,13 +84,13 @@ extract_NLCD <- function(buffer, coords, data_dir = NULL, con = NULL, year = 201
         if (nrow(chk) > 0) {
             machines <- db.query(paste("SELECT * from machines where id in (",
                                        paste(chk$machine_id, sep = ","), ")"), con)
-            if (fqdn() %in% machines$hostname) {
+            if (PEcAn.utils::fqdn() %in% machines$hostname) {
                 ## record already exists on this host
-                data_dir <- chk$file_path[fqdn() == machines$hostname]
+                data_dir <- chk$file_path[PEcAn.utils::fqdn() == machines$hostname]
             } else {
                 print(paste0("File not found on localhost, please check database input.id ", 
                   input.id, ". You may need to run download.NLCD"))
-                return(list(chk = chk, machines = machines, localhost = fqdn()))
+                return(list(chk = chk, machines = machines, localhost = PEcAn.utils::fqdn()))
             }
         } else {
             print(paste("No files found for input.id", input.id))

--- a/tests/interactive-workflow.R
+++ b/tests/interactive-workflow.R
@@ -111,7 +111,7 @@ status.start("FINISHED")
 if (!is.null(settings$email) && !is.null(settings$email$to) && (settings$email$to != "")) {
   sendmail(settings$email$from, settings$email$to,
            paste0("Workflow has finished executing at ", date()),
-           paste0("You can find the results on ", fqdn(), " in ", normalizePath(settings$outdir)))
+           paste0("You can find the results on ", PEcAn.utils::fqdn(), " in ", normalizePath(settings$outdir)))
 }
 
 # write end time in database


### PR DESCRIPTION
## Description
Two minor bugfixes:
- A few places referred to `PEcAn.db` instead of `PEcAn.DB`. This was fixed.
- Some places called the `fqdn()` function without having loaded `PEcAn.utils`. Fixed this by replacing with `PEcAn.utils::fqdn()` everywhere except in the `utils` package itself.

Thanks to @annethomas for catching these.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
