### PR TITLE
RTM: Minor bugfixes to `invert_bt`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ all: install document
 document: $(ALL_PKGS_D) .doc/base/all
 install: $(ALL_PKGS_I) .install/base/all
 check: $(ALL_PKGS_C) .check/base/all
-test: $(ALL_PKGS_T) .test/base/all 
+test: $(ALL_PKGS_T) .test/base/all
 
 ### Dependencies
 .doc/base/all: $(ALL_PKGS_D)
@@ -50,7 +50,7 @@ test: $(ALL_PKGS_T) .test/base/all
 .check/base/all: $(ALL_PKGS_C)
 .test/base/all: $(ALL_PKGS_T)
 
-depends = .check/$(1) .test/$(1)
+depends = .doc/$(1) .install/$(1) .check/$(1) .test/$(1)
 
 $(call depends,base/db): .install/base/logger .install/base/utils
 $(call depends,base/settings): .install/base/logger .install/base/utils .install/base/db
@@ -59,7 +59,7 @@ $(call depends,modules/data.atmosphere): .install/base/logger .install/base/util
 $(call depends,modules/data.land): .install/base/logger .install/base/db .install/base/utils
 $(call depends,modules/meta.analysis): .install/base/logger .install/base/utils .install/base/db
 $(call depends,modules/priors): .install/base/logger .install/base/utils
-$(call depends,modules/assim.batch): .install/base/logger .install/base/utils .install/base/db .install/modules/meta.analysis 
+$(call depends,modules/assim.batch): .install/base/logger .install/base/utils .install/base/db .install/modules/meta.analysis
 $(call depends,modules/rtm): .install/base/logger .install/modules/assim.batch
 $(call depends,modules/uncertainty): .install/base/logger .install/base/utils .install/modules/priors
 $(call depends,models/template): .install/base/logger .install/base/utils

--- a/modules/rtm/R/bayestools.R
+++ b/modules/rtm/R/bayestools.R
@@ -1,5 +1,5 @@
 #' Generic log-likelihood generator for RTMs
-rtm_loglike <- function(nparams, model, observed, lag.max = 0.01, ...) {
+rtm_loglike <- function(nparams, model, observed, lag.max = NULL, ...) {
     fail_ll <- -1e10
     stopifnot(nparams >= 1, nparams %% 1 == 0, is.function(model), is.numeric(observed))
     n_obs <- length(observed)
@@ -7,14 +7,26 @@ rtm_loglike <- function(nparams, model, observed, lag.max = 0.01, ...) {
         rtm_params <- x[seq_len(nparams)]
         rsd <- x[nparams + 1]
         mod <- model(rtm_params, ...)
-        if (any(is.na(mod))) return(fail_ll)
+        if (any(is.na(mod))) {
+            message(sum(is.na(mod)), " NA values in model output. Returning loglike = ", fail_ll)
+            return(fail_ll)
+        }
         err <- mod - observed
         ss <- sum(err * err)
         sigma2 <- rsd * rsd
         n_eff <- neff(err, lag.max = lag.max)
         sigma2eff <- sigma2 * n_obs / n_eff
         ll <- -0.5 * (n_obs * log(sigma2eff) + ss / sigma2eff)
-        if (is.na(ll)) return(fail_ll)
+        if (is.na(ll)) {
+            message("Log likelihood is NA. Returning loglike = ", fail_ll)
+            message("Mean error: ", mean(err))
+            message("Sum of squares: ", ss)
+            message("Sigma2 = ", sigma2)
+            message("n_eff = ", n_eff)
+            message("sigma2eff = ", sigma2eff)
+            message("LL = ", ll)
+            return(fail_ll)
+        }
         return(ll)
     }
     return(out)
@@ -91,7 +103,7 @@ prospect_bt_prior <- function(version, custom_prior = list()) {
 #'      Default is `FALSE` because it may be an excessively conservative
 #'      diagnostic.
 #'      - `min_samp` -- Minimum number of samples after burnin before stopping.
-#'      Default is 1000.
+#'      Default is 5000.
 #'      - `max_iter` -- Maximum total number of iterations. Default is 1e6.
 #'      - `lag.max` -- Maximum lag to use for autocorrelation normalization.
 #'      Default is `10 * log10(n)` (same as `stats::acf` function).
@@ -113,7 +125,7 @@ invert_bt <- function(observed, model, prior, custom_settings = list()) {
                              loop = list(iterations = 2000),
                              other = list(sampler = 'DEzs',
                                           use_mpsrf = FALSE,
-                                          min_samp = 1000,
+                                          min_samp = 5000,
                                           max_iter = 1e6,
                                           lag.max = NULL,
                                           save_progress = NULL,
@@ -205,6 +217,7 @@ invert_bt <- function(observed, model, prior, custom_settings = list()) {
             if (burned_samples$burnin == 1) {
                 message('PEcAn.assim.batch::autoburnin reports convergence has not been achieved. ',
                         'Resuming sampling.')
+                converged <- FALSE
                 next
             }
             n_samples <- coda::niter(burned_samples$samples)

--- a/modules/rtm/man/invert_bt.Rd
+++ b/modules/rtm/man/invert_bt.Rd
@@ -39,7 +39,7 @@ iteration count than in \code{init}.
 Default is \code{FALSE} because it may be an excessively conservative
 diagnostic.
 \item \code{min_samp} -- Minimum number of samples after burnin before stopping.
-Default is 1000.
+Default is 5000.
 \item \code{max_iter} -- Maximum total number of iterations. Default is 1e6.
 \item \code{lag.max} -- Maximum lag to use for autocorrelation normalization.
 Default is \code{10 * log10(n)} (same as \code{stats::acf} function).

--- a/modules/rtm/man/rtm_loglike.Rd
+++ b/modules/rtm/man/rtm_loglike.Rd
@@ -4,7 +4,7 @@
 \alias{rtm_loglike}
 \title{Generic log-likelihood generator for RTMs}
 \usage{
-rtm_loglike(nparams, model, observed, lag.max = 0.01, ...)
+rtm_loglike(nparams, model, observed, lag.max = NULL, ...)
 }
 \description{
 Generic log-likelihood generator for RTMs

--- a/modules/rtm/tests/testthat/test.invert_bayestools.R
+++ b/modules/rtm/tests/testthat/test.invert_bayestools.R
@@ -1,4 +1,4 @@
-#devtools::load_all('.')
+# devtools::load_all('.')
 library(PEcAnRTM)
 library(testthat)
 context('Inversion using BayesianTools')
@@ -11,15 +11,16 @@ if (Sys.getenv('CI') == 'true') {
     model <- function(x) prospect(x, 5)[,1]
     observed <- model(true_params) + generate.noise()
     prior <- prospect_bt_prior(5)
-    custom_settings <- list()
+    threshold <- 1.3
+    custom_settings <- list(init = list(iterations = 2000),
+                            loop = list(iterations = 1000),
+                            other = list(threshold = threshold))
     samples <- invert_bt(observed = observed, model = model, prior = prior,
-                         custom_settings = list(init = list(iterations = 2000),
-                                                loop = list(iterations = 1000),
-                                                other = list(max_iter = 20000, threshold = 1.3)))
+                         custom_settings = custom_settings)
 
-    samples_burned <- PEcAn.assim.batch::autoburnin(BayesianTools::getSample(samples, coda = TRUE), method = 'gelman.plot')
+    samples_burned <- PEcAn.assim.batch::autoburnin(BayesianTools::getSample(samples, coda = TRUE), method = 'gelman.plot', threshold = threshold)
     mean_estimates <- do.call(cbind, summary(samples_burned)[c('statistics', 'quantiles')])
 
     test_that('Mean estimates are within 10% of true values',
-              expect_equal(true_params, mean_estimates[seq_along(true_params),'Mean'], tol = 0.1))
+              expect_equal(true_params, mean_estimates[names(true_params),'Mean'], tol = 0.1))
 }


### PR DESCRIPTION
- Fix wrong default `lag.max` in `rtm_loglike`
- Add more informative messages to `rtm_loglike`
- Change default `min_samp` to 5000, becuase the results are a lot more robust and don't take that long. It can always be lowered by the user if desired.
