### PR TITLE
Debug modis download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - Fixed jagify bug for raw field data
 - Fixed bug (order of dims in nc_create) introduced in model2netcdf.DALEC by standard_vars changes
 - Cleaned up NAMESPACE and source code of `PEcAn.DB` (#1520)
+- Debugged python script in call_MODIS in data.remote to allow MODIS downloads
 
 ### Added
 - Expanded initial conditions workflow for pool-based models, including PEcAn.data.land::prepare_pools to calculate pools from IC file (to be coupled with write.configs)

--- a/modules/data.remote/R/call_MODIS.R
+++ b/modules/data.remote/R/call_MODIS.R
@@ -23,7 +23,7 @@
 ##' }
 ##' 
 call_MODIS <- function(outfolder = ".", fname = "m_data.nc", start, end, lat, lon, size = 0, 
-                       product = "MOD15A2", band = "Lai_1km", qc_band = NA, sd_band = NA) {
+                       product = "MOD15A2", band = "Lai_1km", qc_band = NA, sd_band = NA, verbose = TRUE) {
   
   # library(MODISTools)
   # 
@@ -75,6 +75,7 @@ call_MODIS <- function(outfolder = ".", fname = "m_data.nc", start, end, lat, lo
   rPython::python.assign("band", band)
   rPython::python.assign("qcband", qc_band)
   rPython::python.assign("sdband", sd_band)
+  python.assign("debug", verbose)
   
   # Here we import the MODIS python script as a module for the python. That way we can
   # run the routines within the script as independent commands.
@@ -88,7 +89,7 @@ call_MODIS <- function(outfolder = ".", fname = "m_data.nc", start, end, lat, lo
   
   # And here we execute the main MODIS run. Although it should be noted that while we get
   # values of the run here, the script also does write a netCDF output file.
-  rPython::python.exec("m, k, date = modisWSDL.run_main(start_date=start, end_date=end,la=lat,lo=lon,kmAB=kmNS,kmLR=kmWE,fname=fn,product=product,band=band,qcband=qcband,sdband=sdband)")
+  rPython::python.exec("m, k, date = modisWSDL.run_main(start_date=start, end_date=end,la=lat,lo=lon,kmAB=kmNS,kmLR=kmWE,fname=fn,product=product,band=band,qcband=qcband,sdband=sdband,debug=debug)")
   
   # m = The MODIS observed LAI for the given pixel k = The standard deviation of the
   # MODIS LAI. Be careful with this as it is at times very low date = Year and

--- a/modules/data.remote/R/call_MODIS.R
+++ b/modules/data.remote/R/call_MODIS.R
@@ -12,8 +12,8 @@
 ##' @param size   NS and WE distance in km to be included
 ##' @param product MODIS product number
 ##' @param band   which measurement to extract
-##' @param qcband which quality control band (optional)
-##' @param sdband which standard deviation band (optional)
+##' @param qc_band which quality control band (optional)
+##' @param sd_band which standard deviation band (optional)
 ##' 
 ##' depends on a number of Python libraries. sudo -H pip install numpy suds netCDF4
 ##' 

--- a/modules/data.remote/R/call_MODIS.R
+++ b/modules/data.remote/R/call_MODIS.R
@@ -3,10 +3,17 @@
 ##' @name call_MODIS
 ##' @title call_MODIS
 ##' @export
+##' @param outfolder where the output file will be stored
+##' @param fname  name of netcdf file to output
 ##' @param start  first date in year and day-of-year. For example May 1 2010 would be 2010121
 ##' @param end    laste date in year and day-of-year. For example May 1 2010 would be 2010121
 ##' @param lat    Latitude of the pixel
 ##' @param lon    Longitude of the pixel
+##' @param size   NS and WE distance in km to be included
+##' @param product MODIS product number
+##' @param band   which measurement to extract
+##' @param qcband which quality control band (optional)
+##' @param sdband which standard deviation band (optional)
 ##' 
 ##' depends on a number of Python libraries. sudo -H pip install numpy suds netCDF4
 ##' 
@@ -18,83 +25,81 @@
 call_MODIS <- function(outfolder = ".", fname = "m_data.nc", start, end, lat, lon, size = 0, 
                        product = "MOD15A2", band = "Lai_1km", qc_band = NA, sd_band = NA) {
   
-  library(MODISTools)
-  
-  dat <- MODISTools::GetSubset(Lat=lat, Long=lon, Product=product, Band=band, 
-                   StartDate=as.integer(start), EndDate=as.integer(end), KmAboveBelow=size, KmLeftRight=size)
-  if(!is.na(qc_band)){
-  qc <- MODISTools::GetSubset(Lat=lat, Long=lon, Product=product, Band=qc_band, 
-                               StartDate=as.integer(start), EndDate=as.integer(end), KmAboveBelow=size, KmLeftRight=size)
-  } else {
-    qc <- NULL
-  }
-  if(!is.na(sd_band)){
-    sd <- MODISTools::GetSubset(Lat=lat, Long=lon, Product=product, Band=sd_band, 
-                                StartDate=as.integer(start), EndDate=as.integer(end), KmAboveBelow=size, KmLeftRight=size)
-  } else {
-    sd <- NULL
-  }
-  
-  return(list(dat,qc,sd))
+  # library(MODISTools)
+  # 
+  # dat <- MODISTools::GetSubset(Lat=lat, Long=lon, Product=product, Band=band, 
+  #                  StartDate=as.integer(start), EndDate=as.integer(end), KmAboveBelow=size, KmLeftRight=size)
+  # if(!is.na(qc_band)){
+  # qc <- MODISTools::GetSubset(Lat=lat, Long=lon, Product=product, Band=qc_band, 
+  #                              StartDate=as.integer(start), EndDate=as.integer(end), KmAboveBelow=size, KmLeftRight=size)
+  # } else {
+  #   qc <- NULL
+  # }
+  # if(!is.na(sd_band)){
+  #   sd <- MODISTools::GetSubset(Lat=lat, Long=lon, Product=product, Band=sd_band, 
+  #                               StartDate=as.integer(start), EndDate=as.integer(end), KmAboveBelow=size, KmLeftRight=size)
+  # } else {
+  #   sd <- NULL
+  # }
+  # 
+  # return(list(dat,qc,sd))
   
   library(rPython)
   
-  # The name of the netCDF file. I've here given a constant name, but it can easily be
-  # changed to be an input
+  # The name of the netCDF file. 
   fname <- paste0(outfolder, "/", fname)
   
   # Distance of the are both east-west and north-south from the center of the pixel.
-  # Similarly to the file name, I've left it also easily inputtable.
   kmNS <- as.integer(size)
   kmWE <- as.integer(size)
   
   # Here it assigns the run directory and given variables values within python
-  python.assign("cwd", getwd())
+  rPython::python.assign("cwd", getwd())
   
-  python.assign("start", as.integer(start))
-  if (python.get("start") != start) {
+  rPython::python.assign("start", as.integer(start))
+  if ( rPython::python.get("start") != start) {
     stop("call_MODIS start date sent incorrectly")
   } 
   
-  python.assign("end", as.integer(end))
-  if (python.get("end") != end) {
+  rPython::python.assign("end", as.integer(end))
+  if (rPython::python.get("end") != end) {
     stop("call_MODIS end date sent incorrectly")
   }
   
-  python.assign("lat", lat)
-  python.assign("lon", lon)
-  python.assign("kmNS", kmNS)
-  python.assign("kmWE", kmWE)
-  python.assign("fn", fname)
-  python.assign("product", product)
-  python.assign("band", band)
-  python.assign("qcband", qc_band)
-  python.assign("sdband", sd_band)
+  rPython::python.assign("lat", lat)
+  rPython::python.assign("lon", lon)
+  rPython::python.assign("kmNS", kmNS)
+  rPython::python.assign("kmWE", kmWE)
+  rPython::python.assign("fn", fname)
+  rPython::python.assign("product", product)
+  rPython::python.assign("band", band)
+  rPython::python.assign("qcband", qc_band)
+  rPython::python.assign("sdband", sd_band)
   
   # Here we import the MODIS python script as a module for the python. That way we can
   # run the routines within the script as independent commands.
   script.path <- dirname(system.file("modisWSDL.py", package = "PEcAn.data.remote"))
-  python.exec(paste0("import sys; sys.path.append(\"", script.path, "\")"))
-  python.exec("import modisWSDL")
+  rPython::python.exec(paste0("import sys; sys.path.append(\"", script.path, "\")"))
+  rPython::python.exec("import modisWSDL")
   
   # This is overkill if you are not editing modisWSDL, but if you are developing this
   # will refresh the definition of the module
-  python.exec("reload(modisWSDL)")
+  rPython::python.exec("reload(modisWSDL)")
   
   # And here we execute the main MODIS run. Although it should be noted that while we get
   # values of the run here, the script also does write a netCDF output file.
-  python.exec("m, k, date = modisWSDL.run_main(start_date=start, end_date=end,la=lat,lo=lon,kmAB=kmNS,kmLR=kmWE,fname=fn,product=product,band=band,qcband=qcband,sdband=sdband)")
+  rPython::python.exec("m, k, date = modisWSDL.run_main(start_date=start, end_date=end,la=lat,lo=lon,kmAB=kmNS,kmLR=kmWE,fname=fn,product=product,band=band,qcband=qcband,sdband=sdband)")
   
   # m = The MODIS observed LAI for the given pixel k = The standard deviation of the
   # MODIS LAI. Be careful with this as it is at times very low date = Year and
   # day-of-year of the observation
-  m <- python.get("[ map(float, x) for x in m.data ]")
+  m <- rPython::python.get("[ map(float, x) for x in m.data ]")
   if (!is.na(sd_band)) {
-    k <- python.get("[ map(float, x) for x in k.data ]")
+    k <- rPython::python.get("[ map(float, x) for x in k.data ]")
   } else {
     k <- NA
   }
-  date <- python.get("date")
+  date <- rPython::python.get("date")
   
   return(invisible(list(m = m, k = k, date = date)))
 } # call_MODIS

--- a/modules/data.remote/R/call_MODIS.R
+++ b/modules/data.remote/R/call_MODIS.R
@@ -14,6 +14,7 @@
 ##' @param band   which measurement to extract
 ##' @param qc_band which quality control band (optional)
 ##' @param sd_band which standard deviation band (optional)
+##' @param verbose tell python whether or not to print debug statements (all or nothing)
 ##' 
 ##' depends on a number of Python libraries. sudo -H pip install numpy suds netCDF4
 ##' 

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -370,8 +370,7 @@ def m_data_to_netCDF(filename, m, k):
 
 def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, kmLR=0, fname='m_data.nc',product='MOD15A2',band='Lai_1km',qcband='FparLai_QC',sdband='LaiStdDev_1km',debug=True):
 
-	print DEBUG_PRINTING
-	DEBUG_PRINTING = debug	
+	global DEBUG_PRINTING = debug	
 	print "debug", debug
 	print "DEBUG", DEBUG_PRINTING
  
@@ -393,7 +392,7 @@ def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, 
 	date = m.dateInt
 	m.applyScale()
         if qcband is not None:
-		__debugPrint( "getting QA (quality assurance) for qcband" )
+		__debugPrint( "getting QA (quality assurance) from qcband" )
         	modisGetQA(m, qcband, client=client )
 	#	printModisData(m)
 		__debugPrint( "filter QA" ) 

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -355,7 +355,7 @@ def m_data_to_netCDF(filename, m, k):
         	m_std[:] = 0.1*k.data
 		__debugPrint( "populated LAIstd data in netcdf" )
 	m_date[:] = m.dateInt
-	_debugPrint( "populated dates in netcdf" )
+	__debugPrint( "populated dates in netcdf" )
 	rootgrp.close()
 
 #def m_date_to_netCDF(filename, varname, data):

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -290,7 +290,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 		print >> sys.stderr, requestStart, requestEnd
 		
 		data = client.service.getsubset( lat, lon, product, band, requestStart, requestEnd, kmAboveBelow, kmLeftRight )
-		
+		__debugPrint("Passed download step")	
 		
 		# now fill up the data structure with the returned data...
 

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -209,7 +209,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 
 	m=modisData()
 
-	m.kmABoveBelow=kmAboveBelow
+	m.kmAboveBelow=kmAboveBelow
 	m.kmLeftRight=kmLeftRight
 	
 	if client==None:

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -288,7 +288,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 		requestEnd=dateList[i+j-1]
 		i=i+j-1
 		
-		print >> sys.stderr, requestStart, requestEnd
+		__debugPrint('start date = %s, end date = %s'%(requestStart, requestEnd))
 		data = client.service.getsubset( lat, lon, product, band, requestStart, requestEnd, kmAboveBelow, kmLeftRight )
 		__debugPrint("Passed download step")	
 		

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -350,6 +350,7 @@ def m_data_to_netCDF(filename, m, k):
 	rootgrp.createDimension('dates', len(m.dateInt))
 	m_data = rootgrp.createVariable('LAI', 'f8', ('nrow', 'ncol'))
 	m_std = rootgrp.createVariable('LAIStd', 'f8', ('nrow', 'ncol'))
+	print("dates len ", len(m.dateInt)))
 	m_date = rootgrp.createVariable('Dates', 'i8', ('dates'))
 	print type(m.data[1])
 	m_data[:] = m.data

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -350,7 +350,7 @@ def m_data_to_netCDF(filename, m, k):
 	rootgrp.createDimension('dates', len(m.dateInt))
 	m_data = rootgrp.createVariable('LAI', 'f8', ('nrow', 'ncol'))
 	m_std = rootgrp.createVariable('LAIStd', 'f8', ('nrow', 'ncol'))
-	print("dates len ", len(m.dateInt)))
+	print("dates len ", len(m.dateInt))
 	m_date = rootgrp.createVariable('Dates', 'i8', ('dates'))
 	print type(m.data[1])
 	m_data[:] = m.data

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -280,8 +280,6 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 		
 		__debugPrint( 'i=%d, j=%d, dateList__len__()=%d'%(i,j,dateList.__len__( ))  )
 		while mkIntDate( dateList[i+j-1] ) > endDate:
-		  __debugPrint( 'j=%d'%j )
-		  
 			j=j-1
 		
 		

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -370,8 +370,11 @@ def m_data_to_netCDF(filename, m, k):
 
 def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, kmLR=0, fname='m_data.nc',product='MOD15A2',band='Lai_1km',qcband='FparLai_QC',sdband='LaiStdDev_1km',debug=True):
 
+	print DEBUG_PRINTING
 	DEBUG_PRINTING = debug	
-
+	print "debug", debug
+	print "DEBUG", DEBUG_PRINTING
+ 
 	client=setClient( )
 
 	prodList = modisClient( client )

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -174,7 +174,7 @@ def printModisData( m ):
 	print 'dates:', m.dateStr
 
 	print 'QA:', m.QA
-	print m.data
+	print 'data:',m.data
 
 
 def __debugPrint( o ):
@@ -189,10 +189,6 @@ def modisGetQA( m, QAname, client=None, chunkSize=8 ):
 	startDate=m.dateInt[0]
 	endDate=m.dateInt[-1]
 
-	print "startDate:",startDate
-	print "endDate:", endDate
-	print "kmLR:",m.kmLeftRight
-	print "kmAB:",m.kmAboveBelow
 
 	q = modisClient( client, product=m.product, band=QAname, lat=m.latitude, lon=m.longitude, 
 			startDate=startDate, endDate=endDate, chunkSize=chunkSize, kmAboveBelow=m.kmAboveBelow, kmLeftRight=m.kmLeftRight )
@@ -293,7 +289,6 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 		i=i+j-1
 		
 		print >> sys.stderr, requestStart, requestEnd
-		print "km:",kmAboveBelow, kmLeftRight	
 		data = client.service.getsubset( lat, lon, product, band, requestStart, requestEnd, kmAboveBelow, kmLeftRight )
 		__debugPrint("Passed download step")	
 		
@@ -312,7 +307,6 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 			
 			m.nrows = int(m.nrows)
 			m.ncols = int(m.ncols)
-			print "nrows", m.nrows, type(m.nrows)
 			m.data=np.zeros( (nDates,m.nrows*m.ncols) )
 
 		
@@ -354,9 +348,7 @@ def m_data_to_netCDF(filename, m, k):
 	rootgrp.createDimension('dates', len(m.dateInt))
 	m_data = rootgrp.createVariable('LAI', 'f8', ('nrow', 'ncol'))
 	m_std = rootgrp.createVariable('LAIStd', 'f8', ('nrow', 'ncol'))
-	print("dates len ", len(m.dateInt))
 	m_date = rootgrp.createVariable('Dates', 'i8', ('dates'))
-	print type(m.data[1])
 	m_data[:] = m.data
 	print "populated LAI data in netcdf"
 	if k is not None:
@@ -395,11 +387,10 @@ def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, 
 		return np.array([[]]), np.array([[]])
 	date = m.dateInt
 	m.applyScale()
-	print "kmab", m.kmAboveBelow
         if qcband is not None:
-		print "getting quality assurance for qcband"
+		print "getting QA (quality assurance) for qcband"
         	modisGetQA(m, qcband, client=client )
-		printModisData(m)
+	#	printModisData(m)
 		print "filter QA"
         	m.filterQA( range(0,2**16,2), fill=-1 )
 

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -303,7 +303,8 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 			m.units=data.units         
 			m.yllcorner=data.yllcorner
 			m.xllcorner=data.xllcorner  	
-
+			
+			__debugPrint( 'm.nrows=%d, m.ncols=%d, m.units=%d'%(m.nrows,m.ncols,m.units)  )
 			m.data=np.zeros( (nDates,m.nrows*m.ncols) )
 		
 		__debugPrint( data.subset.__len__() )

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -307,7 +307,10 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 			m.xllcorner=data.xllcorner  	
 			
 			__debugPrint( m.nrows  )
+			__debugPrint( m.ncols  )
+			__debugPrint( nDates  )
 			m.data=np.zeros( (nDates,m.nrows*m.ncols) )
+
 		
 		__debugPrint( data.subset.__len__() )
 		for j in xrange( data.subset.__len__( ) ):

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -373,13 +373,13 @@ def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, 
 	client=setClient( )
 
 	prodList = modisClient( client )
-#	printList( prodList )
+	printList( prodList )
 
 	bandList = modisClient( client, product=product )
-#	printList( bandList )
+	printList( bandList )
 	
 	dateList = modisClient( client, product=product, band=band, lat=la, lon=lo )
-#	printList( dateList )
+	printList( dateList )
 	
 	m = modisClient( client, product=product, band=band, lat=la, lon=lo, startDate=start_date, endDate=end_date, kmAboveBelow=kmAB, kmLeftRight=kmLR)
 	if len(m.dateInt) == 0:

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -314,7 +314,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 			kn=0
 			__debugPrint( data.subset	)		
 			for k in data.subset[j].split(",")[5:]:
-				__debugPrint( k )
+				#__debugPrint( k )
 				try:
 					m.data[ n*chunkSize+j,kn] = int( k )
 				except ValueError:

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -306,7 +306,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 			m.yllcorner=data.yllcorner
 			m.xllcorner=data.xllcorner  	
 			
-			__debugPrint( m.nrows  )
+			 print m.nrows, type(m.nrows)
 			__debugPrint( m.ncols  )
 			__debugPrint( nDates  )
 			m.data=np.zeros( (nDates,m.nrows*m.ncols) )

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -305,7 +305,8 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 			m.xllcorner=data.xllcorner  	
 
 			m.data=np.zeros( (nDates,m.nrows*m.ncols) )
-
+		
+		__debugPrint( data.subset.__len__() )
 		for j in xrange( data.subset.__len__( ) ):
 			kn=0
 			__debugPrint( data.subset	)		

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -370,7 +370,8 @@ def m_data_to_netCDF(filename, m, k):
 
 def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, kmLR=0, fname='m_data.nc',product='MOD15A2',band='Lai_1km',qcband='FparLai_QC',sdband='LaiStdDev_1km',debug=True):
 
-	global DEBUG_PRINTING = debug	
+	global DEBUG_PRINTING 
+	DEBUG_PRINTING = debug
 	print "debug", debug
 	print "DEBUG", DEBUG_PRINTING
  

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -294,6 +294,8 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 		
 		# now fill up the data structure with the returned data...
 		__debugPrint(n)
+		__debugPrint( data.subset.__len__() )
+
 		if n == 0:
 		
 			m.nrows=data.nrows         

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -306,7 +306,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 			m.yllcorner=data.yllcorner
 			m.xllcorner=data.xllcorner  	
 			
-			 print m.nrows, type(m.nrows)
+			print m.nrows, type(m.nrows)
 			__debugPrint( m.ncols  )
 			__debugPrint( nDates  )
 			m.data=np.zeros( (nDates,m.nrows*m.ncols) )

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -306,9 +306,9 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 			m.yllcorner=data.yllcorner
 			m.xllcorner=data.xllcorner  	
 			
+			m.nrows = int(m.nrows)
+			m.nrows = int(m.ncols)
 			print m.nrows, type(m.nrows)
-			__debugPrint( m.ncols  )
-			__debugPrint( nDates  )
 			m.data=np.zeros( (nDates,m.nrows*m.ncols) )
 
 		

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -246,7 +246,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 	while i < dateList.__len__( )-1:	
 		i=i+1
 	
-		#__debugPrint( 'i=%d'%i )
+		__debugPrint( 'i=%d'%i )
 		
 		thisDate=mkIntDate( dateList[i] )
 		
@@ -280,6 +280,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 		
 		__debugPrint( 'i=%d, j=%d, dateList__len__()=%d'%(i,j,dateList.__len__( ))  )
 		while mkIntDate( dateList[i+j-1] ) > endDate:
+		  __debugPrint( 'j=%d'%j )
 			j=j-1
 		
 		

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -319,7 +319,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 			kn=0
 			__debugPrint( data.subset	)		
 			for k in data.subset[j].split(",")[5:]:
-				__debugPrint("k:", k )
+				__debugPrint( k )
 				try:
 					m.data[ n*chunkSize+j,kn] = int( k )
 				except ValueError:

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -350,12 +350,12 @@ def m_data_to_netCDF(filename, m, k):
 	m_std = rootgrp.createVariable('LAIStd', 'f8', ('nrow', 'ncol'))
 	m_date = rootgrp.createVariable('Dates', 'i8', ('dates'))
 	m_data[:] = m.data
-	print "populated LAI data in netcdf"
+	__debugPrint( "populated LAI data in netcdf" )
 	if k is not None:
         	m_std[:] = 0.1*k.data
-		print "populated LAIstd data in netcdf"
+		__debugPrint( "populated LAIstd data in netcdf" )
 	m_date[:] = m.dateInt
-	print "populated dates in netcdf"
+	_debugPrint( "populated dates in netcdf" )
 	rootgrp.close()
 
 #def m_date_to_netCDF(filename, varname, data):
@@ -368,7 +368,9 @@ def m_data_to_netCDF(filename, m, k):
 #	rootgrp.close()
 
 
-def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, kmLR=0, fname='m_data.nc',product='MOD15A2',band='Lai_1km',qcband='FparLai_QC',sdband='LaiStdDev_1km'):
+def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, kmLR=0, fname='m_data.nc',product='MOD15A2',band='Lai_1km',qcband='FparLai_QC',sdband='LaiStdDev_1km',debug=True):
+
+	DEBUG_PRINTING = debug	
 
 	client=setClient( )
 
@@ -388,22 +390,23 @@ def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, 
 	date = m.dateInt
 	m.applyScale()
         if qcband is not None:
-		print "getting QA (quality assurance) for qcband"
+		__debugPrint( "getting QA (quality assurance) for qcband" )
         	modisGetQA(m, qcband, client=client )
 	#	printModisData(m)
-		print "filter QA"
+		__debugPrint( "filter QA" ) 
         	m.filterQA( range(0,2**16,2), fill=-1 )
 
         if sdband is not None:
-		print "getting sdband"
+		__debugPrint( "getting sdband" )
         	k = modisClient( client, product=product, band=sdband, lat=la, lon=lo, startDate=start_date, endDate=end_date, kmAboveBelow=kmAB, kmLeftRight=kmLR)
         	if qcband is not None:
-			print "getting QA band for sdband"
+			__debugPrint( "getting QA band for sdband" )
                         modisGetQA(k, qcband, client=client )
         else:
                 k = None
-		
-	printModisData( m )
+	if DEBUG_PRINTING:		
+		printModisData( m )
+
 	m_data_to_netCDF(fname, m, k)	
 
 #	print(len(m.data))

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -401,7 +401,7 @@ def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, 
         	modisGetQA(m, qcband, client=client )
 		printModisData(m)
 		print "filter QA"
-        	m.filterQA( range(0,2**8,2), fill=-1 )
+        	m.filterQA( range(0,2**16,2), fill=-1 )
 
         if sdband is not None:
 		print "getting sdband"

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -293,8 +293,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 		__debugPrint("Passed download step")	
 		
 		# now fill up the data structure with the returned data...
-		__debugPrint(n)
-		__debugPrint( data.subset.__len__() )
+		#__debugPrint( data.subset.__len__() )
 
 		if n == 0:
 		
@@ -308,15 +307,15 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 			
 			m.nrows = int(m.nrows)
 			m.ncols = int(m.ncols)
-			print m.nrows, type(m.nrows)
+			print "nrows", m.nrows, type(m.nrows)
 			m.data=np.zeros( (nDates,m.nrows*m.ncols) )
 
 		
-		__debugPrint( data.subset.__len__() )
 		for j in xrange( data.subset.__len__( ) ):
 			kn=0
 			__debugPrint( data.subset	)		
 			for k in data.subset[j].split(",")[5:]:
+				print "k"
 				__debugPrint( k )
 				try:
 					m.data[ n*chunkSize+j,kn] = int( k )
@@ -373,13 +372,13 @@ def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, 
 	client=setClient( )
 
 	prodList = modisClient( client )
-	printList( prodList )
+#	printList( prodList )
 
 	bandList = modisClient( client, product=product )
-	printList( bandList )
+#	printList( bandList )
 	
 	dateList = modisClient( client, product=product, band=band, lat=la, lon=lo )
-	printList( dateList )
+#	printList( dateList )
 	
 	m = modisClient( client, product=product, band=band, lat=la, lon=lo, startDate=start_date, endDate=end_date, kmAboveBelow=kmAB, kmLeftRight=kmLR)
 	if len(m.dateInt) == 0:
@@ -388,12 +387,16 @@ def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, 
 	date = m.dateInt
 	m.applyScale()
         if qcband is not None:
+		print "getting quality assurance for qcband"
         	modisGetQA(m, qcband, client=client )
+		print "filter QA"
         	m.filterQA( range(0,2**16,2), fill=-1 )
 
         if sdband is not None:
+		print "getting sdband"
         	k = modisClient( client, product=product, band=sdband, lat=la, lon=lo, startDate=start_date, endDate=end_date, kmAboveBelow=kmAB, kmLeftRight=kmLR)
         	if qcband is not None:
+			print "getting QA band for sdband"
                         modisGetQA(k, qcband, client=client )
         else:
                 k = None

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -406,7 +406,7 @@ def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, 
         else:
                 k = None
 		
-
+	printModisData( m )
 	m_data_to_netCDF(fname, m, k)	
 
 #	print(len(m.data))

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -396,7 +396,7 @@ def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, 
         	modisGetQA(m, qcband, client=client )
 		printModisData(m)
 		print "filter QA"
-        	m.filterQA( range(0,2**16,2), fill=-1 )
+        	m.filterQA( range(0,2**8,2), fill=-1 )
 
         if sdband is not None:
 		print "getting sdband"

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -189,6 +189,10 @@ def modisGetQA( m, QAname, client=None, chunkSize=8 ):
 	startDate=m.dateInt[0]
 	endDate=m.dateInt[-1]
 
+	print "startDate:",startDate
+	print "endDate:", endDate
+	print "kmLR:",m.kmLeftRight
+
 	q = modisClient( client, product=m.product, band=QAname, lat=m.latitude, lon=m.longitude, 
 			startDate=startDate, endDate=endDate, chunkSize=chunkSize, kmAboveBelow=m.kmAboveBelow, kmLeftRight=m.kmLeftRight )
 	
@@ -315,8 +319,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 			kn=0
 			__debugPrint( data.subset	)		
 			for k in data.subset[j].split(",")[5:]:
-				print "k"
-				__debugPrint( k )
+				__debugPrint("k:", k )
 				try:
 					m.data[ n*chunkSize+j,kn] = int( k )
 				except ValueError:
@@ -391,6 +394,7 @@ def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, 
 		return np.array([[]]), np.array([[]])
 	date = m.dateInt
 	m.applyScale()
+	print m.kmLeftRight
         if qcband is not None:
 		print "getting quality assurance for qcband"
         	modisGetQA(m, qcband, client=client )

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -304,7 +304,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 			m.yllcorner=data.yllcorner
 			m.xllcorner=data.xllcorner  	
 			
-			__debugPrint( 'm.nrows=%d, m.ncols=%d, m.units=%d'%(m.nrows,m.ncols,m.units)  )
+			__debugPrint( m.nrows  )
 			m.data=np.zeros( (nDates,m.nrows*m.ncols) )
 		
 		__debugPrint( data.subset.__len__() )

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -372,8 +372,6 @@ def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, 
 
 	global DEBUG_PRINTING 
 	DEBUG_PRINTING = debug
-	print "debug", debug
-	print "DEBUG", DEBUG_PRINTING
  
 	client=setClient( )
 

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -246,7 +246,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 	while i < dateList.__len__( )-1:	
 		i=i+1
 	
-		__debugPrint( 'i=%d'%i )
+		#__debugPrint( 'i=%d'%i )
 		
 		thisDate=mkIntDate( dateList[i] )
 		
@@ -287,7 +287,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 		requestEnd=dateList[i+j-1]
 		i=i+j-1
 		
-		#print >> sys.stderr, requestStart, requestEnd
+		print >> sys.stderr, requestStart, requestEnd
 		
 		data = client.service.getsubset( lat, lon, product, band, requestStart, requestEnd, kmAboveBelow, kmLeftRight )
 		

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -394,6 +394,7 @@ def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, 
         if qcband is not None:
 		print "getting quality assurance for qcband"
         	modisGetQA(m, qcband, client=client )
+		printModisData(m)
 		print "filter QA"
         	m.filterQA( range(0,2**16,2), fill=-1 )
 

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -352,9 +352,12 @@ def m_data_to_netCDF(filename, m, k):
 	m_std = rootgrp.createVariable('LAIStd', 'f8', ('nrow', 'ncol'))
 	m_date = rootgrp.createVariable('Dates', 'i8', ('dates'))
 	m_data[:] = m.data
+	print "populated LAI data in netcdf"
 	if k is not None:
         	m_std[:] = 0.1*k.data
+		print "populated LAIstd data in netcdf"
 	m_date[:] = m.dateInt
+	print "populated dates in netcdf"
 	rootgrp.close()
 
 #def m_date_to_netCDF(filename, varname, data):

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -281,6 +281,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 		__debugPrint( 'i=%d, j=%d, dateList__len__()=%d'%(i,j,dateList.__len__( ))  )
 		while mkIntDate( dateList[i+j-1] ) > endDate:
 		  __debugPrint( 'j=%d'%j )
+		  
 			j=j-1
 		
 		

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -293,7 +293,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 		__debugPrint("Passed download step")	
 		
 		# now fill up the data structure with the returned data...
-
+		__debugPrint(n)
 		if n == 0:
 		
 			m.nrows=data.nrows         

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -293,7 +293,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 		i=i+j-1
 		
 		print >> sys.stderr, requestStart, requestEnd
-		print "km:"kmAboveBelow, kmLeftRight	
+		print "km:",kmAboveBelow, kmLeftRight	
 		data = client.service.getsubset( lat, lon, product, band, requestStart, requestEnd, kmAboveBelow, kmLeftRight )
 		__debugPrint("Passed download step")	
 		

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -307,7 +307,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 			m.xllcorner=data.xllcorner  	
 			
 			m.nrows = int(m.nrows)
-			m.nrows = int(m.ncols)
+			m.ncols = int(m.ncols)
 			print m.nrows, type(m.nrows)
 			m.data=np.zeros( (nDates,m.nrows*m.ncols) )
 

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -344,7 +344,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 
 
 def m_data_to_netCDF(filename, m, k):
-	rootgrp = netCDF4.Dataset(filename, 'w', format='NETCDF3_64BIT')
+	rootgrp = netCDF4.Dataset(filename, 'w', format='NETCDF3_64BIT_DATA')
 	rootgrp.createDimension('ncol', m.data.shape[1])
 	rootgrp.createDimension('nrow', m.data.shape[0])
 	rootgrp.createDimension('dates', len(m.dateInt))

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -344,7 +344,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 
 
 def m_data_to_netCDF(filename, m, k):
-	rootgrp = netCDF4.Dataset(filename, 'w', format='NETCDF3_64BIT_DATA')
+	rootgrp = netCDF4.Dataset(filename, 'w', format='NETCDF4')
 	rootgrp.createDimension('ncol', m.data.shape[1])
 	rootgrp.createDimension('nrow', m.data.shape[0])
 	rootgrp.createDimension('dates', len(m.dateInt))

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -351,6 +351,7 @@ def m_data_to_netCDF(filename, m, k):
 	m_data = rootgrp.createVariable('LAI', 'f8', ('nrow', 'ncol'))
 	m_std = rootgrp.createVariable('LAIStd', 'f8', ('nrow', 'ncol'))
 	m_date = rootgrp.createVariable('Dates', 'i8', ('dates'))
+	print type(m.data[1])
 	m_data[:] = m.data
 	print "populated LAI data in netcdf"
 	if k is not None:

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -350,7 +350,7 @@ def m_data_to_netCDF(filename, m, k):
 	rootgrp.createDimension('dates', len(m.dateInt))
 	m_data = rootgrp.createVariable('LAI', 'f8', ('nrow', 'ncol'))
 	m_std = rootgrp.createVariable('LAIStd', 'f8', ('nrow', 'ncol'))
-	m_date = rootgrp.createVariable('Dates', 'i7', ('dates'))
+	m_date = rootgrp.createVariable('Dates', 'i8', ('dates'))
 	m_data[:] = m.data
 	if k is not None:
         	m_std[:] = 0.1*k.data

--- a/modules/data.remote/inst/modisWSDL.py
+++ b/modules/data.remote/inst/modisWSDL.py
@@ -192,6 +192,7 @@ def modisGetQA( m, QAname, client=None, chunkSize=8 ):
 	print "startDate:",startDate
 	print "endDate:", endDate
 	print "kmLR:",m.kmLeftRight
+	print "kmAB:",m.kmAboveBelow
 
 	q = modisClient( client, product=m.product, band=QAname, lat=m.latitude, lon=m.longitude, 
 			startDate=startDate, endDate=endDate, chunkSize=chunkSize, kmAboveBelow=m.kmAboveBelow, kmLeftRight=m.kmLeftRight )
@@ -292,7 +293,7 @@ def modisClient( client=None, product=None, band=None, lat=None, lon=None, start
 		i=i+j-1
 		
 		print >> sys.stderr, requestStart, requestEnd
-		
+		print "km:"kmAboveBelow, kmLeftRight	
 		data = client.service.getsubset( lat, lon, product, band, requestStart, requestEnd, kmAboveBelow, kmLeftRight )
 		__debugPrint("Passed download step")	
 		
@@ -394,7 +395,7 @@ def run_main(start_date=2004001, end_date=2004017, la=45.92, lo=-90.45, kmAB=0, 
 		return np.array([[]]), np.array([[]])
 	date = m.dateInt
 	m.applyScale()
-	print m.kmLeftRight
+	print "kmab", m.kmAboveBelow
         if qcband is not None:
 		print "getting quality assurance for qcband"
         	modisGetQA(m, qcband, client=client )

--- a/modules/data.remote/man/call_MODIS.Rd
+++ b/modules/data.remote/man/call_MODIS.Rd
@@ -9,13 +9,27 @@ call_MODIS(outfolder = ".", fname = "m_data.nc", start, end, lat, lon,
   sd_band = NA)
 }
 \arguments{
+\item{outfolder}{where the output file will be stored}
+
+\item{fname}{name of netcdf file to output}
+
 \item{start}{first date in year and day-of-year. For example May 1 2010 would be 2010121}
 
 \item{end}{laste date in year and day-of-year. For example May 1 2010 would be 2010121}
 
 \item{lat}{Latitude of the pixel}
 
-\item{lon}{Longitude of the pixel
+\item{lon}{Longitude of the pixel}
+
+\item{size}{NS and WE distance in km to be included}
+
+\item{product}{MODIS product number}
+
+\item{band}{which measurement to extract}
+
+\item{qcband}{which quality control band (optional)}
+
+\item{sdband}{which standard deviation band (optional)
 
 depends on a number of Python libraries. sudo -H pip install numpy suds netCDF4}
 }

--- a/modules/data.remote/man/call_MODIS.Rd
+++ b/modules/data.remote/man/call_MODIS.Rd
@@ -27,9 +27,9 @@ call_MODIS(outfolder = ".", fname = "m_data.nc", start, end, lat, lon,
 
 \item{band}{which measurement to extract}
 
-\item{qcband}{which quality control band (optional)}
+\item{qc_band}{which quality control band (optional)}
 
-\item{sdband}{which standard deviation band (optional)
+\item{sd_band}{which standard deviation band (optional)
 
 depends on a number of Python libraries. sudo -H pip install numpy suds netCDF4}
 }

--- a/modules/data.remote/man/call_MODIS.Rd
+++ b/modules/data.remote/man/call_MODIS.Rd
@@ -6,7 +6,7 @@
 \usage{
 call_MODIS(outfolder = ".", fname = "m_data.nc", start, end, lat, lon,
   size = 0, product = "MOD15A2", band = "Lai_1km", qc_band = NA,
-  sd_band = NA)
+  sd_band = NA, verbose = TRUE)
 }
 \arguments{
 \item{outfolder}{where the output file will be stored}
@@ -29,7 +29,9 @@ call_MODIS(outfolder = ".", fname = "m_data.nc", start, end, lat, lon,
 
 \item{qc_band}{which quality control band (optional)}
 
-\item{sd_band}{which standard deviation band (optional)
+\item{sd_band}{which standard deviation band (optional)}
+
+\item{verbose}{tell python whether or not to print debug statements (all or nothing)
 
 depends on a number of Python libraries. sudo -H pip install numpy suds netCDF4}
 }


### PR DESCRIPTION
## Description
The call_MODIS function in the remote module, which extracts MODIS data for a given location and date range, previously relied on an R package, MODISTools, which was pulled from CRAN (issue #1606 ). There was also an option in the function to call a python script, which was out of date. This PR reverts the function to an updated python script which accesses the MODIS web service API described [here](https://modis.ornl.gov/data/modis_webservice.html). 

The bugs fixed include:

- numpy.zeros being called with the number of rows and columns of the output data as floats; needs ints.
- A netcdf variable created with "i7" instead of "i8" (64-bit integer)
- Out of date netcdf format; updated to NETCDF4
- Typo causing an input variable not to be assigned in QA downloads

Most of the commits are debugging messages, some of which have remained. This PR also makes the existing debug printing switch in the python script operational, but it's all or nothing, which may need to change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
