### PR TITLE
RTM: Fix likelihood calculation in `invert_bt`

### DIFF
--- a/modules/rtm/R/bayestools.R
+++ b/modules/rtm/R/bayestools.R
@@ -1,5 +1,5 @@
 #' Generic log-likelihood generator for RTMs
-rtm_loglike <- function(nparams, model, observed, lag.max = NULL, ...) {
+rtm_loglike <- function(nparams, model, observed, lag.max = NULL, verbose = TRUE, ...) {
     fail_ll <- -1e10
     stopifnot(nparams >= 1, nparams %% 1 == 0, is.function(model), is.numeric(observed))
     n_obs <- length(observed)
@@ -8,7 +8,7 @@ rtm_loglike <- function(nparams, model, observed, lag.max = NULL, ...) {
         rsd <- x[nparams + 1]
         mod <- model(rtm_params, ...)
         if (any(is.na(mod))) {
-            message(sum(is.na(mod)), " NA values in model output. Returning loglike = ", fail_ll)
+            if (verbose) message(sum(is.na(mod)), " NA values in model output. Returning loglike = ", fail_ll)
             return(fail_ll)
         }
         err <- mod - observed
@@ -16,15 +16,17 @@ rtm_loglike <- function(nparams, model, observed, lag.max = NULL, ...) {
         sigma2 <- rsd * rsd
         n_eff <- neff(err, lag.max = lag.max)
         sigma2eff <- sigma2 * n_obs / n_eff
-        ll <- -0.5 * (n_obs * log(sigma2eff) + ss / sigma2eff)
+        ll <- -0.5 * (n_eff * log(sigma2eff) + ss / sigma2eff)
         if (is.na(ll)) {
-            message("Log likelihood is NA. Returning loglike = ", fail_ll)
-            message("Mean error: ", mean(err))
-            message("Sum of squares: ", ss)
-            message("Sigma2 = ", sigma2)
-            message("n_eff = ", n_eff)
-            message("sigma2eff = ", sigma2eff)
-            message("LL = ", ll)
+            if (verbose) {
+                message("Log likelihood is NA. Returning loglike = ", fail_ll)
+                message("Mean error: ", mean(err))
+                message("Sum of squares: ", ss)
+                message("Sigma2 = ", sigma2)
+                message("n_eff = ", n_eff)
+                message("sigma2eff = ", sigma2eff)
+                message("LL = ", ll)
+            }
             return(fail_ll)
         }
         return(ll)
@@ -110,6 +112,7 @@ prospect_bt_prior <- function(version, custom_prior = list()) {
 #'      - `save_progress` -- File name for saving samples between loop
 #'      iterations. If `NULL` (default), do not save progress samples.
 #'      - `threshold` -- Threshold for Gelman PSRF convergence diagnostic. Default is 1.1.
+#'      - `verbose_loglike` -- Diagnostic messages in log likelihood output. Default is TRUE.
 #'
 #' See the BayesianTools sampler documentation for what can go in the `BayesianTools` settings lists.
 #' @param observed Vector of observations
@@ -129,7 +132,8 @@ invert_bt <- function(observed, model, prior, custom_settings = list()) {
                                           max_iter = 1e6,
                                           lag.max = NULL,
                                           save_progress = NULL,
-                                          threshold = 1.1))
+                                          threshold = 1.1,
+                                          verbose_loglike = TRUE))
 
     if (length(custom_settings) > 0) {
         settings <- list()
@@ -152,6 +156,7 @@ invert_bt <- function(observed, model, prior, custom_settings = list()) {
     max_iter <- settings[['other']][['max_iter']]
     save_progress <- settings[['other']][['save_progress']]
     threshold <- settings[['other']][['threshold']]
+    verbose_loglike <- settings[['other']][['verbose_loglike']]
 
     if (!is.null(save_progress)) {
         # `file.create` returns FALSE if target directory doesn't exist.
@@ -164,7 +169,8 @@ invert_bt <- function(observed, model, prior, custom_settings = list()) {
     loglike <- rtm_loglike(nparams = nparams,
                            model = model,
                            observed = observed,
-                           lag.max = lag.max)
+                           lag.max = lag.max,
+                           verbose = verbose_loglike)
 
 
     setup <- BayesianTools::createBayesianSetup(likelihood = loglike,

--- a/modules/rtm/man/invert_bt.Rd
+++ b/modules/rtm/man/invert_bt.Rd
@@ -46,6 +46,7 @@ Default is \code{10 * log10(n)} (same as \code{stats::acf} function).
 \item \code{save_progress} -- File name for saving samples between loop
 iterations. If \code{NULL} (default), do not save progress samples.
 \item \code{threshold} -- Threshold for Gelman PSRF convergence diagnostic. Default is 1.1.
+\item \code{verbose_loglike} -- Diagnostic messages in log likelihood output. Default is TRUE.
 }
 }
 

--- a/modules/rtm/man/rtm_loglike.Rd
+++ b/modules/rtm/man/rtm_loglike.Rd
@@ -4,7 +4,7 @@
 \alias{rtm_loglike}
 \title{Generic log-likelihood generator for RTMs}
 \usage{
-rtm_loglike(nparams, model, observed, lag.max = NULL, ...)
+rtm_loglike(nparams, model, observed, lag.max = NULL, verbose = TRUE, ...)
 }
 \description{
 Generic log-likelihood generator for RTMs

--- a/modules/rtm/tests/testthat/test.invert_bayestools.R
+++ b/modules/rtm/tests/testthat/test.invert_bayestools.R
@@ -10,17 +10,58 @@ if (Sys.getenv('CI') == 'true') {
     true_params <- defparam('prospect_5')
     model <- function(x) prospect(x, 5)[,1]
     observed <- model(true_params) + generate.noise()
+    true_rsd <- mean(sum((observed - model(true_params)) ^ 2))
+    true_params['residual'] <- true_rsd
     prior <- prospect_bt_prior(5)
     threshold <- 1.3
     custom_settings <- list(init = list(iterations = 2000),
                             loop = list(iterations = 1000),
-                            other = list(threshold = threshold))
+                            other = list(threshold = threshold,
+                                         verbose_loglike = FALSE))
     samples <- invert_bt(observed = observed, model = model, prior = prior,
                          custom_settings = custom_settings)
 
     samples_burned <- PEcAn.assim.batch::autoburnin(BayesianTools::getSample(samples, coda = TRUE), method = 'gelman.plot', threshold = threshold)
+
     mean_estimates <- do.call(cbind, summary(samples_burned)[c('statistics', 'quantiles')])
 
     test_that('Mean estimates are within 10% of true values',
               expect_equal(true_params, mean_estimates[names(true_params),'Mean'], tol = 0.1))
+
+    # Compare observation with predicted interval
+    if (interactive()) {
+        samp_mat <- as.matrix(samples_burned)
+        nsamp <- 2500
+        prosp_mat <- matrix(0.0, nsamp, 2101)
+        message('Generating PROSPECT confidence interval')
+        pb <- txtProgressBar(style = 3)
+        for (i in seq_len(nsamp)) {
+            setTxtProgressBar(pb, i/nsamp)
+            samp_param <- samp_mat[sample.int(nrow(samp_mat), 1),]
+            prosp_mat[i,] <- rnorm(2101, model(samp_param[-6]), samp_param[6])
+        }
+        mid <- colMeans(prosp_mat)
+        lo <- apply(prosp_mat, 2, quantile, 0.025)
+        hi <- apply(prosp_mat, 2, quantile, 0.975)
+        outside <- which(observed < lo | observed > hi)
+        plot(observed, type = 'l')
+        lines(mid, col = 'red')
+        lines(lo, col = 'red', lty = 'dashed')
+        lines(hi, col = 'red', lty = 'dashed')
+        orng <- rgb(1, 0.5, 0, 0.2)
+        abline(v = outside, col = orng)
+        legend(
+            'topright',
+            c('observed', 'predictive interval', 'outside PI'),
+            lty = c('solid', 'dashed', 'solid'),
+            col = c('black', 'red', 'orange'),
+            lwd = c(1, 1, 2)
+        )
+        print(paste0(
+            length(outside), '/', 2101,
+            ' = ',
+            format(length(outside) / 2101 * 100, digits = 2),
+            '% of values outside 95% CI'
+        ))
+    }
 }


### PR DESCRIPTION
Was using true sample size (`n_obs`), when I should have been using the effective sample size (`n_eff`), in likelihood calculation.

Also:
- Allow option to disable diagnostic messages
- Add predictive interval plot when doing interactive tests of invert_bt.