### PR TITLE
Further Biocro data.table style cleanup

### DIFF
--- a/models/biocro/R/met2model.BIOCRO.R
+++ b/models/biocro/R/met2model.BIOCRO.R
@@ -150,7 +150,7 @@ cf2biocro <- function(met, longitude = NULL, zulu2solarnoon = FALSE) {
         qair = met$specific_humidity,
         temp = udunits2::ud.convert(met$air_temperature, "Kelvin", "Celsius"),
         press = udunits2::ud.convert(met$air_pressure, "Pa", "hPa"))
-      met[, `:=`(relative_humidity = rh * 100)]
+      met[, `:=`(relative_humidity = rh)]
     } else {
       PEcAn.logger::logger.error("neither relative_humidity nor [air_temperature, air_pressure, and specific_humidity]", 
                    "are in met data")

--- a/models/biocro/R/met2model.BIOCRO.R
+++ b/models/biocro/R/met2model.BIOCRO.R
@@ -142,13 +142,15 @@ cf2biocro <- function(met, longitude = NULL, zulu2solarnoon = FALSE) {
 
   if ((!is.null(longitude)) & zulu2solarnoon) {
     solarnoon_offset <- udunits2::ud.convert(longitude/360, "day", "minute")
-    met[, `:=`(solardate = date + lubridate::minutes(solarnoon_offset))]
+    met[, `:=`(solardate = met$date + lubridate::minutes(solarnoon_offset))]
   }
   if (!"relative_humidity" %in% colnames(met)) {
     if (all(c("air_temperature", "air_pressure", "specific_humidity") %in% colnames(met))) {
-      rh <- qair2rh(qair = met$specific_humidity, temp = udunits2::ud.convert(met$air_temperature, 
-                                                                    "Kelvin", "Celsius"), press = udunits2::ud.convert(met$air_pressure, "Pa", "hPa"))
-      met <- cbind(met, relative_humidity = rh * 100)
+      rh <- qair2rh(
+        qair = met$specific_humidity,
+        temp = udunits2::ud.convert(met$air_temperature, "Kelvin", "Celsius"),
+        press = udunits2::ud.convert(met$air_pressure, "Pa", "hPa"))
+      met[, `:=`(relative_humidity = rh * 100)]
     } else {
       PEcAn.logger::logger.error("neither relative_humidity nor [air_temperature, air_pressure, and specific_humidity]", 
                    "are in met data")
@@ -173,12 +175,12 @@ cf2biocro <- function(met, longitude = NULL, zulu2solarnoon = FALSE) {
   }
   
   ## Convert RH from percent to fraction BioCro functions just to confirm
-  if (met[, max(met$relative_humidity) > 1]) {
-    met$relative_humidity = met$relative_humidity/100
+  if (max(met$relative_humidity) > 1) {
+    met[, `:=`(relative_humidity = met$relative_humidity/100)]
   }
-  newmet <- met[, list(year = lubridate::year(date),
-                       doy = lubridate::yday(date),
-                       hour = round(lubridate::hour(date) + lubridate::minute(date) / 60, 0),
+  newmet <- met[, list(year = lubridate::year(met$date),
+                       doy = lubridate::yday(met$date),
+                       hour = round(lubridate::hour(met$date) + lubridate::minute(met$date) / 60, 0),
                        SolarR = ppfd, 
                        Temp = udunits2::ud.convert(met$air_temperature, "Kelvin", "Celsius"),
                        RH = met$relative_humidity,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a continuation of #1620 -- @dlebauer made some good suggestions in review that seemed worth following up on even though that PR has been merged.

Also of note: Removed an unnecessary conversion from ratio to percentage and back to ratio when computing relative humidity inside `met2model.BIOCRO`.

## Motivation and Context

In [https://github.com/PecanProject/pecan/pull/1620#pullrequestreview-60151116](https://github.com/PecanProject/pecan/pull/1620#pullrequestreview-60151116), @dlebauer said:

> FWIW I think 'data.table' way was faster, as would the dplyr mutate function, though this is definitely more standard and readable. 

I got interested in this speed comparison and [may have gone a *tad* overboard](https://gist.github.com/infotroph/fd76379d8a0e2aa3d7a8ed4ac76dbd2c). Bottom line: data.table is indeed a bit faster, dplyr was way slower, and using base R instead of data.table inside the conditional test gave a surprisingly consistent speedup. I've undone my previous switch to base assignment, but made the `:=` calls consistent throughout.


In [https://github.com/PecanProject/pecan/pull/1620#pullrequestreview-60151578](https://github.com/PecanProject/pecan/pull/1620#pullrequestreview-60151578), @dlebauer said:

> Is the met$ necessary? Why is it used for some variables but not others (like wind_speed and ppfd)?

The met$ is only necessary to shut up R CMD check, with the dual nice side-effects of (1) being a tiny tiny bit faster, and (2) making it clearer that newmet is being constructed from a mix of existing met columns (`met$date`, `met$air_temperature`, `met$relative_humidity`, `met$precipitation_flux`) and newly computed vectors (`wind_speed`, `ppfd`). I've added `met$` to all the local columns to make this more clear.




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 