### PR TITLE
Put workflowid in url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 ## [Unreleased]
 
 ### Fixes
+- Show workflowid in the URL when run is finshed and user clicks results (#1659)
 - `PEcAn.BIOCRO` now uses PEcAn-standard variable names. As a result, two output variables have been renamed but keep their exiting units and definitions:
 	- `StemBiom` renamed to `AbvGrndWood`
 	- `RootBiom` renamed to `root_carbon_content`

--- a/documentation/index_vm.html
+++ b/documentation/index_vm.html
@@ -3,23 +3,17 @@
 <body>
 <h1>PEcAn</h1>
 
-<a href="/pecan/"><h2>Run Models</h2></a>
-
-<a href="/bety/"><h2>Database</h2></a>
-
-<a href="/shiny/"><h2>Output Visualization</h2></a>
-
-<a href="/pecan/history.php"><h2>Output Archive</h2></a>
-
-<a href="/rstudio/"><h2>RStudio</h2></a>
-
-<a href="https://github.com/PecanProject"><h2>Code Repository</h2></a>
-
-<a href="https://gitter.im/PecanProject/pecan"><h2>Chat Room</h2></a>
-
-<a href="https://github.com/PecanProject/pecan/issues/new"><h2>Submit an Issue / Bug Report</h2></a>
-
-<a href="http://pecanproject.org"><h2>Project Homepage</h2></a>
+<ul>
+<li><a href="/pecan/">Run Models</a></li>
+<li><a href="/bety/">Database</a></li>
+<li><a href="/shiny/">Output Visualization</a></li>
+<li><a href="/pecan/history.php">Output Archive (history)</a></li>
+<li><a href="/rstudio/">RStudio</a></li>
+<li><a href="https://github.com/PecanProject">Code Repository</a></li>
+<li><a href="https://gitter.im/PecanProject/pecan">Chat Room</a></li>
+<li><a href="https://github.com/PecanProject/pecan/issues/new">Submit an Issue / Bug Report</a></li>
+<li><a href="http://pecanproject.org">Project Homepage</a></li>
+</ul>
   
 <h2>Documentation</h2>
 

--- a/web/05-running.php
+++ b/web/05-running.php
@@ -135,7 +135,7 @@ if (!$finished) {
 <?php } ?>
     </form>
     
-    <form id="formnext" method="POST" action="08-finished.php">
+    <form id="formnext" method="GET" action="08-finished.php">
 <?php if ($offline != "") { ?>
       <input name="offline" type="hidden" value="offline">
 <?php } ?>


### PR DESCRIPTION
Now uses GET to switch to 08-finish.php which will put the workflowid in the url.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
