### PR TITLE
fix circular dependency

### DIFF
--- a/base/remote/DESCRIPTION
+++ b/base/remote/DESCRIPTION
@@ -7,7 +7,6 @@ Maintainer: Alexey Shiklomanov <ashiklom@bu.edu>
 Description: This package contains utilities for communicating with and executing code on local and remote hosts.
     In particular, it has PEcAn-specific utilities for starting ecosystem model runs.
 Imports:
-    PEcAn.utils,
     PEcAn.logger
 Suggests:
     tools,

--- a/base/remote/R/is.localhost.R
+++ b/base/remote/R/is.localhost.R
@@ -11,10 +11,13 @@
 #' @examples
 #' is.localhost(fqdn())
 is.localhost <- function(host) {
+  # PEcAn.utils::fqdn() would result in a circular dependency.
+  fqdn <- system2("hostname", "-f", stdout = TRUE)
+  
   if (is.character(host)) {
-    return((host == "localhost") || (host == PEcAn.utils::fqdn()))
+    return((host == "localhost") || (host == fqdn))
   } else if (is.list(host)) {
-    return((host$name == "localhost") || (host$name == PEcAn.utils::fqdn()))
+    return((host$name == "localhost") || (host$name == fqdn))
   } else {
     return(FALSE)
   }

--- a/base/remote/R/remote.execute.R.R
+++ b/base/remote/R/remote.execute.R.R
@@ -32,7 +32,7 @@ remote.execute.R <- function(script, host = "localhost", user = NA, verbose = FA
              paste0("ign <- serialize(remoteout, fp)"),
              "close(fp)")
   verbose <- ifelse(as.logical(verbose), "", FALSE)
-  if ((host$name == "localhost") || (host$name == PEcAn.utils::fqdn())) {
+  if (is.localhost(host)) {
     if (R == "R") {
       Rbinary <- file.path(Sys.getenv("R_HOME"), "bin", "R")
       if (file.exists(Rbinary)) {

--- a/base/remote/R/remote.execute.cmd.R
+++ b/base/remote/R/remote.execute.cmd.R
@@ -22,7 +22,7 @@ remote.execute.cmd <- function(host, cmd, args = character(), stderr = FALSE) {
     host <- list(name = host)
   }
 
-  if ((host$name == "localhost") || (host$name == PEcAn.utils::fqdn())) {
+  if (is.localhost(host)) {
     PEcAn.logger::logger.debug(paste(c(cmd, args), collapse = ' '))
     system2(cmd, args, stdout = TRUE, stderr = as.logical(stderr))
   } else {


### PR DESCRIPTION
There was a circular dependecy where PEcAn.remote depended on PEcAn.utils and vice versa. If you did a make clean followed by make it would fail in building PEcAn.remote since it did not exist yet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
