### PR TITLE
Fix typos in prepare_pools and write.configs.SIPNET

### DIFF
--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -367,7 +367,7 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
       IC.nc <- ncdf4::nc_open(IC.path) #for additional variables specific to SIPNET
       ## plantWoodInit gC/m2
       if ("wood" %in% names(IC.pools)) {
-        param[which(param[, 1] == "plantWoodInit"), 2] <- udunits2:ud.convert(IC.pools$wood, "kg m-2", "g m-2")
+        param[which(param[, 1] == "plantWoodInit"), 2] <- udunits2::ud.convert(IC.pools$wood, "kg m-2", "g m-2")
       }
       ## laiInit m2/m2
       lai <- try(ncdf4::ncvar_get(IC.nc,"LAI"),silent = TRUE)

--- a/modules/data.land/R/prepare_pools.R
+++ b/modules/data.land/R/prepare_pools.R
@@ -22,7 +22,7 @@ prepare_pools <- function(nc.path, constants = NULL){
       TotLivBiom <- IC.list$vals$TotLivBiom
       leaf <- IC.list$vals$leaf_carbon_content
       LAI <- IC.list$vals$LAI
-      wood <- wood_carbon_content
+      wood <- IC.list$vals$wood_carbon_content
       AbvGrndWood <- IC.list$vals$AbvGrndWood
       roots <- IC.list$vals$root_carbon_content
       fine.roots <- IC.list$vals$fine_root_carbon_content


### PR DESCRIPTION
prepare_pools was assigning a variable without prefixing the right list stuff. write.configs.SIPNET had a udunits2 namespace with only one colon.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
