### PR TITLE
Install template package after all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ NCPUS ?= 1
 BASE := logger utils db settings visualization qaqc remote
 
 MODELS := biocro clm45 dalec ed fates gday jules linkages \
-				lpjguess maat maespa preles sipnet
+				lpjguess maat maespa preles sipnet template
 
 MODULES := allometry assim.batch assim.sequential benchmark \
 				 data.atmosphere data.hydrology data.land \
@@ -49,6 +49,8 @@ test: $(ALL_PKGS_T) .test/base/all
 .install/base/all: $(ALL_PKGS_I)
 .check/base/all: $(ALL_PKGS_C)
 .test/base/all: $(ALL_PKGS_T)
+
+$(subst .doc/models/template,,$(MODELS_D)): .doc/models/template
 
 depends = .doc/$(1) .install/$(1) .check/$(1) .test/$(1)
 

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test: $(ALL_PKGS_T) .test/base/all
 .check/base/all: $(ALL_PKGS_C)
 .test/base/all: $(ALL_PKGS_T)
 
-$(subst .doc/models/template,,$(MODELS_D)): .doc/models/template
+$(subst .doc/models/template,,$(MODELS_D)): .install/models/template # for models that import Roxygen docs from template
 $(subst .install/base/logger,,$(ALL_PKGS_I)): .install/base/logger
 
 depends = .doc/$(1) .install/$(1) .check/$(1) .test/$(1)

--- a/Makefile
+++ b/Makefile
@@ -51,24 +51,23 @@ test: $(ALL_PKGS_T) .test/base/all
 .test/base/all: $(ALL_PKGS_T)
 
 $(subst .doc/models/template,,$(MODELS_D)): .doc/models/template
+$(subst .install/base/logger,,$(ALL_PKGS_I)): .install/base/logger
 
 depends = .doc/$(1) .install/$(1) .check/$(1) .test/$(1)
 
-$(call depends,base/remote): .install/base/logger
-$(call depends,base/utils): .install/base/logger .install/base/remote
-$(call depends,base/db): .install/base/logger .install/base/utils
-$(call depends,base/settings): .install/base/logger .install/base/utils .install/base/db
-$(call depends,base/visualization): .install/base/logger .install/base/db
-$(call depends,base/qaqc): .install/base/logger
-$(call depends,modules/data.atmosphere): .install/base/logger .install/base/utils .install/base/remote
-$(call depends,modules/data.land): .install/base/logger .install/base/db .install/base/utils .install/base/remote
-$(call depends,modules/meta.analysis): .install/base/logger .install/base/utils .install/base/db .install/base/remote
-$(call depends,modules/priors): .install/base/logger .install/base/utils .install/base/remote
-$(call depends,modules/assim.batch): .install/base/logger .install/base/utils .install/base/db .install/modules/meta.analysis .install/base/remote
-$(call depends,modules/rtm): .install/base/logger .install/modules/assim.batch .install/base/remote
-$(call depends,modules/uncertainty): .install/base/logger .install/base/utils .install/modules/priors .install/base/remote
-$(call depends,models/template): .install/base/logger .install/base/utils .install/base/remote
-$(call depends,models/biocro): .install/base/logger .install/base/utils .install/base/settings .install/base/db .install/modules/data.atmosphere .install/modules/data.land .install/base/remote
+$(call depends,base/utils): .install/base/remote
+$(call depends,base/db): .install/base/utils
+$(call depends,base/settings): .install/base/utils .install/base/db
+$(call depends,base/visualization): .install/base/db
+$(call depends,modules/data.atmosphere): .install/base/utils .install/base/remote
+$(call depends,modules/data.land): .install/base/db .install/base/utils .install/base/remote
+$(call depends,modules/meta.analysis): .install/base/utils .install/base/db .install/base/remote
+$(call depends,modules/priors): .install/base/utils .install/base/remote
+$(call depends,modules/assim.batch): .install/base/utils .install/base/db .install/modules/meta.analysis .install/base/remote
+$(call depends,modules/rtm): .install/modules/assim.batch .install/base/remote
+$(call depends,modules/uncertainty): .install/base/utils .install/modules/priors .install/base/remote
+$(call depends,models/template): .install/base/utils .install/base/remote
+$(call depends,models/biocro): .install/base/utils .install/base/settings .install/base/db .install/modules/data.atmosphere .install/modules/data.land .install/base/remote
 
 clean:
 	rm -rf .install .check .test .doc

--- a/models/sipnet/R/read_restart.SIPNET.R
+++ b/models/sipnet/R/read_restart.SIPNET.R
@@ -11,7 +11,7 @@
 ##' 
 ##' @author Ann Raiho \email{araiho@@nd.edu}
 ##' 
-##' @inheritParams PEcAn.ModelName::read
+##' @inheritParams PEcAn.ModelName::read_restart.ModelName
 ##' 
 ##' @description Read Restart for SIPNET
 ##' 

--- a/models/sipnet/man/read_restart.SIPNET.Rd
+++ b/models/sipnet/man/read_restart.SIPNET.Rd
@@ -6,6 +6,19 @@
 \usage{
 read_restart.SIPNET(outdir, runid, stop.time, settings, var.names, params)
 }
+\arguments{
+\item{outdir}{Output directory}
+
+\item{runid}{Run ID}
+
+\item{stop.time}{Year that is being read}
+
+\item{settings}{PEcAn settings object}
+
+\item{var.names}{Variable names to be extracted}
+
+\item{params}{Any parameters required for state calculations}
+}
 \value{
 X.vec      vector of forecasts
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Re-adds the PEcAn package template to the Makefile, but in a slightly cleaner fashion.

Additionally: 
* cleaner Make syntax for PEcAn.logger dependancy
* fix typo that was preventing `read_restart.SIPNET` docs from compiling

## Motivation and Context

In #1634 I removed the template package `PEcAn.ModelName` from the build, thinking that no other part of PEcAn used it. I was wrong: `read_restart.ED2`, `write_restart.ED2`, and  `read_restart.SIPNET` (but not `write_restart.SIPNET`!) take their parameter documentation from there using the Roxygen `@InheritParams` tag.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 