### PR TITLE
Maespa missed external function call

### DIFF
--- a/models/maespa/R/met2model.MAESPA.R
+++ b/models/maespa/R/met2model.MAESPA.R
@@ -104,7 +104,7 @@ met2model.MAESPA <- function(in.path, in.prefix, outfolder, start_date, end_date
       ## Process PAR
       if (!is.numeric(PAR)) {
         # Function from data.atmosphere will convert SW to par in W/m2
-        PAR <- sw2par(RAD)
+        PAR <- PEcAn.data.atmosphere::sw2par(RAD)
       } else {
         # convert
         PAR <- udunits2::ud.convert(PAR, "mol", "umol")


### PR DESCRIPTION
Missed calling `sw2par` as `PEcAn.data.atmosphere::sw2par`