### PR TITLE
logger: allow for namespaces when filtering calls

### DIFF
--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -138,7 +138,8 @@ logger.message <- function(level, msg, ...) {
   if (logger.getLevelNumber(level) >= .utils.logger$level) {
     dump.frames(dumpto = "dump.log")
     calls <- names(dump.log)
-    func <- sub("\\(.*", "", tail(calls[-(which(substr(calls, 0, 3) == "log"))], 1))
+    calls <- calls[!grepl("^(PEcAn\\.logger::)?logger", calls)]
+    func <- sub("\\(.*", "", tail(calls, 1))
     if (length(func) == 0) {
       func <- "console"
     }

--- a/base/logger/tests/testthat/test.logger.R
+++ b/base/logger/tests/testthat/test.logger.R
@@ -69,3 +69,10 @@ test_that("logger prints right messages, responds correctly to logger.setLevel",
   expect_silent(logger.warn("message"))
   expect_silent(logger.error("message"))
 })
+
+test_that("logger message labels match enclosing function", {
+  logger.setUseConsole(console = TRUE, stderr = FALSE)
+
+  expect_output(identity(logger.info("message")), "[identity] : message", fixed = TRUE)
+  expect_output(identity(PEcAn.logger::logger.info("message")), "[identity] : message", fixed = TRUE)
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Log messages were always reporting "INFO [PEcAn.logger::logger.info]" where they were supposed to report the function that the logger was called from, e.g. "INFO [do_conversions]". 

Fixed by allowing for an optional "PEcAn.logger::" when matching strings to remove logger calls from the frame dump.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 