### PR TITLE
Add contributor names / affiliations via .zenodo.json 

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -7,21 +7,28 @@
         }, 
         {
             "affiliation": "Boston University", 
-            "name": "Michael Dietze"
+            "name": "Michael Dietze",
+            "orcid": "0000-0002-2324-2518"
         }, 
         {
-            "affiliation": "NCSA", 
-            "name": "Rob Kooper"
+            "affiliation": "National Center for Supercomputing Applications", 
+            "name": "Rob Kooper",
+            "orcid": "0000-0002-5781-7287"
         }, 
         {
             "affiliation": "Boston University", 
-            "name": "Alexey Shiklomanov"
+            "name": "Alexey Shiklomanov",
+            "orcid": "0000-0003-4022-5979"
         }, 
         {
-            "name": "Betsy Cowdery"
+            "affiliation": "Boston University", 
+            "name": "Betsy Cowdery",
+            "orcid": "0000-0002-6538-6296"
         }, 
         {
-            "name": "Istem Fer"
+            "affiliation": "Boston Univeristy", 
+            "name": "Istem Fer",
+            "orcid": "0000-0001-8236-303X"
         }, 
         {
             "affiliation": "Boston Univeristy", 
@@ -33,7 +40,8 @@
         }, 
         {
             "affiliation": "Brookhaven National Laboratory", 
-            "name": "Shawn P. Serbin"
+            "name": "Shawn P. Serbin",
+            "orcid": "0000-0003-4136-8971"
         }, 
         {
             "affiliation": "University of Notre Dame", 
@@ -44,7 +52,8 @@
         }, 
         {
             "affiliation": "Pennsylvania State University", 
-            "name": "Chris Black"
+            "name": "Chris Black",
+            "orcid": "0000-0001-8382-298X"
         }, 
         {
             "affiliation": "University of Wisconsin-Madison", 
@@ -52,7 +61,8 @@
         }, 
         {
             "affiliation": "University of Wisconsin-Madison", 
-            "name": "Ankur Desai"
+            "name": "Ankur Desai",
+            "orcid": "0000-0002-5226-6041"
         }, 
         {
             "name": "Joshua Mantooth"
@@ -79,25 +89,29 @@
         }, 
         {
             "affiliation": "University of New South Wales", 
-            "name": "Martin De Kauwe"
+            "name": "Martin De Kauwe",
+            "orcid": "0000-0002-3399-9098"
         }, 
         {
             "name": "Eugene"
         }, 
         {
+            "affiliation": "Boston University", 
             "name": "Tess McCabe"
         }, 
         {
             "name": "kragosta"
         }, 
         {
-            "name": "TonyCohen"
+            "name": "Tony Cohen"
         }, 
         {
             "name": "zhangwenx"
         }, 
         {
-            "name": "Viskari"
+            "affiliation": "Brookhaven National Laboratory", 
+            "name": "Tony Viskari",
+            "oricid": "0000-0002-3357-1374"
         }, 
         {
             "name": "Yan Zhao"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,111 @@
+{
+     "creators": [
+        {
+            "affiliation": "University of Illinois", 
+            "name": "David LeBauer",
+            "orcid": "0000-0001-7228-053X"
+        }, 
+        {
+            "affiliation": "Boston University", 
+            "name": "Michael Dietze"
+        }, 
+        {
+            "affiliation": "NCSA", 
+            "name": "Rob Kooper"
+        }, 
+        {
+            "affiliation": "Boston University", 
+            "name": "Alexey Shiklomanov"
+        }, 
+        {
+            "name": "Betsy Cowdery"
+        }, 
+        {
+            "name": "Istem Fer"
+        }, 
+        {
+            "affiliation": "Boston Univeristy", 
+            "name": "Anthony Gardella"
+        }, 
+        {
+            "affiliation": "PNNL/UMD", 
+            "name": "Ben Bond-Lamberty"
+        }, 
+        {
+            "affiliation": "Brookhaven National Laboratory", 
+            "name": "Shawn P. Serbin"
+        }, 
+        {
+            "affiliation": "University of Notre Dame", 
+            "name": "Ann Raiho"
+        }, 
+        {
+            "name": "Anne Thomas"
+        }, 
+        {
+            "affiliation": "Pennsylvania State University", 
+            "name": "Chris Black"
+        }, 
+        {
+            "affiliation": "University of Wisconsin-Madison", 
+            "name": "James Simkins"
+        }, 
+        {
+            "affiliation": "University of Wisconsin-Madison", 
+            "name": "Ankur Desai"
+        }, 
+        {
+            "name": "Joshua Mantooth"
+        }, 
+        {
+            "name": "Aman Kumar"
+        }, 
+        {
+            "name": "Liam Burke"
+        }, 
+        {
+            "affiliation": "Boston University", 
+            "name": "Afshin Pourmokhtarian"
+        }, 
+        {
+            "affiliation": "Morton Arboretum", 
+            "name": "Christy Rollinson"
+        }, 
+        {
+            "name": "Shubham Agarwal"
+        }, 
+        {
+            "name": "Brady Hardiman"
+        }, 
+        {
+            "affiliation": "University of New South Wales", 
+            "name": "Martin De Kauwe"
+        }, 
+        {
+            "name": "Eugene"
+        }, 
+        {
+            "name": "Tess McCabe"
+        }, 
+        {
+            "name": "kragosta"
+        }, 
+        {
+            "name": "TonyCohen"
+        }, 
+        {
+            "name": "zhangwenx"
+        }, 
+        {
+            "name": "Viskari"
+        }, 
+        {
+            "name": "Yan Zhao"
+        }, 
+        {
+           "affiliation": "University of Illinois at Urbana-Champaign",
+            "name": "Jing Xia"
+        }
+    ], 
+    "access_right": "open", 
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -49,6 +49,7 @@
             "name": "Ann Raiho"
         }, 
         {
+            "affiliation": "Brigham Young University",
             "name": "Anne Thomas"
         }, 
         {
@@ -66,12 +67,14 @@
             "orcid": "0000-0002-5226-6041"
         }, 
         {
+            "affiliation": "Worchester Academy",
             "name": "Joshua Mantooth"
         }, 
         {
             "name": "Aman Kumar"
         }, 
         {
+            "affiliation": "Boston University", 
             "name": "Liam Burke"
         }, 
         {
@@ -86,6 +89,7 @@
             "name": "Shubham Agarwal"
         }, 
         {
+            "affiliation": "Purdue University",
             "name": "Brady Hardiman"
         }, 
         {
@@ -101,7 +105,8 @@
             "name": "Tess McCabe"
         }, 
         {
-            "name": "kragosta"
+            "affiliation": "Boston University", 
+            "name": "Katie Ragosta"
         }, 
         {
             "name": "Tony Cohen"
@@ -110,7 +115,7 @@
             "name": "zhangwenx"
         }, 
         {
-            "affiliation": "Brookhaven National Laboratory", 
+            "affiliation": "Finnish Meteorological Institute", 
             "name": "Tony Viskari",
             "oricid": "0000-0002-3357-1374"
         }, 

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
      "creators": [
         {
-            "affiliation": "University of Illinois", 
+            "affiliation": "University of Illinois at Urbana-Champaign", 
             "name": "David LeBauer",
             "orcid": "0000-0001-7228-053X"
         }, 
@@ -35,8 +35,9 @@
             "name": "Anthony Gardella"
         }, 
         {
-            "affiliation": "PNNL/UMD", 
-            "name": "Ben Bond-Lamberty"
+            "affiliation": "Pacific Northwest National Laboratory / University of Maryland", 
+            "name": "Ben Bond-Lamberty",
+            "orcid": "0000-0001-9525-4633"
         }, 
         {
             "affiliation": "Brookhaven National Laboratory", 


### PR DESCRIPTION
Zenodo automagically publishes our latest release with a doi and makes it easy to cite.

If folks use their real name and affiliation on GitHub, it will be carried through to Zenodo. That would be ideal. But at present we still have a number of folk who don't use their real names on GitHub (and many valid reasons exist for doing so). However in the context of academic credit for software as a scientific product, I think this can be a useful tool.

Notably, it also appears to only include contributors with >= 4 commits by default; we could change that here. 

## Description

Format follows the Zenodo rest API documented here http://developers.zenodo.org/#depositions

creators:  The creators/authors of the deposition. Each array element is an object with the attributes:
attributes: 
* name: Name of creator in the format Family name, Given names
* affiliation: Affiliation of creator (optional).
* orcid: ORCID identifier of creator (optional).
* gnd: GND identifier of creator (optional).

## Motivation and Context

The current bibtex entry for v 1.5.1: https://zenodo.org/record/1003756/export/hx#.We4ev9enFhE  Has a number of people who don't use their real names, for example, @istfer , @Viskari , @kragosta, @zhangwenx  and @jingxia 

For the Academics among us, this can be a good way to get recognition for scientific contributions beyond refereed publications. 

At the same time, perhaps some folk prefer to remain anonymous.

## TODO

* I've updated the real names and affiliations that I knew off hand, but a few are still missing 
* folks can check their affiliations and optionally add your orcid. You can either directly [edit .zenodo.json](https://github.com/PecanProject/pecan/edit/zenodo.json/.zenodo.json?pr=/PecanProject/pecan/pull/1734) or add it below in this PR.
