### PR TITLE
maespa code failed with str_trim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 ## [Unreleased]
 
 ### Fixes
+- Fixed issue where Maeswrap would fail complaining about missing str_trim
 - Fixed issue #1752 by updating the site.lst() function to include site.id=site$id instead of site.id=site, as site is an object not just the id
 - Update to PEcAn.ED2::met2model.ED2 to fix issue with rhdf5::h5write. Bug fix to #1742
 - Fixed write.config.xml.ED2 parsing of data/history* files

--- a/docker/DESCRIPTION.maeswrap
+++ b/docker/DESCRIPTION.maeswrap
@@ -1,0 +1,15 @@
+Package: Maeswrap
+Type: Package
+Title: Wrapper functions for MAESTRA/MAESPA.
+Version: 1.7
+Author: Remko Duursma
+Maintainer: Remko Duursma <remkoduursma@gmail.com>
+Suggests:
+    rgl
+Depends:
+    lattice,geometry,stringr,tools
+Description: A bundle of functions for modifying MAESTRA/MAESPA input files,
+    reading output files, and visualizing the stand in 3D. Handy for running
+    sensitivity analyses, scenario analyses, etc.
+License: GPL
+LazyLoad: yes

--- a/models/maespa/R/met2model.MAESPA.R
+++ b/models/maespa/R/met2model.MAESPA.R
@@ -174,6 +174,9 @@ met2model.MAESPA <- function(in.path, in.prefix, outfolder, start_date, end_date
     lonunits <- "W"
   }
 
+  # need to load stringr in memory for Maeswrap
+  require(stringr)
+
   ## Write output met.dat file
   metfile <- system.file("met.dat", package = "PEcAn.MAESPA")
   met.dat <- Maeswrap::replacemetdata(out, oldmetfile = metfile, newmetfile = out.file.full)

--- a/models/maespa/R/model2netcdf.MAESPA.R
+++ b/models/maespa/R/model2netcdf.MAESPA.R
@@ -24,6 +24,8 @@
 ##' @author Tony Gardella
 model2netcdf.MAESPA <- function(outdir, sitelat, sitelon, start_date, end_date, stem_density) {
   
+  # need to load stringr in memory for Maeswrap
+  require(stringr)
 
   ### Read in model output using Maeswrap. Dayflx.dat, watbalday.dat
   dayflx.dataframe    <- Maeswrap::readdayflux(filename = "Dayflx.dat")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When running a maespa example it would fail in the met2model and model2netcdf, specifically in the maesawrap code. It could not find str_trim call. Adding require(stringr) solved this problem.

Problem seems to be that Maeswrap Depends on stringr, resulting in stringr being loaded into the environment. Since PEcAn.MAESPA only imports Maeswrap it will not load stringr into the environment. Either we need to make PEcAn.MAESPA depend on Maeswrap, or require stringr.

Can somebody else see if this fails for them as well. This is the the pecan.xml file used:
```xml
<?xml version="1.0"?><pecan>
 <outdir>/data/pecan</outdir>
 <database>
  <bety>
   <user>bety</user>
   <password>bety</password>
   <host>postgres</host>
   <dbname>bety</dbname>
   <driver>PostgreSQL</driver>
   <write>TRUE</write>
  </bety>
 </database>
 <pfts>
  <pft>
   <name>eucalyptus</name>
   <constants>
    <num>1</num>
   </constants>
  </pft>
 </pfts>
 <meta.analysis>
  <iter>3000</iter>
  <random.effects>FALSE</random.effects>
  <threshold>1.2</threshold>
  <update>AUTO</update>
 </meta.analysis>
 <ensemble>
  <size>1</size>
  <variable>NPP</variable>
  <start.year>2008</start.year>
  <end.year>2009</end.year>
 </ensemble>
 <model>
  <id>1000000009</id>
  <type>MAESPA</type>
  <revision>1</revision>
  <delete.raw>FALSE</delete.raw>
  <binary>/usr/local/bin/maespa</binary>
 </model>
 <run>
  <site>
   <id>1180</id>
   <met.start>2008/02/16</met.start>
   <met.end>2009/03/20</met.end>
   <name>Botanical Garden of South Wales University</name>
   <lat>-33.880449</lat>
   <lon>151.188354</lon>
  </site>
  <inputs>
   <met>
    <source>CRUNCEP</source>
    <output>MAESPA</output>
   </met>
  </inputs>
  <start.date>2008/02/16</start.date>
  <end.date>2009/03/20</end.date>
  <dbfiles>/data/dbfiles</dbfiles>
  <host>
   <name>localhost</name>
  </host>
 </run>
</pecan>
```
Also checked in is the DESCRIPTION file used when installing Maeswrap, this moves the rgl from depends to recommended.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
