### PR TITLE
Fixing typo in write.configs.ed

### DIFF
--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -149,7 +149,7 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
   
   ed2in.text <- gsub("@SITE_LAT@", settings$run$site$lat, ed2in.text)
   ed2in.text <- gsub("@SITE_LON@", settings$run$site$lon, ed2in.text)
-  ed2in.text <- gsub("@SITE_MET@", settings$run$inputs$me$path, ed2in.text)
+  ed2in.text <- gsub("@SITE_MET@", settings$run$inputs$met$path, ed2in.text)
   ed2in.text <- gsub("@MET_START@", metstart, ed2in.text)
   ed2in.text <- gsub("@MET_END@", metend, ed2in.text)
   


### PR DESCRIPTION
Missing the t in met for settings$run$inputs$met$path