### PR TITLE
Fix for improper subsetting of end date in met2model for sipnet

### DIFF
--- a/models/sipnet/R/met2model.SIPNET.R
+++ b/models/sipnet/R/met2model.SIPNET.R
@@ -218,7 +218,7 @@ met2model.SIPNET <- function(in.path, in.prefix, outfolder, start_date, end_date
         extra.days  <- length(as.Date(start_date):as.Date(end_date))
         if (extra.days > 1){
           PEcAn.logger::logger.info("Subsetting SIPNET met to match end date")
-          end.row <-  nrow(tmp) - ((extra.days - 1) * 86400 / dt)  #subtract to include end.date
+          end.row <-  extra.days * 86400 / dt  #subtract to include end.date
           tmp <- tmp[1:end.row,]
         }
       } else{


### PR DESCRIPTION
Fixes subsetting bug in met2model.sipnet closes #1769 . Tested in web workflow, seems to work. For those who have tested previously, be sure to delete your "bad" sipnet .clim files both physically on disk and also in dbfiles table.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
