### PR TITLE
Small fixes for missing values in soil2netcdf and soil_params (soil_utils) in data.land

### DIFF
--- a/modules/data.land/R/soil_utils.R
+++ b/modules/data.land/R/soil_utils.R
@@ -32,7 +32,7 @@ soil_params <- function(soil_type,sand,silt,clay,bulk){
   #---------------------------------------------------------------------------------------#
   #     Find soil class and sand, silt, and clay fractions.                               #
   #---------------------------------------------------------------------------------------#
-  if (missing(sand) & missing(clay)){
+  if ((missing(sand)||is.null(sand)) & (missing(clay)|is.null(clay))){
     ## insufficient texture data, infer from soil_type
     if(missing(soil_type)) PEcAn.logger::logger.error("insufficient arguments")
     mysoil$soil_type <- soil_type
@@ -42,11 +42,11 @@ soil_params <- function(soil_type,sand,silt,clay,bulk){
     mysoil$fraction_of_clay_in_soil <- xclay.def[soil_type]
     mysoil$fraction_of_silt_in_soil <- 1. - mysoil$fraction_of_sand_in_soil - mysoil$fraction_of_clay_in_soil
   } else {
-    if(missing(sand)){
+    if(missing(sand)|is.null(sand)){
       sand <- 1-silt-clay
-    }else if(missing(silt)){
+    }else if(missing(silt)|is.null(silt)){
       silt <- 1-sand-clay
-    }else if(missing(clay)){
+    }else if(missing(clay)|is.null(clay)){
       clay <- 1-sand-silt
     } else {
       #not missing anything else, normalize


### PR DESCRIPTION
soil2netcdf relies on soil_params (in soil_utils) to estimate parameters. This fix allows 1) passing soil type instead of texture to soil2netcdf to be consistent with recent change @mdietze made to soil_params, 2) passing empty texture variables to soil_params results in them being NULL not missing, and this needs to be tested in estimating texture, and 3) some soil types (like "peat") output NULL or NA values for some variables and soil2netcdf was incorrectly writing those out to the NetCDF file. These changes fixes those, so we can make wetlands great again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
