### PR TITLE
write.configs.dalec udunits fix

### DIFF
--- a/models/dalec/R/write.configs.dalec.R
+++ b/models/dalec/R/write.configs.dalec.R
@@ -115,7 +115,7 @@ write.config.DALEC <- function(defaults, trait.values, settings, run.id) {
 
     sla <- NULL
     if("SLA" %in% names(params)){
-      sla <- udunits2::ud.convert(params[1,"SLA"], 'm2 kg-1', 'm2 g') #convert SLA to m2/kgC from m2/gC (convert.samples)
+      sla <- udunits2::ud.convert(params[1,"SLA"], 'm2 kg-1', 'm2 g-1') #convert SLA to m2/kgC from m2/gC (convert.samples)
     } else{
       default.param <- read.table(system.file("default_param.dalec", package = "PEcAn.DALEC"), header = TRUE)
       sla <- udunits2::ud.convert(default.param[which(default.param$cmdFlag == "SLA"),"val"], 'm2 kg-1', 'm2 g') #convert SLA to m2/kgC from m2/gC (dalec default)

--- a/models/dalec/R/write.configs.dalec.R
+++ b/models/dalec/R/write.configs.dalec.R
@@ -112,10 +112,11 @@ write.config.DALEC <- function(defaults, trait.values, settings, run.id) {
 
   if(!is.null(settings$run$inputs$poolinitcond$path)) {
     IC.path <- settings$run$inputs$poolinitcond$path
-
+    
+    #grab SLA from parameters and convert to PECAN standard
     sla <- NULL
     if("SLA" %in% names(params)){
-      sla <- udunits2::ud.convert(params[1,"SLA"], 'm2 kg-1', 'm2 g-1') #convert SLA to m2/kgC from m2/gC (convert.samples)
+      sla <- udunits2::ud.convert(params[1,"SLA"], 'm2 g-1', 'm2 kg-1') #convert SLA to m2/kgC from m2/gC (revert convert.samples conversion to dalec default; need standard for prepare.pools)
     } else{
       default.param <- read.table(system.file("default_param.dalec", package = "PEcAn.DALEC"), header = TRUE)
       sla <- udunits2::ud.convert(default.param[which(default.param$cmdFlag == "SLA"),"val"], 'm2 kg-1', 'm2 g') #convert SLA to m2/kgC from m2/gC (dalec default)

--- a/models/dalec/R/write.configs.dalec.R
+++ b/models/dalec/R/write.configs.dalec.R
@@ -119,7 +119,7 @@ write.config.DALEC <- function(defaults, trait.values, settings, run.id) {
       sla <- udunits2::ud.convert(params[1,"SLA"], 'm2 g-1', 'm2 kg-1') #convert SLA to m2/kgC from m2/gC (revert convert.samples conversion to dalec default; need standard for prepare.pools)
     } else{
       default.param <- read.table(system.file("default_param.dalec", package = "PEcAn.DALEC"), header = TRUE)
-      sla <- udunits2::ud.convert(default.param[which(default.param$cmdFlag == "SLA"),"val"], 'm2 kg-1', 'm2 g') #convert SLA to m2/kgC from m2/gC (dalec default)
+      sla <- udunits2::ud.convert(default.param[which(default.param$cmdFlag == "SLA"),"val"], 'm2 g-1', 'm2 kg-1') #convert SLA to m2/kgC from m2/gC (dalec default)
     }
 
     IC.pools <- PEcAn.data.land::prepare_pools(IC.path, constants = list(sla = sla))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There's one line in write.configs.dalec where a udunits conversion has two small errors: missing a -1 and the order is switched; it should be convering to PECAN standard rather than from it because the variable is an input for prepare.pools.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
