### PR TITLE
Remove Shiny dependencies from PEcAn.DB

### DIFF
--- a/base/db/R/query.dplyr.R
+++ b/base/db/R/query.dplyr.R
@@ -129,25 +129,19 @@ runs <- function(bety, workflow_id) {
 
 #' Get vector of workflow IDs
 #' @inheritParams dbHostInfo
-#' @param session Session object passed through Shiny
+#' @param query Named vector or list of workflow IDs
 #' @export
-get_workflow_ids <- function(bety, session, all.ids=FALSE) {
-  query <- isolate(shiny::parseQueryString(session$clientData$url_search))
+get_workflow_ids <- function(bety, query, all.ids = FALSE) {
   # If we dont want all workflow ids but only workflow id from the user url query
-  if (!all.ids & "workflow_id" %in% names(query)) {
+  if (!all.ids && "workflow_id" %in% names(query)) {
     ids <- unlist(query[names(query) == "workflow_id"], use.names = FALSE)
   } else {
     # Get all workflow IDs
-
-    ids <- workflows(bety, ensemble = FALSE) %>% dplyr::distinct(workflow_id) %>% dplyr::collect %>% 
-      .[["workflow_id"]] %>% sort(decreasing = TRUE)
-    # pull(.,workflow_id) %>% sort(decreasing = TRUE)
-
-#    ids <- workflows(bety, ensemble = TRUE) %>%
-#      dplyr::distinct(workflow_id) %>%
-#      dplyr::pull() %>%
-#      sort(decreasing = TRUE)
-
+    ids <- workflows(bety, ensemble = FALSE) %>%
+      dplyr::distinct(workflow_id) %>%
+      dplyr::collect() %>%
+      dplyr::pull(workflow_id) %>%
+      sort(decreasing = TRUE)
   }
   return(ids)
 }  # get_workflow_ids

--- a/base/db/R/query.dplyr.R
+++ b/base/db/R/query.dplyr.R
@@ -148,9 +148,8 @@ get_workflow_ids <- function(bety, query, all.ids = FALSE) {
 
 #' Get data frame of users and IDs
 #' @inheritParams dbHostInfo
-#' @param session Session object passed through Shiny
 #' @export
-get_users <- function(bety, session) {
+get_users <- function(bety) {
   hostinfo <- dbHostInfo(bety)
   query <- "SELECT id, login FROM users"
   out <- dplyr::tbl(bety, dbplyr::sql(query)) %>%

--- a/base/db/man/get_users.Rd
+++ b/base/db/man/get_users.Rd
@@ -4,12 +4,10 @@
 \alias{get_users}
 \title{Get data frame of users and IDs}
 \usage{
-get_users(bety, session)
+get_users(bety)
 }
 \arguments{
 \item{bety}{BETYdb connection, as opened by `betyConnect()`}
-
-\item{session}{Session object passed through Shiny}
 }
 \description{
 Get data frame of users and IDs

--- a/base/db/man/get_workflow_ids.Rd
+++ b/base/db/man/get_workflow_ids.Rd
@@ -4,12 +4,12 @@
 \alias{get_workflow_ids}
 \title{Get vector of workflow IDs}
 \usage{
-get_workflow_ids(bety, session, all.ids = FALSE)
+get_workflow_ids(bety, query, all.ids = FALSE)
 }
 \arguments{
 \item{bety}{BETYdb connection, as opened by `betyConnect()`}
 
-\item{session}{Session object passed through Shiny}
+\item{query}{Named vector or list of workflow IDs}
 }
 \description{
 Get vector of workflow IDs

--- a/shiny/workflowPlot/server.R
+++ b/shiny/workflowPlot/server.R
@@ -26,7 +26,8 @@ server <- shinyServer(function(input, output, session) {
     # get_workflow_ids function (line 137) in db/R/query.dplyr.R takes a flag to check
     # if we want to load all workflow ids.
     # get_workflow_id function from query.dplyr.R
-    all_ids <- get_workflow_ids(bety, session,all.ids=TRUE)
+    query <- isolate(shiny::parseQueryString(session$clientData$url_search))
+    all_ids <- get_workflow_ids(bety, query, all.ids=TRUE)
     updateSelectizeInput(session, "all_workflow_id", choices=all_ids)
   })
   # Update all run ids


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Externalize Shiny calls in `get_workflow_ids`. Remove unused `session` argument from `get_users`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ain't nobody got time to load all those Shiny dependencies.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
