### PR TITLE
Temporary hotfix for Shiny

### DIFF
--- a/base/db/R/query.dplyr.R
+++ b/base/db/R/query.dplyr.R
@@ -266,9 +266,9 @@ load_data_single_run <- function(bety, workflow_id, run_id) {
         x <- ncdays2date(ncdf4::ncvar_get(nc, 'time'), ncdf4::ncatt_get(nc, 'time'))
         y <- ncdf4::ncvar_get(nc, var_name)
         # !!!HACK!!!
-        # Soil moisture and temperature are a matrices Returning only the first row for now.
+        # Soil moisture and temperature are a matrices. Returning the column sum for now.
         if (var_name %in% c("SoilMoist", "SoilTemp")) {
-          y <- y[1, ]
+          y <- colSums(y)
         }
         b <- !is.na(x) & !is.na(y) & sw != 0
         

--- a/base/db/R/query.dplyr.R
+++ b/base/db/R/query.dplyr.R
@@ -148,9 +148,8 @@ get_workflow_ids <- function(bety, query, all.ids = FALSE) {
 
 #' Get data frame of users and IDs
 #' @inheritParams dbHostInfo
-#' @param session Session object passed through Shiny
 #' @export
-get_users <- function(bety, session) {
+get_users <- function(bety) {
   hostinfo <- dbHostInfo(bety)
   query <- "SELECT id, login FROM users"
   out <- dplyr::tbl(bety, dbplyr::sql(query)) %>%

--- a/base/db/man/get_users.Rd
+++ b/base/db/man/get_users.Rd
@@ -4,12 +4,10 @@
 \alias{get_users}
 \title{Get data frame of users and IDs}
 \usage{
-get_users(bety, session)
+get_users(bety)
 }
 \arguments{
 \item{bety}{BETYdb connection, as opened by `betyConnect()`}
-
-\item{session}{Session object passed through Shiny}
 }
 \description{
 Get data frame of users and IDs

--- a/book_source/developers_guide/Testing.Rmd
+++ b/book_source/developers_guide/Testing.Rmd
@@ -342,12 +342,12 @@ shiny::runApp(port = XXXX)
 Then, on your local machine, open a terminal and run the following command, matching `XXXX` to the port above and `YYYY` to any unused port on your local machine (any 4-digit number should work).
 
 ```
-ssh -L YYYY:<remove name>:XXXX <remote connection>
+ssh -L YYYY:localhost:XXXX <remote connection>
 # E.g., for the PEcAn VM, given the above port:
 # ssh -L 5639:localhost:5638 carya@localhost -p 6422
 ```
 
-Now, in a web browser on your local machine, browse to `localhost:5639` to run whatever app you started with `shiny::runApp` in the previous step.
+Now, in a web browser on your local machine, browse to `localhost:YYYY` (e.g., `localhost:5639`) to run whatever app you started with `shiny::runApp` in the previous step.
 All of the output should display in the R console where the `shiny::runApp` command was executed.
 Note that this includes any `print`, `message`, `logger.*`, etc. statements in your Shiny app.
 

--- a/book_source/developers_guide/Testing.Rmd
+++ b/book_source/developers_guide/Testing.Rmd
@@ -326,3 +326,38 @@ test_that(“as.sequence works”;{
 })
 ```
 
+## Testing the Shiny Server
+
+Shiny can be difficult to debug because, when run as a web service, the R output is hidden in system log files that are hard to find and read.
+One useful approach to debugging is to use port forwarding, as follows.
+
+First, on the remote machine (including the VM), make sure R's working directory is set to the directory of the Shiny app (e.g., `setwd(/path/to/pecan/shiny/WorkflowPlots)`, or just open the app as an RStudio project).
+Then, in the R console, run the app as:
+
+```
+shiny::runApp(port = XXXX)
+# E.g. shiny::runApp(port = 5638)
+```
+
+Then, on your local machine, open a terminal and run the following command, matching `XXXX` to the port above and `YYYY` to any unused port on your local machine (any 4-digit number should work).
+
+```
+ssh -L YYYY:<remove name>:XXXX <remote connection>
+# E.g., for the PEcAn VM, given the above port:
+# ssh -L 5639:localhost:5638 carya@localhost -p 6422
+```
+
+Now, in a web browser on your local machine, browse to `localhost:5639` to run whatever app you started with `shiny::runApp` in the previous step.
+All of the output should display in the R console where the `shiny::runApp` command was executed.
+Note that this includes any `print`, `message`, `logger.*`, etc. statements in your Shiny app.
+
+If the Shiny app hits an R error, the backtrace should include a line like `Hit error at of server.R#LXX` -- that `XX` being a line number that you can use to track down the error.
+To return from the error to a normal R prompt, hit `<Control>-C` (alternatively, the "Stop" button in RStudio).
+To restart the app, run `shiny::runApp(port = XXXX)` again (keeping the same port).
+
+Note that Shiny runs any code in the `pecan/shiny/<app>` directory at the moment the app is launched.
+So, any changes you make to the code in `server.R` and `ui.R` or scripts loaded therein will take effect the next time the app is started.
+
+If for whatever reason this doesn't work with RStudio, you can always run R from the command line.
+Also, note that the ability to forward ports (`ssh -L`) may depend on the `ssh` configuration of your remote machine.
+These instructions have been tested on the PEcAn VM (v.1.5.2+).


### PR DESCRIPTION
Several potential issues:

- `PEcAn.DB::load_data_single_run`:
  - Currently can't handle matrix output (e.g. multiple layers of soil for moisture and temperature). This has a hack to only grab the top layer.
  - If variable is not found, returns a 0-length data frame, which then crashes on the `cbind`. This skips the variable with a warning if it has 0-length output.
- `shiny::server.R`
  - Shiny crashes if no inputs are available for a given site and format. This hotfix returns `NULL` if no inputs are found, which allows Shiny to draw the output, even if it can't find data to plot with.