### PR TITLE
Temporary patch to fix `rhdf5` installation

### DIFF
--- a/models/ed/DESCRIPTION
+++ b/models/ed/DESCRIPTION
@@ -29,8 +29,7 @@ Imports:
 Suggests:
     testthat (>= 1.0.2)
 Remotes:
-    github::bioconductor-mirror/biocinstaller@release-3.4,
-    github::bioconductor-mirror/rhdf5@release-3.4
+    bioc::release/rhdf5
 License: FreeBSD + file LICENSE
 Copyright: Authors
 LazyLoad: yes

--- a/models/ed/DESCRIPTION
+++ b/models/ed/DESCRIPTION
@@ -24,12 +24,13 @@ Imports:
     stringr(>= 1.1.0),
     udunits2 (>= 0.11),
     XML (>= 3.98-1.4),
-    BiocInstaller,
+    Rhdf5lib,
     rhdf5
 Suggests:
     testthat (>= 1.0.2)
 Remotes:
-    bioc::release/rhdf5
+    grimbough/Rhdf5lib,
+    grimbough/rhdf5
 License: FreeBSD + file LICENSE
 Copyright: Authors
 LazyLoad: yes


### PR DESCRIPTION
See issue #1806. Temporarily switching to a specific GitHub user's `rhdf5` forks. `Rhdf5lib` dependency added to `Imports` because it's required by `rhdf5`.