### PR TITLE
Make documentation builds fail Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,6 +129,7 @@ script:
   - set +e
 
 after_script:
+  - set -e
   - echo 'Building Book'
   - pushd book_source
   - make
@@ -137,3 +138,4 @@ after_script:
   - pushd documentation/tutorials
   - make build deploy
   - popd
+  - set +e


### PR DESCRIPTION
Set the error option (`set -e`) for the documentation-building part of Travis, so that if `make` throws an error, the build will fail.