### PR TITLE
skip documentation build if user has not forked repo

### DIFF
--- a/book_source/deploy.sh
+++ b/book_source/deploy.sh
@@ -37,7 +37,13 @@ USER=${TRAVIS_REPO_SLUG%/*}
 git config --global user.email "pecanproj@gmail.com"
 git config --global user.name "TRAVIS-DOC-BUILD"
 
-# clone documentation git repo
+# Don't deploy if documentation git repo does not exist
+if ! ( git ls-remote -h git@github.com:${USER}/pecan-documentation >/dev/null 2>&1); then
+  echo "Can't find a repository at https://github.com/${USER}/pecan-documentation"
+  echo "Will not render Book."
+  exit 0
+fi
+
 git clone https://${GITHUB_PAT}@github.com/${USER}/pecan-documentation.git book_hosted
 cd book_hosted
 

--- a/documentation/tutorials/deploy.sh
+++ b/documentation/tutorials/deploy.sh
@@ -14,6 +14,13 @@ if [ ! -d book_hosted ]; then
     # Set GitHub user
     USER=${TRAVIS_REPO_SLUG%/*}
 
+	# Don't deploy if documentation git repo does not exist
+	if ! ( git ls-remote -h git@github.com:${USER}/pecan-documentation >/dev/null 2>&1); then
+	  echo "Can't find a repository at https://github.com/${USER}/pecan-documentation"
+	  echo "Will not render tutorials."
+	  exit 0
+	fi
+
     # configure your name and email if you have not done so
     git config --global user.email "pecanproj@gmail.com"
     git config --global user.name "TRAVIS-DOC-BUILD"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Skips documentation deployment for builds in forks where the user hasn't set up a `pecan-documentation` repository.

## Motivation and Context
The current build script attempts to deploy to `${USER}/pecan-documentation.git` on every push to a branch named "master", "release*" or "develop", even in forks owned by users who don't have such a repo. Before #1833, this was masked by *all* documentation failures going unreported, which is obviously even less desirable.

This patch queries for the existence of a documentation repository and only attempts the deployment if one is found. Then for anyone who *does* want a local documentation repo, the procedure should be as simple as "Fork `PecAnProject/pecan-documentation` to the same account as your PEcAn fork, and the next CI build will start it updating."

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 