### PR TITLE
silence psql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ before_script:
   - psql -q -o /dev/null -U postgres -c "CREATE ROLE BETY WITH LOGIN CREATEDB SUPERUSER CREATEROLE UNENCRYPTED PASSWORD 'bety'";
   - psql -q -o /dev/null -U postgres -c "CREATE DATABASE bety OWNER bety;"
   - curl -o bety.sql http://isda.ncsa.illinois.edu/~kooper/PEcAn/data/bety.sql
-  - psql -q -o /dev/null-U postgres < bety.sql
+  - psql -q -o /dev/null -U postgres < bety.sql
   - rm bety.sql
   - ./scripts/add.models.sh
   - chmod +x book_source/deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,10 +101,10 @@ install:
   - popd
 
 before_script:
-  - psql -U postgres -c "CREATE ROLE BETY WITH LOGIN CREATEDB SUPERUSER CREATEROLE UNENCRYPTED PASSWORD 'bety'";
-  - psql -U postgres -c "CREATE DATABASE bety OWNER bety;"
+  - psql -q -o /dev/null -U postgres -c "CREATE ROLE BETY WITH LOGIN CREATEDB SUPERUSER CREATEROLE UNENCRYPTED PASSWORD 'bety'";
+  - psql -q -o /dev/null -U postgres -c "CREATE DATABASE bety OWNER bety;"
   - curl -o bety.sql http://isda.ncsa.illinois.edu/~kooper/PEcAn/data/bety.sql
-  - psql -q -U postgres < bety.sql
+  - psql -q -o /dev/null-U postgres < bety.sql
   - rm bety.sql
   - ./scripts/add.models.sh
   - chmod +x book_source/deploy.sh


### PR DESCRIPTION
This will remove all the setvalue from psql loading of the database.

## Description
`psql -q` will make postgresql quiet, but all output from any select type statements is still printed. When doing a setval this is considered output that should be printed. Using the `-o` flag the output is now redirected to /dev/null. Errors will still be printed to the console.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [x] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
