### PR TITLE
RTM: Remove references to `n_eff` and `sigma2eff`

### DIFF
--- a/modules/rtm/R/bayestools.R
+++ b/modules/rtm/R/bayestools.R
@@ -25,8 +25,6 @@ rtm_loglike <- function(nparams, model, observed, lag.max = NULL, verbose = TRUE
                 message("Mean error: ", mean(err))
                 message("Sum of squares: ", ss)
                 message("Sigma2 = ", sigma2)
-                message("n_eff = ", n_eff)
-                message("sigma2eff = ", sigma2eff)
                 message("LL = ", ll)
             }
             return(fail_ll)


### PR DESCRIPTION
These values no longer exist. Asking for them in an error message would
cause an error.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [X] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
