### PR TITLE
Define package location of teardown function

### DIFF
--- a/models/biocro/tests/testthat/test-call_biocro.R
+++ b/models/biocro/tests/testthat/test-call_biocro.R
@@ -3,7 +3,7 @@ context("checking call_biocro wrappers")
 
 loglevel <- PEcAn.logger::logger.getLevel()
 PEcAn.logger::logger.setLevel("OFF")
-teardown(PEcAn.logger::logger.setLevel(loglevel))
+testthat::teardown(PEcAn.logger::logger.setLevel(loglevel))
 
 WetDat <- read.csv("data/US-Bo1.2004.csv", nrows=7*24)
 config <- list(pft = list(


### PR DESCRIPTION
A few builds on TRAVIS are failing with error:
```
Testing PEcAn.BIOCRO
Error in teardown(PEcAn.logger::logger.setLevel(loglevel)) : 
  could not find function "teardown"
```
## Description
Added `testthat::` so that it knows where `teardown` is coming from.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
