### PR TITLE
Add machine check to query in load_veg

### DIFF
--- a/modules/data.land/R/load_veg.R
+++ b/modules/data.land/R/load_veg.R
@@ -16,16 +16,22 @@ load_veg <- function(new_site, start_date, end_date,
   #--------------------------------------------------------------------------------------------------#
   # Load data : this step requires DB connections 
   
+  # get machine id
+  machine_id <- get.id(table = "machines", colnames = "hostname", 
+                       values = machine_host, con = bety$con)
+  
   # query data.path from source id [input id in BETY]
-  query      <- paste0("SELECT * FROM dbfiles where container_id = ", source_id)
+  query      <- paste0("SELECT * FROM dbfiles where container_id =  ", source_id,
+                       "AND machine_id=", machine_id)
+  
   input_file <- PEcAn.DB::db.query(query, con = bety$con)
   data_path  <- file.path(input_file[["file_path"]], input_file[["file_name"]])
   
   # query format info
-  format <- PEcAn.DB::query.format.vars(bety = bety, input.id = source_id)
+  format     <- PEcAn.DB::query.format.vars(bety = bety, input.id = source_id)
   
   # load_data{benchmark}
-  obs <- PEcAn.benchmark::load_data(data.path = data_path, format, site = new_site)
+  obs        <- PEcAn.benchmark::load_data(data.path = data_path, format, site = new_site)
   
   #--------------------------------------------------------------------------------------------------#
   # Match species : this step requires DB connections 


### PR DESCRIPTION
`load_veg` has a query to find an input veg file, but there is the possibility that the file can be on multiple machines. Added to the query to make sure it finds the file on the  for that within the function as it has the necessary params to make that query.

Tagging @istfer for review because you wrote this function and you happen to be my code reviewer this week.
## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [x] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
