### PR TITLE
utils: Residual leap year-related bug

### DIFF
--- a/base/utils/R/seconds_in_year.R
+++ b/base/utils/R/seconds_in_year.R
@@ -9,7 +9,7 @@
 #' seconds_in_year(2000:2005)  # Vectorized over year
 #' @inheritParams days_in_year
 #' @export
-seconds_in_year <- function(year, ...) {
+seconds_in_year <- function(year, leap_year = TRUE, ...) {
     diy <- days_in_year(year, leap_year)
     siy <- udunits2::ud.convert(diy, 'days', 'seconds')
     return(siy)

--- a/base/utils/man/seconds_in_year.Rd
+++ b/base/utils/man/seconds_in_year.Rd
@@ -4,7 +4,7 @@
 \alias{seconds_in_year}
 \title{Number of seconds in a given year}
 \usage{
-seconds_in_year(year, ...)
+seconds_in_year(year, leap_year = TRUE, ...)
 }
 \arguments{
 \item{year}{Numeric year (can be a vector)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
`PEcAn.utils::seconds_in_year` also needs to be aware of the `leap_year` argument. This adds the `leap_year` argument in.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without it, running `met2model.*` would throw an error, because `leap_year` is expected by `days_in_year`, but is not properly passed through when called by `seconds_in_year`.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [X] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
