### PR TITLE
change check_paths default to false

### DIFF
--- a/models/ed/R/modify_ed2in.R
+++ b/models/ed/R/modify_ed2in.R
@@ -48,7 +48,7 @@
 #'(history) files
 #' @param run_dir Directory in which to store run-related config files (e.g. `config.xml`).
 #' @param runtype ED initialization mode; either "INITIAL" or "HISTORY"
-#' @param pecan_defaults Logical. If `TRUE` (default), set common `ED2IN` defaults.
+#' @param pecan_defaults Logical. If `TRUE`, set common `ED2IN` defaults.
 #' @param add_if_missing Logical. If `TRUE`, all-caps arguments not found in 
 #'existing `ed2in` list will be added to the end.  Default = `FALSE`.
 #' @param check_paths Logical. If `TRUE` (default), for any parameters that 
@@ -69,7 +69,7 @@ modify_ed2in <- function(ed2in, ...,
                          run_dir = NULL,
                          runtype = NULL,
                          run_name = NULL,
-                         pecan_defaults = TRUE,
+                         pecan_defaults = FALSE,
                          add_if_missing = FALSE,
                          check_paths = TRUE,
                          .dots = list()) {

--- a/models/ed/R/modify_ed2in.R
+++ b/models/ed/R/modify_ed2in.R
@@ -51,7 +51,7 @@
 #' @param pecan_defaults Logical. If `TRUE` (default), set common `ED2IN` defaults.
 #' @param add_if_missing Logical. If `TRUE`, all-caps arguments not found in 
 #'existing `ed2in` list will be added to the end.  Default = `FALSE`.
-#' @param check_paths Logical. If `TRUE` (default), for any parameters that 
+#' @param check_paths Logical. If `TRUE`, for any parameters that 
 #' expect files, check that files exist and throw an error if they don't.
 #' @param .dots A list of `...` arguments.
 #' @return Modified `ed2in` list object. See [read_ed2in].
@@ -71,7 +71,7 @@ modify_ed2in <- function(ed2in, ...,
                          run_name = NULL,
                          pecan_defaults = TRUE,
                          add_if_missing = FALSE,
-                         check_paths = TRUE,
+                         check_paths = FALSE,
                          .dots = list()) {
 
   if (is.null(.dots)) {

--- a/models/ed/R/modify_ed2in.R
+++ b/models/ed/R/modify_ed2in.R
@@ -51,7 +51,7 @@
 #' @param pecan_defaults Logical. If `TRUE` (default), set common `ED2IN` defaults.
 #' @param add_if_missing Logical. If `TRUE`, all-caps arguments not found in 
 #'existing `ed2in` list will be added to the end.  Default = `FALSE`.
-#' @param check_paths Logical. If `TRUE`, for any parameters that 
+#' @param check_paths Logical. If `TRUE` (default), for any parameters that 
 #' expect files, check that files exist and throw an error if they don't.
 #' @param .dots A list of `...` arguments.
 #' @return Modified `ed2in` list object. See [read_ed2in].
@@ -71,7 +71,7 @@ modify_ed2in <- function(ed2in, ...,
                          run_name = NULL,
                          pecan_defaults = TRUE,
                          add_if_missing = FALSE,
-                         check_paths = FALSE,
+                         check_paths = TRUE,
                          .dots = list()) {
 
   if (is.null(.dots)) {

--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -181,23 +181,27 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
     ## Set prescribed phenology switch in ED2IN
     ed2in.text <- modify_ed2in(
       ed2in.text,
-      IPHEN_SCHEME = settings$model$phenol.scheme,
-      PHENPATH = settings$model$phenol,
-      IPHENYS1 = settings$model$phenol.start,
-      PIPHENYSF = settings$model$phenol.end,
+      IPHEN_SCHEME   = as.numeric(settings$model$phenol.scheme),
+      PHENPATH       = settings$model$phenol,
+      IPHENYS1       = settings$model$phenol.start,
+      PIPHENYSF      = settings$model$phenol.end,
+      IPHENYF1       = settings$model$phenol.start,
+      IPHENYFF       = settings$model$phenol.end,
       add_if_missing = TRUE,
-      check_paths = check
+      check_paths    = check
     )
   } else {
     ## If not prescribed set alternative phenology scheme.
     ed2in.text <- modify_ed2in(
       ed2in.text,
-      IPHEN_SCHEME = as.numeric(settings$model$phenol.scheme),
-      PHENPATH = "",
-      IPHENYS1 = ssettings$model$phenol.start,
-      PIPHENYSF= settings$model$phenol.end,
+      IPHEN_SCHEME   = as.numeric(settings$model$phenol.scheme),
+      PHENPATH       = "",
+      IPHENYS1       = settings$model$phenol.start,
+      PIPHENYSF      = settings$model$phenol.end,
+      IPHENYF1       = settings$model$phenol.start,
+      IPHENYFF       = settings$model$phenol.end,
       add_if_missing = TRUE,
-      check_paths = check
+      check_paths    = check
     )
   }
 

--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -160,7 +160,8 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
     MET_START = metstart,
     MET_END = metend,
     IMETAVG = -1,   # See below,
-    add_if_missing = TRUE
+    add_if_missing = TRUE,
+    check_paths = check
   )
 
   # The flag for IMETAVG tells ED what to do given how input radiation was 
@@ -184,7 +185,8 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
       PHENOL = settings$model$phenol,
       PHENOL_START = settings$model$phenol.start,
       PHENOL_END = settings$model$phenol.end,
-      add_if_missing = TRUE
+      add_if_missing = TRUE,
+      check_paths = check
     )
   } else {
     ## If not prescribed set alternative phenology scheme.
@@ -194,7 +196,8 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
       PHENOL = "",
       PHENOL_START = "",
       PHENOL_END = "",
-      add_if_missing = TRUE
+      add_if_missing = TRUE,
+      check_paths = check
     )
   }
 
@@ -211,7 +214,7 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
 
     # Overwrite defaults with values from settings$model$ed2in_tags list
     sda_tags <- modifyList(sda_tags, settings$model$ed2in_tags[names(sda_tags)])
-    ed2in.text <- modify_ed2in(ed2in.text, .dots = sda_tags, add_if_missing = TRUE)
+    ed2in.text <- modify_ed2in(ed2in.text, .dots = sda_tags, add_if_missing = TRUE, check_paths = check)
   }
 
   ##----------------------------------------------------------------------
@@ -225,7 +228,8 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
       ed2in.text,
       IED_INIT_MODE = 0,
       SFILIN = "",
-      add_if_missing = TRUE
+      add_if_missing = TRUE,
+      check_paths = check
     )
   } else {
     lat_rxp <- "\\.lat.*lon.*\\.(css|pss|site)"
@@ -257,7 +261,8 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
       ed2in.text,
       IED_INIT_MODE = value,
       SFILIN = paste0(prefix.pss, "."),
-      add_if_missing = TRUE
+      add_if_missing = TRUE,
+      check_paths = check
     )
   }
 
@@ -272,7 +277,8 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
     SOIL_DATABASE = settings$run$inputs$soil$path,
     LU_DATABASE = settings$run$inputs$lu$path,
     THSUMS_DATABASE = thsum,
-    add_if_missing = TRUE
+    add_if_missing = TRUE,
+    check_paths = check
   )
   
   ##----------------------------------------------------------------------
@@ -286,12 +292,13 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
     run_name = paste0("ED2 v", revision, " PEcAn ", run.id),
     run_dir = file.path(settings$host$rundir, run.id),    # For `config.xml`
     output_dir = modeloutdir,   # Sets analysis and history paths
-    add_if_missing = TRUE
+    add_if_missing = TRUE,
+    check_paths = check
   )
   
   ##---------------------------------------------------------------------
   # Modify any additional tags provided in settings$model$ed2in_tags
-  ed2in.text <- modify_ed2in(ed2in.text, .dots = settings$model$ed2in_tags, add_if_missing = TRUE)
+  ed2in.text <- modify_ed2in(ed2in.text, .dots = settings$model$ed2in_tags, add_if_missing = TRUE, check_paths = check)
   
   ##----------------------------------------------------------------------
   if (check) {

--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -152,8 +152,8 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
 
   ed2in.text <- modify_ed2in(
     ed2in.text,
-    latitude = settings$run$site$lat,
-    longitude = settings$run$site$lon,
+    latitude = as.numeric(settings$run$site$lat),
+    longitude = as.numeric(settings$run$site$lon),
     met_driver = settings$run$inputs$met$path,
     start_date = startdate,
     end_date = enddate,

--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -181,10 +181,10 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
     ## Set prescribed phenology switch in ED2IN
     ed2in.text <- modify_ed2in(
       ed2in.text,
-      PHENOL_SCHEME = settings$model$phenol.scheme,
-      PHENOL = settings$model$phenol,
-      PHENOL_START = settings$model$phenol.start,
-      PHENOL_END = settings$model$phenol.end,
+      IPHEN_SCHEME = settings$model$phenol.scheme,
+      PHENPATH = settings$model$phenol,
+      IPHENYS1 = settings$model$phenol.start,
+      PIPHENYSF = settings$model$phenol.end,
       add_if_missing = TRUE,
       check_paths = check
     )
@@ -192,10 +192,10 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
     ## If not prescribed set alternative phenology scheme.
     ed2in.text <- modify_ed2in(
       ed2in.text,
-      PHENOL_SCHEME = settings$model$phenol.scheme,
-      PHENOL = "",
-      PHENOL_START = "",
-      PHENOL_END = "",
+      IPHEN_SCHEME = as.numeric(settings$model$phenol.scheme),
+      PHENPATH = "",
+      IPHENYS1 = ssettings$model$phenol.start,
+      PIPHENYSF= settings$model$phenol.end,
       add_if_missing = TRUE,
       check_paths = check
     )

--- a/models/ed/man/modify_ed2in.Rd
+++ b/models/ed/man/modify_ed2in.Rd
@@ -8,7 +8,7 @@ modify_ed2in(ed2in, ..., veg_prefix = NULL, latitude = NULL,
   longitude = NULL, met_driver = NULL, start_date = NULL,
   end_date = NULL, EDI_path = NULL, output_types = NULL,
   output_dir = NULL, run_dir = NULL, runtype = NULL, run_name = NULL,
-  pecan_defaults = TRUE, add_if_missing = FALSE, check_paths = FALSE,
+  pecan_defaults = TRUE, add_if_missing = FALSE, check_paths = TRUE,
   .dots = list())
 }
 \arguments{
@@ -48,7 +48,7 @@ and \code{THSUMS_DATABASE} files.}
 \item{add_if_missing}{Logical. If \code{TRUE}, all-caps arguments not found in
 existing \code{ed2in} list will be added to the end.  Default = \code{FALSE}.}
 
-\item{check_paths}{Logical. If \code{TRUE}, for any parameters that
+\item{check_paths}{Logical. If \code{TRUE} (default), for any parameters that
 expect files, check that files exist and throw an error if they don't.}
 
 \item{.dots}{A list of \code{...} arguments.}

--- a/models/ed/man/modify_ed2in.Rd
+++ b/models/ed/man/modify_ed2in.Rd
@@ -8,7 +8,7 @@ modify_ed2in(ed2in, ..., veg_prefix = NULL, latitude = NULL,
   longitude = NULL, met_driver = NULL, start_date = NULL,
   end_date = NULL, EDI_path = NULL, output_types = NULL,
   output_dir = NULL, run_dir = NULL, runtype = NULL, run_name = NULL,
-  pecan_defaults = TRUE, add_if_missing = FALSE, check_paths = TRUE,
+  pecan_defaults = TRUE, add_if_missing = FALSE, check_paths = FALSE,
   .dots = list())
 }
 \arguments{
@@ -48,7 +48,7 @@ and \code{THSUMS_DATABASE} files.}
 \item{add_if_missing}{Logical. If \code{TRUE}, all-caps arguments not found in
 existing \code{ed2in} list will be added to the end.  Default = \code{FALSE}.}
 
-\item{check_paths}{Logical. If \code{TRUE} (default), for any parameters that
+\item{check_paths}{Logical. If \code{TRUE}, for any parameters that
 expect files, check that files exist and throw an error if they don't.}
 
 \item{.dots}{A list of \code{...} arguments.}

--- a/models/ed/man/modify_ed2in.Rd
+++ b/models/ed/man/modify_ed2in.Rd
@@ -8,7 +8,7 @@ modify_ed2in(ed2in, ..., veg_prefix = NULL, latitude = NULL,
   longitude = NULL, met_driver = NULL, start_date = NULL,
   end_date = NULL, EDI_path = NULL, output_types = NULL,
   output_dir = NULL, run_dir = NULL, runtype = NULL, run_name = NULL,
-  pecan_defaults = TRUE, add_if_missing = FALSE, check_paths = TRUE,
+  pecan_defaults = FALSE, add_if_missing = FALSE, check_paths = TRUE,
   .dots = list())
 }
 \arguments{
@@ -43,7 +43,7 @@ and \code{THSUMS_DATABASE} files.}
 
 \item{runtype}{ED initialization mode; either "INITIAL" or "HISTORY"}
 
-\item{pecan_defaults}{Logical. If \code{TRUE} (default), set common \code{ED2IN} defaults.}
+\item{pecan_defaults}{Logical. If \code{TRUE}, set common \code{ED2IN} defaults.}
 
 \item{add_if_missing}{Logical. If \code{TRUE}, all-caps arguments not found in
 existing \code{ed2in} list will be added to the end.  Default = \code{FALSE}.}


### PR DESCRIPTION
check_paths in modify_ed2in is breaking remote runs, defaulting it to false

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [X] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

