### PR TITLE
Fixes #1886, assignment to vector when NA error

### DIFF
--- a/modules/data.atmosphere/R/metgapfill.R
+++ b/modules/data.atmosphere/R/metgapfill.R
@@ -302,10 +302,12 @@ metgapfill <- function(in.path, in.prefix, outfolder, start_date, end_date, lst 
 
     ##Once all are filled, do one more consistency check
     es <- get.es(Tair_degC) * 100
+
     rH[rH < 0] <- 0
     rH[rH > 100] <- 100
     VPD[VPD < 0] <- 0
-    VPD[VPD > es] <- es
+    badVPD_es <- which(VPD > es)
+    VPD[badVPD_es] <- es[badVPD_es]
     sHum[sHum < 0] <- 0
     
     ## one set of these must exist (either wind_speed or east+north wind)
@@ -563,7 +565,8 @@ metgapfill <- function(in.path, in.prefix, outfolder, start_date, end_date, lst 
       if (("Tair_f" %in% colnames(Extracted))) {
         Tair_f_degC <- udunits2::ud.convert(Tair_f, "K", "degC")
         es <- get.es(Tair_f_degC) * 100
-        VPD_f[VPD_f > es] <- es
+        badVPD_f <- which(VPD_f > es)
+        VPD_f[badVPD_f] <- es[badVPD_f]
       }
     }
     if (length(which(is.na(VPD_f))) > 0) {


### PR DESCRIPTION
Closes #1886 

## Description
Assignment subsetting when the assigning values are a vector fail if the subset includes NA. Using the which statement fixes that. metgapfill should work better now.