### PR TITLE
need login before calling anything in setup folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 ## [1.5.3] - not yet
 
 ### Fixes
+- Fixed xss issue in setup folder, now require users to login before accessing the setup folder scripts.
 - Fixed issue where in website not all sites are shown #1884
 - Fixed status page, should now be run from cronjob, creates static page
 - Fixed bug that overwrote remote  met file paths with local file paths

--- a/web/setups/core.php
+++ b/web/setups/core.php
@@ -47,4 +47,13 @@
     '4' => "",
     );
 
+  // always require user to be logged in.
+  include '../common.php';
+  open_database();
+  if (!check_login()) {
+    header( "Location: ../login.php");
+    close_database();
+    exit;
+  }
+  close_database();
 ?>


### PR DESCRIPTION
NCSA security discovered a XSS issue, this is fixed in this pull request.

## Description
php code in setup folder can be run without being logged in. Now requires user to be logged in. This does not completely address issue yet, however it makes it harder to abuse the setup system. Will need a more thorough review of the code.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [X] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
