### PR TITLE
testthat::teardown requires testthat 2.0.0

### DIFF
--- a/base/utils/DESCRIPTION
+++ b/base/utils/DESCRIPTION
@@ -43,7 +43,7 @@ Suggests:
     PEcAn.settings,
     PEcAn.DB,
     MASS,
-    testthat
+    testthat (>= 2.0.0)
 License: FreeBSD + file LICENSE
 Copyright: Authors
 LazyData: true


### PR DESCRIPTION
## Description

This is a minor fixup for #1893 -- I added tests that use testthat::teardown (new in testthat 2.0.0) but neglected to update the version spec.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
