### PR TITLE
show curl command to re-execute workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 
 ## [Unreleased]
 
+### Added
+- From history you can now select an old run and show the curl command to re-execute this run. This only works with runs submitted through web interface right now.
+
 ## [1.5.3] - not yet
 
 ### Fixes

--- a/web/curl.php
+++ b/web/curl.php
@@ -1,0 +1,66 @@
+<?php
+require("common.php");
+open_database();
+
+// runid
+if (!isset($_REQUEST['workflowid'])) {
+  die("Need a workflowid.");
+}
+$workflowid=$_REQUEST['workflowid'];
+
+// get run information
+$stmt = $pdo->prepare("SELECT * FROM workflows WHERE workflows.id=?");
+if (!$stmt->execute(array($workflowid))) {
+  die('Invalid query: ' . error_database());
+}
+$workflow = $stmt->fetch(PDO::FETCH_ASSOC);
+$stmt->closeCursor();
+$start = substr($workflow['start_date'], 0, 4);
+$end = substr($workflow['end_date'], 0, 4);
+$folder = $workflow['folder'];
+$notes = htmlspecialchars($workflow['notes']);
+$params = $workflow['params'];
+if ($params == '') {
+  die('No parameters found, was this not launched from web interface?');
+}
+eval('$array = ' . $params . ';');
+
+$pft=$array['pft'];
+
+
+$stmt = $pdo->prepare("SELECT model_name, revision FROM models WHERE id=?;");
+if (!$stmt->execute(array($array['modelid']))) {
+  die('Invalid query: ' . error_database());
+}
+$model = "";
+while ($row = @$stmt->fetch(PDO::FETCH_ASSOC)) {
+    $model = "${row['model_name']} (v${row['revision']})";
+}
+$stmt->closeCursor();
+
+
+echo "<pre>\n";
+echo "# model       : ${model}\n";
+echo "# site        : ${array['sitename']}\n";
+echo "# pft         : ${pft[0]}\n";
+echo "# time range  : ${array['start']} - ${array['end']}\n";
+echo "curl -v -X POST \\\n";
+echo "    -F 'hostname=${array['hostname']}' \\\n";
+echo "    -F 'modelid=${array['modelid']}' \\\n";
+echo "    -F 'sitegroupid=1' \\\n";
+echo "    -F 'siteid=${array['siteid']}' \\\n";
+echo "    -F 'sitename=${array['sitename']}' \\\n";
+echo "    -F 'pft[]=${pft[0]}' \\\n";
+echo "    -F 'start=${array['start']}' \\\n";
+echo "    -F 'end=${array['end']}' \\\n";
+foreach($array as $key => $value) {
+    if (substr($key, 0, 6) === "input_" && $value !== "-1") {
+        echo "    -F '${key}=${value}' \\\n";
+    }
+}
+echo "    -F 'email=' \\\n";
+echo "    -F 'notes=' \\\n";
+echo "    'http://localhost:6480/pecan/04-runpecan.php'\n";
+echo "</pre>";
+
+close_database();

--- a/web/history.php
+++ b/web/history.php
@@ -96,6 +96,7 @@ close_database();
         row += '  <div class="cell">' + workflow.attr("started_at") + '</div>';
         row += '  <div class="cell">' + workflow.attr("finished_at") + '</div>';
 <?php if (check_login() && (get_page_acccess_level() <= $min_delete_level)) { ?>
+        row += '  <div class="cell"><a href="curl.php?workflowid=' + workflow.attr("id") + '">CURL</a></div>';
         row += '  <div class="cell"><a href="delete.php?workflowid=' + workflow.attr("id") + '">DELETE</a></div>';
 <?php } ?>
         row += '</div>';
@@ -158,6 +159,7 @@ close_database();
           <div class="header">Started</div>
           <div class="header">Finished</div>
 <?php if (check_login() && (get_page_acccess_level() <= $min_delete_level)) { ?>
+          <div class="header">Curl</div>
           <div class="header">Delete</div>
 <?php } ?>
         </div>


### PR DESCRIPTION
This will allow you to see the curl command needed to re-execute an existing workflow.

## Description
This will look at the parameters stored when the workflow was last executed through the web interface and create the curl command to re-execute the same workflow. Only caveat is that all spaces had been removed from the parameters, this is visible in site-names, however this should not impact the actual run.

## Motivation and Context
For testing I needed to quickly be able to re-execute a workflow.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [X] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
