### PR TITLE
download.GFDL: CF-compliant time units, download only requested dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - PEcAn.data.atmosphere: 
     - download.Geostreams is pickier about formatting start/end datess, for fewer surprises in result timestamps
     - Fixed swapped lat/lon in met2CF.Geostreams
+    - download.GFDL now records reference date in time units field, as required by the CF met standard
+    - Reduced download.GFDL network load by not preloading dimension data
 - ED:
     - Change all history parameter files to have zero storage respiration
     

--- a/modules/data.atmosphere/DESCRIPTION
+++ b/modules/data.atmosphere/DESCRIPTION
@@ -55,7 +55,8 @@ Suggests:
     foreach,
     parallel,
     progress,
-    testthat
+    rlang (>= 0.2.0),
+    testthat (>= 2.0.0)
 Remotes:
     github::ropenscilabs/nneo,
     github::rforge/reddyproc/pkg/REddyProc

--- a/modules/data.atmosphere/R/download.GFDL.R
+++ b/modules/data.atmosphere/R/download.GFDL.R
@@ -14,7 +14,7 @@
 #' @param scenario Which scenario to run (options are rcp26, rcp45, rcp60, rcp85)
 #' @param ensemble_member Which ensemble_member to initialize the run (options are r1i1p1, r3i1p1, r5i1p1)
 #' @author James Simkins, Alexey Shiklomanov, Ankur Desai
-download.GFDL <- function(outfolder, start_date, end_date, site_id, lat.in, lon.in,
+download.GFDL <- function(outfolder, start_date, end_date, lat.in, lon.in,
                           overwrite = FALSE, verbose = FALSE,
                           model = "CM3", scenario = "rcp45", ensemble_member = "r1i1p1", ...) {
 

--- a/modules/data.atmosphere/R/download.GFDL.R
+++ b/modules/data.atmosphere/R/download.GFDL.R
@@ -82,7 +82,7 @@ download.GFDL <- function(outfolder, start_date, end_date, lat.in, lon.in,
     PEcAn.logger::logger.debug(
       sprintf(
         "Downloading GFDL year %d (%d of %d)",
-        year, i, length(rows)
+        year, i, rows
       )
     )
 

--- a/modules/data.atmosphere/man/download.GFDL.Rd
+++ b/modules/data.atmosphere/man/download.GFDL.Rd
@@ -4,7 +4,7 @@
 \alias{download.GFDL}
 \title{Download GFDL CMIP5 outputs for a single grid point using OPeNDAP and convert to CF}
 \usage{
-download.GFDL(outfolder, start_date, end_date, site_id, lat.in, lon.in,
+download.GFDL(outfolder, start_date, end_date, lat.in, lon.in,
   overwrite = FALSE, verbose = FALSE, model = "CM3", scenario = "rcp45",
   ensemble_member = "r1i1p1", ...)
 }

--- a/modules/data.atmosphere/tests/testthat/helper.R
+++ b/modules/data.atmosphere/tests/testthat/helper.R
@@ -1,0 +1,37 @@
+#' Expectation: Does PEcAn logger produce warning/debug/error?
+#'
+#' Tests whether PEcAn.logger produced the expected output.
+#' Modeled after testthat::expect_message, but looks for output on stderr
+#' (where PEcAn.logger writes it) rather than a message() object
+#'
+#' @param object object to test, probably a PEcAn function call
+#' @param regexp pattern expected in the output
+#' @param ... other arguments passed on to \code{\link[testthat]{expect_match}}
+#' @examples
+#' expect_log(PEcAn.logger::logger.debug("test"), "DEBUG.*test")
+#' expect_log(PEcAn.utils::get.model.output(), "update your workflow")
+#' expect_log(cat("Hello", file = stderr()), "Hello")
+#' # Only messages on stderr are recognized
+#' expect_failure(expect_log("Hello", "Hello"))
+#'
+expect_log <- function(object, regexp, ...){
+	qobj <- rlang::enquo(object)
+	msg <- capture.output(
+		{val <- rlang::eval_tidy(qobj)},
+		type = "message")
+	label = rlang::expr_label(rlang::get_expr(qobj))
+
+	expect(
+		length(msg) > 0,
+		sprintf("%s did not produce any log messages", label))
+	msg = paste(msg, collapse = "\n")
+	expect(
+		grepl(regexp, msg,  ...),
+		sprintf(
+			"%s does not match %s.\nActual value: \"%s\"",
+			label,
+			encodeString(regexp, quote = "\""),
+			encodeString(msg)))
+
+	invisible(val)
+}

--- a/modules/data.atmosphere/tests/testthat/test-download.GFDLR.R
+++ b/modules/data.atmosphere/tests/testthat/test-download.GFDLR.R
@@ -1,0 +1,42 @@
+context("Checking GFDL download")
+
+tmpdir = tempfile(pattern="GFDLtest")
+dir.create(tmpdir)
+teardown(unlink(tmpdir, recursive = TRUE))
+
+test_that("download works and returns a valid CF file", {
+  # Download is too slow for Travis -- please run locally before committing!
+  skip_on_travis()
+
+  PEcAn.logger::logger.setLevel("WARN")
+
+  result <- download.GFDL(outfolder = tmpdir,
+                             start_date = "2007-01-01",
+                             end_date = "2007-12-31",
+                             site_id = 753,
+                             lat.in = 40,
+                             lon.in = -88)
+  cf <- ncdf4::nc_open(result$file)
+  teardown(ncdf4::nc_close(cf))
+
+  # Expect that reference times are present and set to start date
+  cf_units <- cf$dim$time$units
+  expect_equal(cf_units, "seconds since 2007-01-01 00:00:00")
+
+  expect_equal(cf$dim$latitude$len, 1)
+  expect_equal(cf$dim$longitude$len, 1)
+  expect_equal(cf$dim$time$len, 365*(24/3)) # one year at 3-hr interval, leap days ignored
+  expect_equal(cf$nvar, 8)
+
+  # Expect that overwrite argument is respected
+  expect_log(
+    download.GFDL(
+      outfolder = tmpdir,
+      start_date = "2007-01-01",
+      end_date = "2007-12-31",
+      site_id = 753,
+      lat.in = 40,
+      lon.in = -88,
+      overwrite = FALSE),
+    "already exists. Skipping")
+})

--- a/modules/data.atmosphere/tests/testthat/test.download.CRUNCEP.R
+++ b/modules/data.atmosphere/tests/testthat/test.download.CRUNCEP.R
@@ -1,14 +1,14 @@
 context("Checking CRUNCEP download")
 
+tmpdir = tempfile(pattern="CRUNCEPtest")
+dir.create(tmpdir)
+teardown(unlink(tmpdir, recursive = TRUE))
 
 test_that("download works and returns a valid CF file", {
   # download is slow and was causing lots of Travis timeouts
   skip_on_travis()
 
   PEcAn.logger::logger.setLevel("WARN")
-
-  tmpdir <- tempdir()
-  on.exit(unlink(tmpdir, recursive = TRUE))
 
   result <- download.CRUNCEP(outfolder = tmpdir,
                              start_date = "2000-01-01",
@@ -23,17 +23,14 @@ test_that("download works and returns a valid CF file", {
   # Expect that reference times are present and set to start date
   expect_equal(cf_units, "days since 2000-01-01T00:00:00Z")
 
-  # Expect that overwrite argument is respected
-  # The skip message comes fromPEcAn.logger::logger.error,
-  # which writes to stderr but does not use message().
-  # If it did, this test would reduce to expect_message(download.CRUNCEP(...), "foo")
-  msg <- capture.output(download.CRUNCEP(outfolder = tmpdir,
-                                         start_date = "2000-01-01",
-                                         end_date = "2000-12-31",
-                                         site_id = 753,
-                                         lat.in = 40,
-                                         lon.in = -88,
-                                         overwrite = FALSE),
-                        type = "message")
-  expect_match(paste(msg, collapse="\n"), "already exists. Skipping")
+  expect_log(
+    download.CRUNCEP(
+      outfolder = tmpdir,
+      start_date = "2000-01-01",
+      end_date = "2000-12-31",
+      site_id = 753,
+      lat.in = 40,
+      lon.in = -88,
+      overwrite = FALSE),
+    "already exists. Skipping")
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
* Record time units as seconds since current_year-01-01, not "secs" (#1347). (cc @dlebauer this fixes GFDL->BioCro conversion errors)
* Adds basic tests for GFDL download, skipped on Travis for speed
* Download only the observations from the year of current interest (was downloading whole 5-year block and then subsetting)

Please review commits 13e8956 and d544380 extra-critically -- My changes pass all of my tests, but I feel like that `if(year %%5...` chain is a great example of "don't let me delete it until I understand why it was there in the first place"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 