### PR TITLE
use newer geonames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
     - Fixed swapped lat/lon in met2CF.Geostreams
     - download.GFDL now records reference date in time units field, as required by the CF met standard
     - Reduced download.GFDL network load by not preloading dimension data
+    - Fixed spurious `No geonamesUsername set` warning by updating geonames package to development version
 - ED:
     - Change all history parameter files to have zero storage respiration
     

--- a/modules/data.atmosphere/DESCRIPTION
+++ b/modules/data.atmosphere/DESCRIPTION
@@ -58,6 +58,7 @@ Suggests:
     rlang (>= 0.2.0),
     testthat (>= 2.0.0)
 Remotes:
+    github::ropensci/geonames,
     github::ropenscilabs/nneo,
     github::rforge/reddyproc/pkg/REddyProc
 License: FreeBSD + file LICENSE

--- a/modules/data.atmosphere/R/met2CF.Ameriflux.R
+++ b/modules/data.atmosphere/R/met2CF.Ameriflux.R
@@ -74,9 +74,6 @@ getLatLon <- function(nc1) {
 met2CF.Ameriflux <- function(in.path, in.prefix, outfolder, start_date, end_date,
                              overwrite = FALSE, verbose = FALSE, ...) {
 
-  #---------------- Load libraries. -----------------------------------------------------------------#
-  library(geonames)  ## has to be loaded as a library
-  #--------------------------------------------------------------------------------------------------#
 
   # get start/end year code works on whole years only
   start_year <- lubridate::year(start_date)
@@ -129,8 +126,10 @@ met2CF.Ameriflux <- function(in.path, in.prefix, outfolder, start_date, end_date
     if ((tdimtz == "+") || (tdimtz == "-")) {
       lst <- tdimunit[length(tdimunit)]  #already in definition, leave it alone
     } else {
-      options(geonamesUsername = "carya")  #login to geoname server
-      lst <- GNtimezone(latlon[1], latlon[2], radius = 0)$gmtOffset
+      if (is.null(getOption("geonamesUsername"))) {
+        options(geonamesUsername = "carya")  #login to geoname server
+      }
+      lst <- geonames::GNtimezone(latlon[1], latlon[2], radius = 0)$gmtOffset
       if (lst >= 0) {
         lststr <- paste("+", lst, sep = "")
       } else {

--- a/modules/data.atmosphere/R/site.lst.R
+++ b/modules/data.atmosphere/R/site.lst.R
@@ -7,8 +7,6 @@
 ##' @param con
 ##' @author Betsy Cowdery
 site.lst <- function(site.id, con) {
-  library(geonames)
-  
   time.zone <- PEcAn.DB::db.query(paste("SELECT time_zone from SITES where id =", site.id), con)
 
   if (!is.na(time.zone) && !is.na(as.character(time.zone))) {
@@ -16,8 +14,10 @@ site.lst <- function(site.id, con) {
   } else {
     site <- PEcAn.DB::db.query(paste("SELECT ST_X(ST_CENTROID(geometry)) AS lon, ST_Y(ST_CENTROID(geometry)) AS lat",
       "FROM sites WHERE id =", site.id), con)
-    options(geonamesUsername = "carya")
-    lst <- GNtimezone(site$lat, site$lon, radius = 0)$gmtOffset
+    if (is.null(getOption("geonamesUsername"))) {
+      options(geonamesUsername = "carya")
+    }
+    lst <- geonames::GNtimezone(site$lat, site$lon, radius = 0)$gmtOffset
   }
   return(lst)
 } # site.lst


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
* Installs dependency package `geonames` from Github
* Uses `::` instead of `library`
* Does not overwrite `options(geonamesUsername)` in the (unlikely?) case it's already set

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

By default, the current CRAN version of geonames queries `ws.geonames.org`, which is now defunct. This *could* be fixed by setting options(geonamesHostname = "api.geonames.org"), but the github version of geonames has done this for us and has the nice additional benefit of better `.onLoad` behavior, so we can now use GNtimezone without attaching whole package.

When https://github.com/ropensci/geonames/issues/17 is closed, we can bump the geonames version spec and switch back to installing the CRAN version.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 