### PR TITLE
remove aspace package dependency

### DIFF
--- a/modules/data.atmosphere/DESCRIPTION
+++ b/modules/data.atmosphere/DESCRIPTION
@@ -16,7 +16,6 @@ Depends:
     methods
 Imports:
     abind (>= 1.4.5),
-    aspace,
     car,
     data.table,
     dbplyr,

--- a/modules/data.atmosphere/R/met_temporal_downscale.Gaussian_ensemble.R
+++ b/modules/data.atmosphere/R/met_temporal_downscale.Gaussian_ensemble.R
@@ -304,7 +304,7 @@ met_temporal_downscale.Gaussian_ensemble <- function(in.path, in.prefix, outfold
                   by = inter)
       
       Z <- RAtmosphere::SZA(days, lat_train, lon_train)
-      I <- 1000 * aspace::cos_d(Z)
+      I <- 1000 * cos(Z * pi/180) # degrees to radians
       m <- vector()
       for (i in seq_len(12)) {
         m[i] <- lubridate::days_in_month(as.Date(paste0(year, "-", i, "-01")))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Removes a single call to `aspace::cos_d` by calculating degrees-to-radians for ourselves.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
aspace depends on Hmisc, which we don't use anywhere else in data.atmosphere and which depends on approximately everything. Removing it should shorten the dependency chain considerably.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
