### PR TITLE
Shiny app for viewing CF met

### DIFF
--- a/base/visualization/DESCRIPTION
+++ b/base/visualization/DESCRIPTION
@@ -25,6 +25,7 @@ Depends:
     earth,
     XML,
     shiny,
+    shinjs,
     PEcAn.DB,
     RPostgreSQL,
     dplyr,

--- a/base/visualization/DESCRIPTION
+++ b/base/visualization/DESCRIPTION
@@ -25,7 +25,7 @@ Depends:
     earth,
     XML,
     shiny,
-    shinjs,
+    shinyjs,
     PEcAn.DB,
     RPostgreSQL,
     dplyr,

--- a/shiny/ViewMet/server.R
+++ b/shiny/ViewMet/server.R
@@ -1,0 +1,181 @@
+# ViewMet Server 
+
+library(PEcAn.benchmark)
+library(PEcAn.visualization)
+
+options(shiny.maxRequestSize=30*1024^2) #maximum file input size
+
+server <- function(input, output, session) {
+  
+  bety <- betyConnect()
+  rv <- reactiveValues()
+  
+  observe({
+    # Look in the database for all inputs that are in CF format 
+    # and grab their site ids
+    inputs <- tbl(bety, "inputs") %>% filter(format_id == 33) %>% collect 
+    updateSelectizeInput(session, "site.id", choices = sort(unique(inputs$site_id)))
+    
+  })
+  
+  
+  observeEvent({input$site.id}, ignoreInit = TRUE, {
+    
+    site <- input$site.id
+    PEcAn.logger::logger.debug("Site", site, "selected")
+    
+    if(is.na(as.numeric(site))){
+      full.paths <- ""
+    }else{
+      
+      # Given site id, get info about the input 
+      inputs <- tbl(bety, "inputs") %>% filter(format_id == 33) %>% 
+        filter(site_id == site) %>% collect
+      
+      # Check the machine
+      # If the machine is one of the three pecan servers then files that have
+      # dbfile entries for any of the three servers can be loaded 
+      host <- PEcAn.remote::fqdn()
+      if(host %in% c("test-pecan.bu.edu", "pecan1.bu.edu", "pecan2.bu.edu")){
+        host <- c("test-pecan.bu.edu", "pecan1.bu.edu", "pecan2.bu.edu")
+      }
+      machine <- tbl(bety, "machines") %>% filter(hostname %in% host) %>% collect
+      
+      dbfiles <- tbl(bety, "dbfiles") %>%
+        filter(container_type == "Input") %>%
+        filter(container_id %in% inputs$id) %>%
+        filter(machine_id %in% machine$id) %>%
+        collect 
+      
+      if(all(dim(dbfiles) == 0)){
+        full.paths <- ""
+      }else{
+        dbfiles <- dbfiles %>%
+          mutate(file = gsub("//", "/",file.path(file_path, file_name)))
+        
+        types <- unique(dbfiles$file_path) %>% basename() %>%
+          gsub(pattern = "\\_site_.*",replacement = "", x = .) %>%
+          unique() %>% sort()
+        
+        updateCheckboxGroupInput(session, "met", choices = types)
+        
+        paths <- unique(dbfiles$file)
+        full.paths <- c()
+        yrs <- c()
+        for(i in seq_along(paths)){
+          new.files <- dir(dirname(paths[i]), pattern = basename(paths[i]),
+                          full.names = TRUE)
+          yrs <- c(yrs, stringr::str_extract(new.files, pattern="[0-9]{4}"))
+          full.paths <- c(full.paths,new.files)
+        }
+        updateCheckboxGroupInput(session, "years", choices = sort(unique(yrs)))
+      }
+    }
+    rv$full.paths <- full.paths
+    
+  })
+  
+  # Once met and years are selected, the paths to available files on the server 
+  # will show in a tabel
+  observeEvent({
+    input$met 
+    input$years},{
+    
+    met <- input$met
+    years <- input$years
+    
+    full.paths <- rv$full.paths
+
+    load.paths <- c()
+    for(i in seq_along(met)){
+      new.paths <- full.paths[grep(paste0(met[i],"_site_"), full.paths)]
+      year_sub <- stringr::str_extract(new.paths, pattern="[0-9]{4}") %in% years
+      new.paths <- new.paths[year_sub]
+      load.paths <- c(load.paths, new.paths)
+    }
+    rv$load.paths <- load.paths
+  })
+  
+  
+  observeEvent({rv$load.paths},{
+    output$results_table <- DT::renderDataTable(DT::datatable(as.matrix(rv$load.paths)))
+  })
+  
+  # Click the load data to read in the met data
+  load.model.data <- eventReactive(input$load_data, {
+    req(input$met)
+    req(input$years)
+    
+    PEcAn.logger::logger.debug("Loading", input$met)
+    PEcAn.logger::logger.debug("Loading", input$years)
+    
+    data <- list()
+    for(i in seq_along(rv$load.paths)){
+      
+      fpath <- dirname(rv$load.paths[i])
+      inputid <- tbl(bety, "dbfiles") %>% filter(file_path == fpath) %>% 
+        pull(container_id) %>% unique() %>% .[1]
+      formatid <- tbl(bety, "inputs") %>% filter(id == inputid) %>% pull(format_id)
+      siteid <- tbl(bety, "inputs") %>% filter(id == inputid) %>% pull(site_id)
+      
+      site = query.site(con = bety$con, siteid)
+      
+      vars_in_file <- ncdf4::nc_open(rv$load.paths[i]) %>% ncdf4.helpers::nc.get.variable.list()
+      format = query.format.vars(bety, inputid, formatid)
+      format$vars <- format$vars %>% filter(input_name %in% vars_in_file)
+      
+      
+      dat <- try(load_data(data.path = rv$load.paths[i],
+                           format = format, site = site, ))
+      
+      if(class(dat) == "data.frame"){
+        dat$met <- rv$load.paths[i] %>% dirname() %>% basename() %>%
+          gsub(pattern = "\\_site_.*",replacement = "", x = .)
+        data[[i]] <- dat
+      }
+    }
+    data.final <- do.call(plyr::rbind.fill, data)
+    return(data.final)
+  })
+  
+  observeEvent(input$load_data, {
+    data.final <- load.model.data()
+    rv$data.final <- data.final
+    updateSelectizeInput(session, "var", choices = colnames(data.final))
+  })
+  
+  observeEvent({input$var},{
+    PEcAn.logger::logger.debug(input$var)
+    var <- input$var
+    if(input$var != ""){
+      plot.data <- rv$data.final %>% dplyr::select(one_of(c("posix", var, "met")))
+      # print(head(plot.data))
+      colnames(plot.data) <- c("date", "var", "met")
+      rv$plot.data <- plot.data
+    }
+  })
+  
+  observeEvent(input$plot_data,{
+    req(rv$plot.data)
+    req(input$var)
+
+    rv$plot.data$met <- factor(rv$plot.data$met, 
+           levels = sort(unique(rv$plot.data$met), decreasing = TRUE))
+  
+    p_overlay <- ggplot(rv$plot.data) + geom_line(aes(x=date, y=var, color=met)) + 
+      ylab(input$var) + ggtitle(input$var)
+    
+    p_facet <-   ggplot(rv$plot.data) + geom_line(aes(x=date, y=var, color=met), size=1) + 
+      ylab(input$var) + ggtitle(input$var) + 
+      facet_grid(met ~ .)
+    
+    output$plot_overlay <- renderPlot(p_overlay)
+    PEcAn.logger::logger.debug("Overlay plot finished")
+    output$plot_facet <- renderPlot(p_facet)
+    PEcAn.logger::logger.debug("Facet plot finished")
+  
+  })
+
+
+
+}

--- a/shiny/ViewMet/ui.R
+++ b/shiny/ViewMet/ui.R
@@ -1,0 +1,29 @@
+# ViewMet UI 
+
+ui <- fluidPage(sidebarPanel(
+                  h3("Select Files"),
+                  wellPanel(
+                  selectizeInput(inputId = "site.id", "Site ID", c()),
+                    checkboxGroupInput(inputId = "met", label = "Met product", choices = c()),
+                  checkboxGroupInput(inputId = "years", label = "Years", choices = c()),
+                    actionButton(inputId ="load_data", label = "Load Met Data")
+                  ),
+                  h3("Select Plots"),
+                  wellPanel(
+                    selectizeInput(inputId = "var", "Variable", c()),
+                    actionButton(inputId ="plot_data", label = "Plot Met Data")
+                  )
+                ),
+                mainPanel(navbarPage(title = NULL,
+                                     tabPanel("Files to be loaded", 
+                                              DT::dataTableOutput("results_table")
+                                     ),
+                                     tabPanel("Combined Plot", 
+                                              plotOutput("plot_overlay")
+                                     ),
+                                     tabPanel("Facet Plot", 
+                                              plotOutput("plot_facet")
+                                     )
+                )
+                )
+)


### PR DESCRIPTION
## Description

### Shiny App 

I made a quick shiny app for finding and visualizing all met data that is in CF format.  The app has two main features:

Finding files:
- The app searches for all inputs in BETY that are in CF format and pulls their site id's. 
   - A menu with a list of sites is shown. 
- After selecting a site, the app then searches to see if there any met files for the site on your local server.
   - Checkboxes with the met types and which dates available is shown. 
- After clicking on a met type and year, a table with the corresponding file paths will render in the "Files to be loaded" tab. 

Plotting met:
- After selecting met type(s) and year(s) and clicking on the "Load Met Data" button the app runs `load_data` and attempts to read all files in. 
- Once the files are loaded, a menu with available variables for plotting appears. 
   - If you think a variable is missing: check that the [formats record for CF](http://psql-pecan.bu.edu/bety/formats/33/edit) has the variable in question in the related variable list.   
- After selecting variables and clicking on the "Load Met Data" button plots are generated in two different tabs:
   - Combined plot: timeseries plot of the met variable for each met product all in one plot. This can often be hard to read because they are all on top of each other. I tried adjusting the alpha of the lines and it didn't look much better. Suggestions are welcome. 
   - Facet plot: a timeseries plot for of the met variable for each met product in separate plots, aligned by x axis (time).

I haven't written documentation for the app - waiting to see if we want to pull it in and if other people want to make significant changes first. 

### Edits to `load_netcdf`

Trying to load in CF met data, I found that `load_data` couldn't units of the form `time_unit since YYYY-MM-DD HH:MM:SS` with "-hour" timezone offset. 

For example `days since 2000-01-01 -6`

 It could already read `time_unit since YYYY-MM-DD HH:MM:SS` so I just subtracted the timezone offset from the given `YYYY-MM-DD HH:MM:SS`.  

This would change the example to `days since 1999-12-31 18:00:00`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
