### PR TITLE
Met debias: fix year indexing to accommodate missing years

### DIFF
--- a/modules/data.atmosphere/R/debias_met_regression.R
+++ b/modules/data.atmosphere/R/debias_met_regression.R
@@ -159,7 +159,7 @@ debias.met.regression <- function(train.data, source.data, n.ens, vars.debias=NU
       # rain.train <- met.bias[met.bias$dataset==dat.train.orig,]
       rainless <- vector()
       cons.wet <- vector()
-      for(y in min(train.data$time$Year):max(train.data$time$Year)){
+      for(y in unique(train.data$time$Year)){
         for(i in 1:ncol(train.data$precipitation_flux)){
           rain.now <- train.data$precipitation_flux[train.data$time$Year==y, i]
           


### PR DESCRIPTION
Min to max may seem more logical but for datasets where a year is
missing for whatever reason, this will cause the precipitation
redistribution to fail.  Using unique() might be a hair slower, but has
no noticeable impacts on performance.

## Description
Change from indexing from the minimum year to the max year in the training dataset to using unique years.

## Motivation and Context
If using non-consecutive years in the training dataset, an error will occur when trying to determine the precipitation distribution.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [X] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 