### PR TITLE
Bug Fix, Debias routine: Bound rainless day distribution

### DIFF
--- a/modules/data.atmosphere/R/debias_met_regression.R
+++ b/modules/data.atmosphere/R/debias_met_regression.R
@@ -185,6 +185,8 @@ debias.met.regression <- function(train.data, source.data, n.ens, vars.debias=NU
       
       # Hard-coding in some sort of max for precipitaiton
       rain.max <- max(train.data$precipitation_flux) + sd(train.data$precipitation_flux)
+      rainless.min <- ifelse(min(rainless)-sd(rainless)>0, min(rainless)-sd(rainless), max(min(rainless)-sd(rainless)/2, 1))
+      rainless.max <- ifelse(max(rainless)+sd(rainless)<365, max(rainless)+sd(rainless), min(max(rainless)+sd(rainless)/2, 364))
     }
     # -------------
     
@@ -852,7 +854,9 @@ debias.met.regression <- function(train.data, source.data, n.ens, vars.debias=NU
             
             # n.now = number of rainless days for this sim
             n.now <- round(rnorm(1, mean(rainless, na.rm=T), sd(rainless, na.rm=T)), 0) 
-        
+            if(n.now < rainless.min) n.now <- rainless.min # Make sure we don't have negative or no rainless days
+            if(n.now > rainless.max) n.now <- rainless.max # Make sure we have at least one day with rain
+            
             # We're having major seasonality issues, so lets randomly redistribute our precip
             # Pull ~twice what we need and randomly select from that so that we don't have such clean cuttoffs
             # set.seed(12)

--- a/modules/data.atmosphere/R/debias_met_regression.R
+++ b/modules/data.atmosphere/R/debias_met_regression.R
@@ -185,8 +185,8 @@ debias.met.regression <- function(train.data, source.data, n.ens, vars.debias=NU
       
       # Hard-coding in some sort of max for precipitaiton
       rain.max <- max(train.data$precipitation_flux) + sd(train.data$precipitation_flux)
-      rainless.min <- ifelse(min(rainless)-sd(rainless)>0, min(rainless)-sd(rainless), max(min(rainless)-sd(rainless)/2, 1))
-      rainless.max <- ifelse(max(rainless)+sd(rainless)<365, max(rainless)+sd(rainless), min(max(rainless)+sd(rainless)/2, 364))
+      rainless.min <- ifelse(min(rainless)-sd(rainless)>=0, min(rainless)-sd(rainless), max(min(rainless)-sd(rainless)/2, 0))
+      rainless.max <- ifelse(max(rainless)+sd(rainless)<=365, max(rainless)+sd(rainless), min(max(rainless)+sd(rainless)/2, 365))
     }
     # -------------
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Bound the number of rainless days to at least 1 and no more than 364.
At sites with a high standard deviation, you can get random values for
n.now that cause the quantile to be negative or greater than 1 (which
is impossible.)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In sites or datasets with high inter annual variability in the number of rainless days and when processing thousands of years (via ensemble generation), an impossible number of rainless days can be generated.  This causes the quantile function too ind the precip cutoff to fail because it's trying to find a number outside of the 0-1 bound.  

I've added a bound where the minimum number of days is as much as 1 sd less than the minimum observed in the training dataset, allowing for the dataset to drift into novel conditions.  If that produces a negative number, then try 0.5 sd less and if that fails, set the minimum number of rainless days to 1.  A similar logic is used for an upper bound.  These cases should be invoked rarely, but they do happen.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [X] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 