### PR TITLE
Minor update to modules/data.atmosphere/R/met2CF.csv.R

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 ### Removed
 
 ### Changed
+- Minor update to modules/data.atmosphere/R/met2CF.csv.R to include recursive=TRUE for outfolder.  Seemed to work better
 - Updated models/maat/R/model2netcdf.MAAT.R to work with the release version of the MAAT model. Other small MAAT wrapper code cleanup
 - Small change to modules/data.atmosphere/R/download.NARR_site.R to set parallel=TRUE to match documentation and sub-function calls
 

--- a/modules/data.atmosphere/R/met2CF.csv.R
+++ b/modules/data.atmosphere/R/met2CF.csv.R
@@ -52,7 +52,7 @@ met2CF.csv <- function(in.path, in.prefix, outfolder, start_date, end_date, form
   start_year <- lubridate::year(start_date)
   end_year   <- lubridate::year(end_date)
   if (!file.exists(outfolder)) {
-    dir.create(outfolder)
+    dir.create(outfolder, showWarnings = FALSE, recursive = TRUE)
   }
   
   ## set up results output to return


### PR DESCRIPTION

Minor update to modules/data.atmosphere/R/met2CF.csv.R to include recursive=TRUE for outfolder.  Seemed to work better

@ankurdesai are you OK with this?  very minor but seemed to work better on my cluster...perhaps a problem for other machines?