### PR TITLE
Fix the defining of args for db.file.insert in convert.inputs

### DIFF
--- a/base/utils/R/convert.input.R
+++ b/base/utils/R/convert.input.R
@@ -678,8 +678,8 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
       
       if (insert.new.file && id_not_added) {
         dbfile.id <- PEcAn.DB::dbfile.insert(in.path = dirname(result[[1]]$file[1]),
-                                             in.prefix = result$dbfile.name[1], 
-                                             'Input', existing.input$id, 
+                                             in.prefix = result[[1]]$dbfile.name[1], 
+                                             'Input', existing.input[[1]]$id, 
                                              con, reuse=TRUE, hostname = machine$hostname)
         newinput$input.id  <- c(newinput$input.id, existing.input$id)
         newinput$dbfile.id <- c(newinput$dbfile.id, dbfile.id)

--- a/base/utils/R/convert.input.R
+++ b/base/utils/R/convert.input.R
@@ -677,9 +677,9 @@ convert.input <- function(input.id, outfolder, formatname, mimetype, site.id, st
       }
       
       if (insert.new.file && id_not_added) {
-        dbfile.id <- PEcAn.DB::dbfile.insert(in.path = dirname(result[[1]]$file[1]),
-                                             in.prefix = result[[1]]$dbfile.name[1], 
-                                             'Input', existing.input[[1]]$id, 
+        dbfile.id <- PEcAn.DB::dbfile.insert(in.path = dirname(result[[i]]$file[1]),
+                                             in.prefix = result[[i]]$dbfile.name[1], 
+                                             'Input', existing.input[[i]]$id, 
                                              con, reuse=TRUE, hostname = machine$hostname)
         newinput$input.id  <- c(newinput$input.id, existing.input$id)
         newinput$dbfile.id <- c(newinput$dbfile.id, dbfile.id)


### PR DESCRIPTION
## Description
Was getting an error:
```
Error in basename(in.prefix) : a character vector argument expected
```
And found that in convert.inputs, when trying to insert the result into the database, it wasn't handling the result object correctly to define `in.prefix`. The id `existing.input` arg wasn't being defined properly as well
## Motivation and Context
This comes from testing the VM

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
