### PR TITLE
use tempdir for settings tests, clean up afterward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 ## [Unreleased]
 
 ### Fixes
+- Running tests for PEcAn.settings package no longer leaves empty temp directories in test folder (#2075)
 - Fixed issue #2064 which sends one met path to write.sa.config.
 - `PEcAn.data.land::soil_params` now accepts any 2 out of 3 texture components as documented, and correctly converts percentages to proportion (#2043).
 

--- a/base/settings/DESCRIPTION
+++ b/base/settings/DESCRIPTION
@@ -21,6 +21,6 @@ Imports:
     lubridate (>= 1.6.0),
     XML (>= 3.98-1.3)
 Suggests:
-    testthat (>= 1.0.2)
+    testthat (>= 2.0.0)
 Encoding: UTF-8
 RoxygenNote: 6.1.0

--- a/base/settings/tests/testthat/helper-get.test.settings.R
+++ b/base/settings/tests/testthat/helper-get.test.settings.R
@@ -1,4 +1,4 @@
-.get.test.settings = function() {
+.get.test.settings = function(outdir=NULL) {
   settings <- NULL
   try({
     if(PEcAn.remote::fqdn() == "pecan2.bu.edu") {
@@ -11,6 +11,9 @@
   
   if(is.null(settings)) {
     skip("Can't get a valid test Settings right now. Skipping test. ")
+  }
+  if(!is.null(outdir)){
+    settings$outdir <- outdir
   }
   return(settings)
 }

--- a/base/settings/tests/testthat/test.deprecated.settings.R
+++ b/base/settings/tests/testthat/test.deprecated.settings.R
@@ -11,8 +11,6 @@ PEcAn.logger::logger.setQuitOnSevere(FALSE)
 PEcAn.logger::logger.setLevel("OFF")
 context("fix.deprecated.settings")
 
-source('get.test.settings.R')
-
 test_that("deprecated jobtemplate settings handled correctly", {
   settings <- .get.test.settings()
   settings$run$jobtemplate = "somefile"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Settings package tests were writing to the test directory and not cleaning up properly, which was (1) annoying, and (2) caused Make to always see the modules/settings folder as having been updated, so the settings tests would rerun every time `make test` was called. 

Fixed by setting up a tempdir, consistently passing that as the outdir for all settings, and making sure to unlink the directory at the end of the test.

Tagging @robkooper because you're paired with me for review this week and probably know the settings code best as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [x] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
