### PR TITLE
Add page scaling to documentation

### DIFF
--- a/book_source/index.Rmd
+++ b/book_source/index.Rmd
@@ -12,8 +12,9 @@ link-citations: yes
 **Ecosystem science, policy, and management informed by the best available data and models**
 
 ```{r, echo=FALSE,out.height= "90%", out.width="90%"}
-  knitr::include_graphics(rep("figures/PecanLogo.png"))
+knitr::include_graphics(rep("figures/PecanLogo.png"))
 ```
+
 
 **Our Mission:**
 
@@ -28,3 +29,11 @@ link-citations: yes
 
 [Github Repository](https://github.com/PecanProject/pecan)
 
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.page-inner{max-width:80% !important;}
+</style>
+</head>
+</html> 


### PR DESCRIPTION
## Description
Makes page scale to 80% of the viewing window.

## Motivation and Context
When you made the window smaller, it would hide text so you would have to scroll to see everything. This makes documentation scale to the window. 

@bcow you're my reviewer this week.
## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [x] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
