### PR TITLE
Update Bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -4,27 +4,35 @@ about: Create a report to help us improve
 
 ---
 
-**Describe the bug**
+### Bug Description
+
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+In the format "When I do X, I expect Y but observe Z"
+
+### To Reproduce
+
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+## Expected behavior
+
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+## Screenshots
+
 If applicable, add screenshots to help explain your problem.
 
-**Machine (please complete the following information):**
+## Machine (please complete the following information):
+
  - Server [e.g. BU, NCSA, VM, etc.]
  - OS: [e.g.Linux]
  - Browser(if applicable) [e.g. chrome, safari]
  - Version [e.g. 22]
 
-**Additional context**
+## Additional context
+
 Add any other context about the problem here.


### PR DESCRIPTION
* use sub-section headings instead of bold for sections. This is because if I also use bold in the text (or see bold for `@mentions` etc it is hard to visually differentiate
