### PR TITLE
DOCKER: Make web post RabbitMQ messages even after edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 ## Unreleased
 
 ### Fixes
-- Fixed error in read_web_config which would filter out all variables.
+- Fixed error in `read_web_config` which would filter out all variables.
+- Docker:
+  - Make sure web interface posts RabbitMQ messages even after editing files (fixes #2151)
 
 ### Added
 - Lots of new documentation for running PEcAn using Docker
@@ -18,6 +20,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 ### Changed
 - Docker:
   - Change base image for R code from `r-base` to `rocker/tidyverse:3.5.1`. This (1) saves build time (because many R packages and system dependencies are pre-installed), and (2) enhances reproducibility (because of the strict versioning rules of the `rocker` packages)
+  - Re-factor web interface RabbitMQ create connections and post messages into their own PHP functions.
 
 ## [1.6.0] - 2018-09-01
 

--- a/book_source/06_reference/09_rabbitmq.Rmd
+++ b/book_source/06_reference/09_rabbitmq.Rmd
@@ -52,11 +52,20 @@ See corresponding argument in the [producer](#rabbitmq-basics-sender)
 
 - `RABBITMQ_QUEUE` -- This is the name of the queue on which the consumer will listen for messages, just as in the [producer](#rabbitmq-basics-sender).
 
-- `APPLICATION` -- This specifies the name (including the path) of the executable to run when receiving a message.
-At the moment, it should be an executable that runs in the directory specified by the message's `folder` variable.
-In the case of PEcAn models, this is usually `./job.sh`, such that the `folder` corresponds to the `run` directory associated with a particular `runID` (i.e. where the `job.sh` is located).
-For the PEcAn workflow itself, this is set to `R CMD BATCH workflow.R`, such that the `folder` is the root directory of the workflow (in the `executor` Docker container, something like `/data/workflows/PEcAn_<workflowID>`).
+- `APPLICATION` -- This specifies the name (including the path) of the default executable to run when receiving a message.
+  At the moment, it should be an executable that runs in the directory specified by the message's `folder` variable.
+  In the case of PEcAn models, this is usually `./job.sh`, such that the `folder` corresponds to the `run` directory associated with a particular `runID` (i.e. where the `job.sh` is located).
+  For the PEcAn workflow itself, this is set to `R CMD BATCH workflow.R`, such that the `folder` is the root directory of the workflow (in the `executor` Docker container, something like `/data/workflows/PEcAn_<workflowID>`).
+  This default executable is _overridden_ if the message contains a `custom_application` key.
+  If included, the string specified by the `custom_application` key will be run as a command exactly as is on the container, from the directory specified by `folder`.
+  For instance, in the example below, the container will print "Hello there!" instead of running its default application.
 
+   ```json
+   {"custom_application": "echo 'Hello there!'", "folder": "/path/to/my/dir"}
+   ```
+   
+   NOTE that in RabbitMQ messages, the `folder` key is always required.
+   
 ## RabbitMQ and the PEcAn web interface {#rabbitmq-web}
 
 RabbitMQ is configured by the following variables in `config.php`:

--- a/web/04-runpecan.php
+++ b/web/04-runpecan.php
@@ -518,31 +518,9 @@ if ($pecan_edit) {
   header("Location: ${path}");
 } else if ($rabbitmq_host != "") {
 
-  # create connection and queue
-  $connection = new AMQPConnection();
-  $connection->setHost($rabbitmq_host);
-  $connection->setPort($rabbitmq_port);
-  $connection->setVhost($rabbitmq_vhost);
-  $connection->setLogin($rabbitmq_username);
-  $connection->setPassword($rabbitmq_password);
-  $connection->connect();
-  $channel = new AMQPChannel($connection);
-  $exchange = new AMQPExchange($channel);
-
-  # create the queue
-  $queue = new AMQPQueue($channel);
-  $queue->setName($rabbitmq_queue);
-  $queue->setFlags(AMQP_DURABLE);
-  $queue->declareQueue();
-
   # create the message
   $message = '{"folder": "' . $folder . '", "workflowid": "' . $workflowid . '"}';
-
-  # send the message
-  $exchange->publish($message, $rabbitmq_queue);
-
-  # cleanup
-  $connection->disconnect();
+  send_rabbitmq_message($message, $rabbitmq_queue);
 
   #done
   $path = "05-running.php?workflowid=$workflowid";

--- a/web/07-continue.php
+++ b/web/07-continue.php
@@ -73,10 +73,15 @@ if (file_exists($folder . DIRECTORY_SEPARATOR . "STATUS")) {
 }
 
 # start the workflow again
-chdir($folder);
-pclose(popen("$exec &", 'r'));
+if ($rabbitmq_host != "") {
+  $msg_exec = str_replace("\"", "'", $exec);
+  $message = '{"folder": "' . $folder . '", "custom_application": "' . $msg_exec . '"}';
+  send_rabbitmq_message($message, $rabbitmq_queue);
+} else {
+  chdir($folder);
+  pclose(popen("$exec &", 'r'));
+}
 
 #done
 header("Location: $path");
 ?>
-

--- a/web/common.php
+++ b/web/common.php
@@ -179,4 +179,32 @@ function get_page_acccess_level() {
   }
 }
 
+# Create a new RabbitMQ connection
+# Global variables are set in config.php
+function make_rabbitmq_connection() {
+  global $rabbitmq_host;
+  global $rabbitmq_port;
+  global $rabbitmq_vhost;
+  global $rabbitmq_username;
+  global $rabbitmq_password;
+  $connection = new AMQPConnection();
+  $connection->setHost($rabbitmq_host);
+  $connection->setPort($rabbitmq_port);
+  $connection->setVhost($rabbitmq_vhost);
+  $connection->setLogin($rabbitmq_username);
+  $connection->setPassword($rabbitmq_password);
+  $connection->connect();
+  return $connection;
+}
+
+# Post $message (string) to RabbitMQ queue $rabbitmq_queue (string)
+function send_rabbitmq_message($message, $rabbitmq_queue) {
+  $connection = make_rabbitmq_connection();
+  $channel = new AMQPChannel($connection);
+  $exchange = new AMQPExchange($channel);
+
+  $exchange->publish($message, $rabbitmq_queue);
+  $connection->disconnect();
+}
+
 ?>


### PR DESCRIPTION
Also, refactor RabbitMQ functionality in web interface into its own functions.

Also, allow `docker/receiver.py` to receive custom applications via `custom_application` message.

This PR fixes #2151.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [X] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the CHANGELOG.md.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
