### PR TITLE
Check against CRUNCEP land-sea mask during `download.CRUNCEP`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 ### Added
 - Lots of new documentation for running PEcAn using Docker
 - Download method (`method`) argument for `data.atmosphere::download.CRUNCEP`, which defaults to `opendap` (as it was), but can be switched to the slower but more robust NetCDF subset (`ncss`).
+- In `download.CRUNCEP`, check target coordinate against the land-sea mask. If sea, pick the nearest land pixel within 1 degree of target. This facilitates doing runs at coastal sites that may get masked out.
 
 ### Removed
 

--- a/modules/data.atmosphere/R/download.CRUNCEP_Global.R
+++ b/modules/data.atmosphere/R/download.CRUNCEP_Global.R
@@ -50,6 +50,62 @@ download.CRUNCEP <- function(outfolder, start_date, end_date, site_id, lat.in, l
   lat.in <- as.numeric(lat.in)
   lon.in <- as.numeric(lon.in)
 
+  # Convert lat-lon to grid row and column
+  lat_grid <- floor(2 * (90 - lat.in)) + 1
+  lon_grid <- floor(2 * (lon.in + 180)) + 1
+
+  # Check against land-sea mask
+  maskfile <- file.path(outfolder, "cruncep_landwater_mask.nc")
+  mask_url <- paste0(
+    "https://thredds.daac.ornl.gov/thredds/ncss/ornldaac/1220/",
+    "mstmip_driver_global_hd_landwatermask_v1.nc4",
+    "?var=land_water_mask&disableLLSubset=on&disableProjSubset=on&horizStride=1&",
+    "accept=netcdf"
+  )
+  download.file(mask_url, maskfile)
+
+  mask_nc <- ncdf4::nc_open(maskfile)
+  on.exit(ncdf4::nc_close(mask_nc))
+
+  # Set search radius to up to 2 pixels (1 degree) in any direction
+  mask_minlat <- lat_grid - 2
+  mask_minlon <- lon_grid - 2
+  mask_lats <- ncdf4::ncvar_get(mask_nc, "lat", start = mask_minlat, count = 5)
+  mask_lons <- ncdf4::ncvar_get(mask_nc, "lon", start = mask_minlon, count = 5)
+  mask_values <- ncdf4::ncvar_get(
+    mask_nc,
+    "land_water_mask",
+    start = c(mask_minlon, mask_minlat),
+    count = c(5, 5)
+  )
+
+  # Build a lat-lon grid matrix and calculate distance from target coords
+  mask_grid <- as.matrix(expand.grid(lon = mask_lons, lat = mask_lats))
+  mask_igrid <- as.matrix(expand.grid(lon = seq_along(mask_lons), lats = seq_along(mask_lats)))
+  mask_dist <- (lon.in - mask_grid[, 1])^2 + (lat.in - mask_grid[, 2])^2
+  # Order by increasing distance (closest first)
+  mask_order <- order(mask_dist)
+  mask_igrido <- mask_igrid[mask_order,]
+  on_land <- as.logical(mask_values[mask_igrido])
+  if (!any(on_land)) {
+    PEcAn.logger::logger.severe(glue::glue(
+      "Coordinates {lat.in} latitude, {lon.in} longitude ",
+      "are not within 2 pixels (1 degree) of any land."
+    ))
+  }
+  igrid <- which(on_land)[1]
+  if (igrid > 1) {
+    lon.in.orig <- lon.in
+    lat.in.orig <- lat.in
+    lon.in <- mask_grid[mask_order[igrid], 1]
+    lat.in <- mask_grid[mask_order[igrid], 2]
+    PEcAn.logger::logger.warn(glue::glue(
+      "Coordinates {lat.in.orig} latitude, {lon.in.orig} longitude ",
+      "are not on land, so using closest land pixel within 1 degree. ",
+      "New coordinates are {lat.in} latitude, {lon.in} longitude."
+    ))
+  }
+
   if (method == "opendap") {
     # Convert lat-lon to grid row and column
     lat_grid <- floor(2 * (90 - lat.in)) + 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Downloads the CRUNCEP 0.5 degree land-water mask (small file, ~250 KB) and checks if the specified site coordinate falls on land. If yes, proceed as usual. If not, look for land 1 degree in every direction, and if any pixels are land, use data for those coordinates instead. If no land within 1 degree of coordinates, throw an informative error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses issue #1265 for CRUNCEP specifically. The same issue may appear for other met products, in which case this should be generalized, but this fix should work for now.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [X] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
