### PR TITLE
Change args for install_deps in Make file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,7 @@ script:
   # TODO: Would probably be faster to use -j2 NCPUS=1 as for other steps,
   # but many dependency compilations seem not parallel-safe.
   # More debugging needed.
-  - Rscript -e "devtools::install('base/utils', Ncpus = 2,dependencies = FALSE)"
+  - Rscript -e 'devtools::install('base/utils', Ncpus = 2, dependencies = c("Depends", "Imports"))'
   - NCPUS=2 make -j1
   - echo 'Testing PEcAn packages'
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,13 @@ script:
   # TODO: Would probably be faster to use -j2 NCPUS=1 as for other steps,
   # but many dependency compilations seem not parallel-safe.
   # More debugging needed.
-  - R CMD INSTALL ./base/utils
+  # TEMPORARY HACK: preinstall PEcAn.utils to avoid dependency cyles.
+  # remove when utils no longer depends on any PEcAn packages other than logger
+  - Rscript -e 'devtools::document("base/utils")'
+  - echo `date` > .doc/base/utils
+  - Rscript -e 'devtools::install("base/utils", Ncpus = 2, dependencies = c("Depends", "Imports"))'
+  - echo `date` > .install/base.utils
+  ## End HACK
   - NCPUS=2 make -j1
   - echo 'Testing PEcAn packages'
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,10 +125,10 @@ script:
   # More debugging needed.
   # TEMPORARY HACK: preinstall PEcAn.utils to avoid dependency cyles.
   # remove when utils no longer depends on any PEcAn packages other than logger
-  - Rscript -e 'devtools::document("base/utils",Ncpus = 2, dependencies = c("Depends", "Imports"))'
-  - echo `date` > .doc/base/utils
   - Rscript -e 'devtools::install("base/utils", Ncpus = 2, dependencies = c("Depends", "Imports"))'
   - echo `date` > .install/base.utils
+  - Rscript -e 'devtools::document("base/utils")'
+  - echo `date` > .doc/base/utils
   ## End HACK
   - NCPUS=2 make -j1
   - echo 'Testing PEcAn packages'

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ script:
   # More debugging needed.
   # TEMPORARY HACK: preinstall PEcAn.utils to avoid dependency cyles.
   # remove when utils no longer depends on any PEcAn packages other than logger
-  - Rscript -e 'devtools::document("base/utils")'
+  - Rscript -e 'devtools::document("base/utils",Ncpus = 2, dependencies = c("Depends", "Imports"))'
   - echo `date` > .doc/base/utils
   - Rscript -e 'devtools::install("base/utils", Ncpus = 2, dependencies = c("Depends", "Imports"))'
   - echo `date` > .install/base.utils

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,6 +125,10 @@ script:
   # More debugging needed.
   # TEMPORARY HACK: preinstall PEcAn.utils to avoid dependency cyles.
   # remove when utils no longer depends on any PEcAn packages other than logger
+  - Rscript -e 'devtools::install("base/logger", Ncpus = 2, dependencies = c("Depends", "Imports"))'
+  - echo `date` > .install/base.utils
+  - Rscript -e 'devtools::install("base/remote", Ncpus = 2, dependencies = c("Depends", "Imports"))'
+  - echo `date` > .install/base.utils
   - Rscript -e 'devtools::install("base/utils", Ncpus = 2, dependencies = c("Depends", "Imports"))'
   - echo `date` > .install/base.utils
   - Rscript -e 'devtools::document("base/utils")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,7 @@ script:
   # TODO: Would probably be faster to use -j2 NCPUS=1 as for other steps,
   # but many dependency compilations seem not parallel-safe.
   # More debugging needed.
-  - RCMD INSTALL ./base/utils
+  - R CMD INSTALL ./base/utils
   - NCPUS=2 make -j1
   - echo 'Testing PEcAn packages'
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,7 @@ script:
   # TODO: Would probably be faster to use -j2 NCPUS=1 as for other steps,
   # but many dependency compilations seem not parallel-safe.
   # More debugging needed.
+  - Rscript -e "devtools::install('base/utils', Ncpus = 2,dependencies = FALSE)"
   - NCPUS=2 make -j1
   - echo 'Testing PEcAn packages'
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,7 @@ script:
   # TODO: Would probably be faster to use -j2 NCPUS=1 as for other steps,
   # but many dependency compilations seem not parallel-safe.
   # More debugging needed.
-  - Rscript -e 'devtools::install('base/utils', Ncpus = 2, dependencies = c("Depends", "Imports"))'
+  - RCMD INSTALL ./base/utils
   - NCPUS=2 make -j1
   - echo 'Testing PEcAn packages'
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,8 +131,6 @@ script:
   - echo `date` > .install/base.utils
   - Rscript -e 'devtools::install("base/utils", Ncpus = 2, dependencies = c("Depends", "Imports"))'
   - echo `date` > .install/base.utils
-  - Rscript -e 'devtools::document("base/utils")'
-  - echo `date` > .doc/base/utils
   ## End HACK
   - NCPUS=2 make -j1
   - echo 'Testing PEcAn packages'

--- a/Makefile
+++ b/Makefile
@@ -117,10 +117,6 @@ clean:
 	+ time Rscript -e "if(!requireNamespace('devtools', quietly = TRUE)) install.packages('devtools', repos = 'http://cran.rstudio.com', Ncpus = ${NCPUS})"
 	echo `date` > $@
 
-.install/remotes: | .install
-	+ time Rscript -e "if(!requireNamespace('remotes', quietly = TRUE)) install.packages('remotes', repos = 'http://cran.rstudio.com', Ncpus = ${NCPUS})"
-	echo `date` > $@
-
 .install/roxygen2: | .install
 	+ time Rscript -e "if(!requireNamespace('roxygen2', quietly = TRUE)) install.packages('roxygen2', repos = 'http://cran.rstudio.com', Ncpus = ${NCPUS})"
 	echo `date` > $@
@@ -133,13 +129,13 @@ clean:
 	+ time Rscript -e "if(!requireNamespace('mockery', quietly = TRUE)) install.packages('mockery', repos = 'http://cran.rstudio.com', Ncpus = ${NCPUS})"
 	echo `date` > $@
 
-depends_R_pkg = time Rscript -e "remotes::install_deps('$(strip $(1))', Ncpus = ${NCPUS}, dependencies = TRUE, upgrade = TRUE);"
+depends_R_pkg = time Rscript -e "devtools::install_deps('$(strip $(1))', Ncpus = ${NCPUS}, dependencies = TRUE);"
 install_R_pkg = time Rscript -e "devtools::install('$(strip $(1))', Ncpus = ${NCPUS});"
 check_R_pkg = Rscript scripts/check_with_errors.R $(strip $(1))
 test_R_pkg = Rscript -e "devtools::test('"$(strip $(1))"', stop_on_failure = TRUE, stop_on_warning = FALSE)" # TODO: Raise bar to stop_on_warning = TRUE when we can
 doc_R_pkg = Rscript -e "devtools::document('"$(strip $(1))"')"
 
-$(ALL_PKGS_I) $(ALL_PKGS_C) $(ALL_PKGS_T) $(ALL_PKGS_D): | .install/devtools .install/remotes .install/roxygen2 .install/testthat
+$(ALL_PKGS_I) $(ALL_PKGS_C) $(ALL_PKGS_T) $(ALL_PKGS_D): | .install/devtools .install/roxygen2 .install/testthat
 
 .SECONDEXPANSION:
 .doc/%: $$(wildcard %/**/*) $$(wildcard %/*) | $$(@D)

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ clean:
 	+ time Rscript -e "if(!requireNamespace('mockery', quietly = TRUE)) install.packages('mockery', repos = 'http://cran.rstudio.com', Ncpus = ${NCPUS})"
 	echo `date` > $@
 
-depends_R_pkg = time Rscript -e "remotes::install_deps('$(strip $(1))', Ncpus = ${NCPUS}, dependencies = TRUE, upgrade = FALSE);"
+depends_R_pkg = time Rscript -e "remotes::install_deps('$(strip $(1))', Ncpus = ${NCPUS}, dependencies = TRUE, upgrade = TRUE);"
 install_R_pkg = time Rscript -e "devtools::install('$(strip $(1))', Ncpus = ${NCPUS});"
 check_R_pkg = Rscript scripts/check_with_errors.R $(strip $(1))
 test_R_pkg = Rscript -e "devtools::test('"$(strip $(1))"', stop_on_failure = TRUE, stop_on_warning = FALSE)" # TODO: Raise bar to stop_on_warning = TRUE when we can

--- a/Makefile
+++ b/Makefile
@@ -73,40 +73,39 @@ $(subst .doc/models/template,,$(MODELS_D)): .install/models/template
 $(subst .install/base/logger,,$(ALL_PKGS_I)): | .install/base/logger
 $(subst .doc/base/logger,,$(ALL_PKGS_D)): | .install/base/logger
 
-$(call depends,base/db): | .install/base/utils
-$(call depends,base/qaqc): | .install/base/utils
-$(call depends,base/settings): | .install/base/utils .install/base/db
+$(call depends,base/qaqc): | 
+$(call depends,base/settings): | .install/base/db
 $(call depends,base/visualization): | .install/base/db
 $(call depends,base/workflow): | .install/base/db .install/base/settings
 $(call depends,modules/allometry): | .install/base/db
-$(call depends,modules/assim.batch): | .install/base/utils .install/base/db .install/base/settings .install/base/remote .install/modules/meta.analysis
+$(call depends,modules/assim.batch): | .install/base/db .install/base/settings .install/base/remote .install/modules/meta.analysis
 $(call depends,modules/assim.sequential): | .install/base/remote
-$(call depends,modules/benchmark): | .install/base/db .install/base/remote .install/base/settings .install/base/utils .install/modules/data.land
-$(call depends,modules/data.atmosphere): | .install/base/utils .install/base/remote .install/base/db
-$(call depends,modules/data.hydrology): | .install/base/utils
-$(call depends,modules/data.land): | .install/base/db .install/base/utils .install/base/settings .install/base/remote
-$(call depends,modules/data.mining): | .install/base/utils
+$(call depends,modules/benchmark): | .install/base/db .install/base/remote .install/base/settings .install/modules/data.land
+$(call depends,modules/data.atmosphere): |  .install/base/remote .install/base/db
+$(call depends,modules/data.hydrology): | 
+$(call depends,modules/data.land): | .install/base/db  .install/base/settings .install/base/remote
+$(call depends,modules/data.mining): | 
 $(call depends,modules/data.remote): | .install/base/remote
-$(call depends,modules/meta.analysis): | .install/base/utils .install/base/db .install/base/settings .install/modules/priors
-$(call depends,modules/priors): | .install/base/utils
-$(call depends,modules/rtm): | .install/modules/assim.batch .install/base/utils .install/models/ed
-$(call depends,modules/uncertainty): | .install/base/utils .install/base/db .install/modules/priors .install/modules/emulator
-$(call depends,models/biocro): | .install/mockery .install/base/utils .install/base/settings .install/base/db .install/modules/data.atmosphere .install/modules/data.land .install/base/remote
-$(call depends,models/cable): | .install/base/utils
-$(call depends,models/clm45): | .install/base/utils
+$(call depends,modules/meta.analysis): |  .install/base/db .install/base/settings .install/modules/priors
+$(call depends,modules/priors): | 
+$(call depends,modules/rtm): | .install/modules/assim.batch  .install/models/ed
+$(call depends,modules/uncertainty): |  .install/base/db .install/modules/priors .install/modules/emulator
+$(call depends,models/biocro): | .install/mockery  .install/base/settings .install/base/db .install/modules/data.atmosphere .install/modules/data.land .install/base/remote
+$(call depends,models/cable): | 
+$(call depends,models/clm45): | 
 $(call depends,models/dalec): | .install/base/remote
-$(call depends,models/dvmdostem): | .install/base/utils
-$(call depends,models/ed): | .install/base/utils .install/base/remote .install/base/settings
-$(call depends,models/fates): | .install/base/utils .install/base/remote
-$(call depends,models/gday): | .install/base/utils .install/base/remote
-$(call depends,models/jules): | .install/base/utils .install/base/remote
-$(call depends,models/linkages): | .install/base/utils .install/base/remote
-$(call depends,models/lpjguess): | .install/base/utils .install/base/remote
-$(call depends,models/maat): | .install/base/utils .install/base/remote .install/base/settings
-$(call depends,models/maespa): | .install/base/utils .install/base/remote .install/modules/data.atmosphere
-$(call depends,models/preles): | .install/base/utils .install/modules/data.atmosphere
-$(call depends,models/sipnet): | .install/base/utils .install/base/remote .install/modules/data.atmosphere
-$(call depends,models/template): | .install/base/utils
+$(call depends,models/dvmdostem): | 
+$(call depends,models/ed): |  .install/base/remote .install/base/settings
+$(call depends,models/fates): |  .install/base/remote
+$(call depends,models/gday): |  .install/base/remote
+$(call depends,models/jules): |  .install/base/remote
+$(call depends,models/linkages): |  .install/base/remote
+$(call depends,models/lpjguess): |  .install/base/remote
+$(call depends,models/maat): |  .install/base/remote .install/base/settings
+$(call depends,models/maespa): |  .install/base/remote .install/modules/data.atmosphere
+$(call depends,models/preles): |  .install/modules/data.atmosphere
+$(call depends,models/sipnet): |  .install/base/remote .install/modules/data.atmosphere
+$(call depends,models/template): | 
 
 clean:
 	rm -rf .install .check .test .doc

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,10 @@ clean:
 	+ time Rscript -e "if(!requireNamespace('devtools', quietly = TRUE)) install.packages('devtools', repos = 'http://cran.rstudio.com', Ncpus = ${NCPUS})"
 	echo `date` > $@
 
+.install/remotes: | .install
+	+ time Rscript -e "if(!requireNamespace('remotes', quietly = TRUE)) install.packages('remotes', repos = 'http://cran.rstudio.com', Ncpus = ${NCPUS})"
+	echo `date` > $@
+
 .install/roxygen2: | .install
 	+ time Rscript -e "if(!requireNamespace('roxygen2', quietly = TRUE)) install.packages('roxygen2', repos = 'http://cran.rstudio.com', Ncpus = ${NCPUS})"
 	echo `date` > $@
@@ -129,13 +133,13 @@ clean:
 	+ time Rscript -e "if(!requireNamespace('mockery', quietly = TRUE)) install.packages('mockery', repos = 'http://cran.rstudio.com', Ncpus = ${NCPUS})"
 	echo `date` > $@
 
-depends_R_pkg = time Rscript -e "devtools::install_deps('$(strip $(1))', Ncpus = ${NCPUS}, dependencies = TRUE);"
+depends_R_pkg = time Rscript -e "remotes::install_deps('$(strip $(1))', Ncpus = ${NCPUS}, dependencies = TRUE);"
 install_R_pkg = time Rscript -e "devtools::install('$(strip $(1))', Ncpus = ${NCPUS});"
 check_R_pkg = Rscript scripts/check_with_errors.R $(strip $(1))
 test_R_pkg = Rscript -e "devtools::test('"$(strip $(1))"', stop_on_failure = TRUE, stop_on_warning = FALSE)" # TODO: Raise bar to stop_on_warning = TRUE when we can
 doc_R_pkg = Rscript -e "devtools::document('"$(strip $(1))"')"
 
-$(ALL_PKGS_I) $(ALL_PKGS_C) $(ALL_PKGS_T) $(ALL_PKGS_D): | .install/devtools .install/roxygen2 .install/testthat
+$(ALL_PKGS_I) $(ALL_PKGS_C) $(ALL_PKGS_T) $(ALL_PKGS_D): | .install/devtools .install/remotes .install/roxygen2 .install/testthat
 
 .SECONDEXPANSION:
 .doc/%: $$(wildcard %/**/*) $$(wildcard %/*) | $$(@D)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NCPUS ?= 1
 
-BASE := logger utils db settings visualization qaqc remote workflow
+BASE := logger db settings visualization qaqc remote workflow
 
 MODELS := biocro clm45 dalec ed fates gday jules linkages \
 				lpjguess maat maespa preles sipnet dvmdostem template
@@ -73,7 +73,6 @@ $(subst .doc/models/template,,$(MODELS_D)): .install/models/template
 $(subst .install/base/logger,,$(ALL_PKGS_I)): | .install/base/logger
 $(subst .doc/base/logger,,$(ALL_PKGS_D)): | .install/base/logger
 
-$(call depends,base/utils): | .install/base/remote
 $(call depends,base/db): | .install/base/utils
 $(call depends,base/qaqc): | .install/base/utils
 $(call depends,base/settings): | .install/base/utils .install/base/db

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ clean:
 	+ time Rscript -e "if(!requireNamespace('mockery', quietly = TRUE)) install.packages('mockery', repos = 'http://cran.rstudio.com', Ncpus = ${NCPUS})"
 	echo `date` > $@
 
-depends_R_pkg = time Rscript -e "remotes::install_deps('$(strip $(1))', Ncpus = ${NCPUS}, dependencies = TRUE);"
+depends_R_pkg = time Rscript -e "remotes::install_deps('$(strip $(1))', Ncpus = ${NCPUS}, dependencies = TRUE, upgrade = FALSE);"
 install_R_pkg = time Rscript -e "devtools::install('$(strip $(1))', Ncpus = ${NCPUS});"
 check_R_pkg = Rscript scripts/check_with_errors.R $(strip $(1))
 test_R_pkg = Rscript -e "devtools::test('"$(strip $(1))"', stop_on_failure = TRUE, stop_on_warning = FALSE)" # TODO: Raise bar to stop_on_warning = TRUE when we can

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NCPUS ?= 1
 
-BASE := logger db settings visualization qaqc remote workflow
+BASE := logger utils db settings visualization qaqc remote workflow
 
 MODELS := biocro clm45 dalec ed fates gday jules linkages \
 				lpjguess maat maespa preles sipnet dvmdostem template
@@ -73,39 +73,41 @@ $(subst .doc/models/template,,$(MODELS_D)): .install/models/template
 $(subst .install/base/logger,,$(ALL_PKGS_I)): | .install/base/logger
 $(subst .doc/base/logger,,$(ALL_PKGS_D)): | .install/base/logger
 
-$(call depends,base/qaqc): | 
-$(call depends,base/settings): | .install/base/db
+$(call depends,base/utils): | .install/base/remote
+$(call depends,base/db): | .install/base/utils
+$(call depends,base/qaqc): | .install/base/utils
+$(call depends,base/settings): | .install/base/utils .install/base/db
 $(call depends,base/visualization): | .install/base/db
 $(call depends,base/workflow): | .install/base/db .install/base/settings
 $(call depends,modules/allometry): | .install/base/db
-$(call depends,modules/assim.batch): | .install/base/db .install/base/settings .install/base/remote .install/modules/meta.analysis
+$(call depends,modules/assim.batch): | .install/base/utils .install/base/db .install/base/settings .install/base/remote .install/modules/meta.analysis
 $(call depends,modules/assim.sequential): | .install/base/remote
-$(call depends,modules/benchmark): | .install/base/db .install/base/remote .install/base/settings .install/modules/data.land
-$(call depends,modules/data.atmosphere): |  .install/base/remote .install/base/db
-$(call depends,modules/data.hydrology): | 
-$(call depends,modules/data.land): | .install/base/db  .install/base/settings .install/base/remote
-$(call depends,modules/data.mining): | 
+$(call depends,modules/benchmark): | .install/base/db .install/base/remote .install/base/settings .install/base/utils .install/modules/data.land
+$(call depends,modules/data.atmosphere): | .install/base/utils .install/base/remote .install/base/db
+$(call depends,modules/data.hydrology): | .install/base/utils
+$(call depends,modules/data.land): | .install/base/db .install/base/utils .install/base/settings .install/base/remote
+$(call depends,modules/data.mining): | .install/base/utils
 $(call depends,modules/data.remote): | .install/base/remote
-$(call depends,modules/meta.analysis): |  .install/base/db .install/base/settings .install/modules/priors
-$(call depends,modules/priors): | 
-$(call depends,modules/rtm): | .install/modules/assim.batch  .install/models/ed
-$(call depends,modules/uncertainty): |  .install/base/db .install/modules/priors .install/modules/emulator
-$(call depends,models/biocro): | .install/mockery  .install/base/settings .install/base/db .install/modules/data.atmosphere .install/modules/data.land .install/base/remote
-$(call depends,models/cable): | 
-$(call depends,models/clm45): | 
+$(call depends,modules/meta.analysis): | .install/base/utils .install/base/db .install/base/settings .install/modules/priors
+$(call depends,modules/priors): | .install/base/utils
+$(call depends,modules/rtm): | .install/modules/assim.batch .install/base/utils .install/models/ed
+$(call depends,modules/uncertainty): | .install/base/utils .install/base/db .install/modules/priors .install/modules/emulator
+$(call depends,models/biocro): | .install/mockery .install/base/utils .install/base/settings .install/base/db .install/modules/data.atmosphere .install/modules/data.land .install/base/remote
+$(call depends,models/cable): | .install/base/utils
+$(call depends,models/clm45): | .install/base/utils
 $(call depends,models/dalec): | .install/base/remote
-$(call depends,models/dvmdostem): | 
-$(call depends,models/ed): |  .install/base/remote .install/base/settings
-$(call depends,models/fates): |  .install/base/remote
-$(call depends,models/gday): |  .install/base/remote
-$(call depends,models/jules): |  .install/base/remote
-$(call depends,models/linkages): |  .install/base/remote
-$(call depends,models/lpjguess): |  .install/base/remote
-$(call depends,models/maat): |  .install/base/remote .install/base/settings
-$(call depends,models/maespa): |  .install/base/remote .install/modules/data.atmosphere
-$(call depends,models/preles): |  .install/modules/data.atmosphere
-$(call depends,models/sipnet): |  .install/base/remote .install/modules/data.atmosphere
-$(call depends,models/template): | 
+$(call depends,models/dvmdostem): | .install/base/utils
+$(call depends,models/ed): | .install/base/utils .install/base/remote .install/base/settings
+$(call depends,models/fates): | .install/base/utils .install/base/remote
+$(call depends,models/gday): | .install/base/utils .install/base/remote
+$(call depends,models/jules): | .install/base/utils .install/base/remote
+$(call depends,models/linkages): | .install/base/utils .install/base/remote
+$(call depends,models/lpjguess): | .install/base/utils .install/base/remote
+$(call depends,models/maat): | .install/base/utils .install/base/remote .install/base/settings
+$(call depends,models/maespa): | .install/base/utils .install/base/remote .install/modules/data.atmosphere
+$(call depends,models/preles): | .install/base/utils .install/modules/data.atmosphere
+$(call depends,models/sipnet): | .install/base/utils .install/base/remote .install/modules/data.atmosphere
+$(call depends,models/template): | .install/base/utils
 
 clean:
 	rm -rf .install .check .test .doc

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ clean:
 	+ time Rscript -e "if(!requireNamespace('mockery', quietly = TRUE)) install.packages('mockery', repos = 'http://cran.rstudio.com', Ncpus = ${NCPUS})"
 	echo `date` > $@
 
-depends_R_pkg = time Rscript -e "devtools::install_deps('$(strip $(1))', threads = ${NCPUS}, dependencies = TRUE);"
+depends_R_pkg = time Rscript -e "devtools::install_deps('$(strip $(1))', Ncpus = ${NCPUS}, dependencies = TRUE);"
 install_R_pkg = time Rscript -e "devtools::install('$(strip $(1))', Ncpus = ${NCPUS});"
 check_R_pkg = Rscript scripts/check_with_errors.R $(strip $(1))
 test_R_pkg = Rscript -e "devtools::test('"$(strip $(1))"', stop_on_failure = TRUE, stop_on_warning = FALSE)" # TODO: Raise bar to stop_on_warning = TRUE when we can

--- a/base/all/DESCRIPTION
+++ b/base/all/DESCRIPTION
@@ -49,7 +49,7 @@ Depends:
     PEcAn.workflow
 Suggests:
     PEcAn.ED2,
-    PEcAn.sipnet,
+    PEcAn.SIPNET,
     PEcAn.BIOCRO,
     PEcAn.DALEC,
     PEcAn.LINKAGES,


### PR DESCRIPTION
## Description
Latest release for the R package "remotes" has [breaking changes](https://github.com/r-lib/remotes/releases/tag/v2.0.0) for the `install_deps` function. The `threads` arg need to be changes Ncpus.

THIS HAS NOT SOLVED THE BUILD LOCALLY. I'm still running into the issues locally with make where it can't install PEcAn packages.
## Motivation and Context
Travis builds are breaking installing all PEcAn packages.
## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
