### PR TITLE
update check_with_errors for new devtools

### DIFF
--- a/scripts/check_with_errors.R
+++ b/scripts/check_with_errors.R
@@ -1,6 +1,16 @@
 library(devtools)
+
 arg <- commandArgs(trailingOnly = TRUE)
 pkg <- arg[1]
+
+# Workaround for devtools/#1914:
+# check() sets its own values for `_R_CHECK_*` environment variables, without
+# checking whether any are already set. It winds up string-concatenating new
+# onto old (e.g. "FALSE TRUE") instead of either respecting or overriding them.
+Sys.unsetenv(
+    c('_R_CHECK_CRAN_INCOMING_',
+    '_R_CHECK_CRAN_INCOMING_REMOTE_',
+    '_R_CHECK_FORCE_SUGGESTS_'))
 
 log_level <- Sys.getenv('LOGLEVEL', unset = NA)
 die_level <- Sys.getenv('DIELEVEL', unset = NA)
@@ -24,7 +34,7 @@ die_warn <- !is.na(die_level) && die_level == 'warn'
 
 log_notes <- !is.na(log_level) && log_level == 'all'
 
-chk <- check(pkg, quiet = TRUE)
+chk <- check(pkg, quiet = TRUE, error_on = "never")
 
 errors <- chk[['errors']]
 n_errors <- length(errors)

--- a/scripts/check_with_errors.R
+++ b/scripts/check_with_errors.R
@@ -1,4 +1,3 @@
-library(devtools)
 
 arg <- commandArgs(trailingOnly = TRUE)
 pkg <- arg[1]
@@ -15,8 +14,8 @@ Sys.unsetenv(
 log_level <- Sys.getenv('LOGLEVEL', unset = NA)
 die_level <- Sys.getenv('DIELEVEL', unset = NA)
 
-message('log_level = ', log_level)
-message('die_level = ', die_level)
+# message('log_level = ', log_level)
+# message('die_level = ', die_level)
 
 valid_log_levels <- c('warn', 'all')
 if (!is.na(log_level) && !log_level %in% valid_log_levels) {
@@ -34,7 +33,7 @@ die_warn <- !is.na(die_level) && die_level == 'warn'
 
 log_notes <- !is.na(log_level) && log_level == 'all'
 
-chk <- check(pkg, quiet = TRUE, error_on = "never")
+chk <- devtools::check(pkg, quiet = TRUE, error_on = "never")
 
 errors <- chk[['errors']]
 n_errors <- length(errors)


### PR DESCRIPTION
Fixes #2173

`devtools::check` now defaults to exiting with an error on any warning or error from `R CMD check`, so we need to specify `error="never"` so that the check_with_errors script can finish (<del>Otherwise it </del><ins>Also, an [unrelated issue](https://github.com/r-lib/devtools/issues/1914)</ins> will falsely report success with 0 warnings and 0 notes).

Note that this means `check_with_errors.R` is now redundant for its *original* purpose (which was basically to provide the behavior we could now get from `devtools::check(..., error_on="error")`), but I propose we keep it around and use it to start *promoting* specific warnings to errors as a path toward finishing #1949.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
