### PR TITLE
Workflow pkg should depend data.atmosphere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ $(call depends,base/db): | .install/base/utils
 $(call depends,base/qaqc): | .install/base/utils
 $(call depends,base/settings): | .install/base/utils .install/base/db
 $(call depends,base/visualization): | .install/base/db
-$(call depends,base/workflow): | .install/base/db .install/base/settings .install/modules/data.atmosphere
+$(call depends,base/workflow): | .install/modules/data.atmosphere .install/modules/data.land .install/base/db .install/base/logger .install/base/remote .install/base/settings .install/modules/uncertainty .install/base/utils
 $(call depends,modules/allometry): | .install/base/db
 $(call depends,modules/assim.batch): | .install/base/utils .install/base/db .install/base/settings .install/base/remote .install/modules/meta.analysis
 $(call depends,modules/assim.sequential): | .install/base/remote

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ $(call depends,base/db): | .install/base/utils
 $(call depends,base/qaqc): | .install/base/utils
 $(call depends,base/settings): | .install/base/utils .install/base/db
 $(call depends,base/visualization): | .install/base/db
-$(call depends,base/workflow): | .install/base/db .install/base/settings
+$(call depends,base/workflow): | .install/base/db .install/base/settings .install/modules/data.atmosphere
 $(call depends,modules/allometry): | .install/base/db
 $(call depends,modules/assim.batch): | .install/base/utils .install/base/db .install/base/settings .install/base/remote .install/modules/meta.analysis
 $(call depends,modules/assim.sequential): | .install/base/remote


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

`base/workflow` depends on `modules/data.atmosphere`, but this was not indicated in the Makefile list of dependencies. This change adds `modules/data.atmosphere` to the list of dependencies for `base/workflow`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Build will fail otherwise. Trying to install workflow will fail if `data.atmosphere` is not already installed.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [X] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99-->