### PR TITLE
DOCKER: New development workflow using RabbitMQ

### DIFF
--- a/book_source/06_reference/04_docker/05_building_images.Rmd
+++ b/book_source/06_reference/04_docker/05_building_images.Rmd
@@ -107,6 +107,11 @@ NOTE: All commands assume you are working from the PEcAn source code root direct
 NOTE: The updates with this workflow are _specific to the running container session_; restarting the `executor` container will revert to the previous versions of the installed packages.
 To make persistent changes, you should re-build the `pecan/base` and `pecan/executor` containers against the current version of the source code.
 
+NOTE: The mounted PEcAn source code directory includes _everything_ in your local source directory, _including installation artifacts used by make_.
+This can lead to two common issues:
+- Any previous make cache files (stuff in the `.install`, `.docs`, etc. directories) persist across container instances, even though the installed packages may not. To ensure a complete build, it's a good idea to run `make clean` on the host machine to remove these artifacts.
+- Similarly, any installation artifacts from local builds will be carried over to the build. In particular, be wary of packages with compiled code, such as `modules/rtm` (`PEcAnRTM`) -- the compiled `.o`, `.so`, `.mod`, etc. files from compilation of such packages will carry over into the build, which can cause conflicts if the package was also built locally.
+
 The `docker-compose.override.yml` is useful for some other local modifications.
 For instance, the following adds a custom ED2 "develop" model container.
 

--- a/book_source/06_reference/04_docker/05_building_images.Rmd
+++ b/book_source/06_reference/04_docker/05_building_images.Rmd
@@ -77,71 +77,62 @@ The convention in PEcAn is to put Dockerfiles for core PEcAn functionality in `d
 ### Local development and testing with Docker {#docker-local-devel}
 
 The following is an example of one possible workflow for developing and testing PEcAn using local Docker images.
-The basic idea is to build `:local` versions of the PEcAn containers from whatever version of the PEcAn code you currently have.
+The basic idea is to mount a local version of the PEcAn source code onto a running `pecan/executor` image, and then send a special "rebuild" RabbitMQ message to the container to trigger the rebuild whenever you make changes.
 NOTE: All commands assume you are working from the PEcAn source code root directory.
 
-1. (First time only) Create a "bleeding-edge" version of the `pecan/depends` image with all the latest R packages.
+1. In the PEcAn source code directory, create a `docker-compose.override.yml` file with the following contents.:
 
-   ```
-   docker build -t pecan/depends:local -f docker/base/Dockerfile.depends
-   ```
-
-   Alternatively, if you are satisfied with the package versions of an existing image, you can just re-tag an existing image by using `docker tag`, e.g.:
-   
-   ```
-   docker tag pecan/depends:latest pecan/depends:local
-   # Or, provide an image ID, e.g.
-   # docker tag 96cfcc388bc2 pecan/depends:local
-   # See `docker tag --help` for more details
-   ```
-
-2. (First time only) Build the `pecan/base` and `pecan/executor` images, setting the `IMAGE_VERSION` build argument to `local`.
-
-    ```
-    docker build -t pecan/base:local -f docker/base/Dockerfile.base --build-arg IMAGE_VERSION=local .
-    docker build -t pecan/executor:local -f docker/base/Dockerfile.executor --build-arg IMAGE_VERSION=local .
-    ```
-
-	To check that you have all the required images, you can run `docker image ls`.
-	Near the top of the table, you should see `pecan/executor local` and `pecan/base local` images.
-    To check that you have a working version of PEcAn, you can launch the PEcAn stack with the following (note the use of `PECAN=local` to specify the PEcAn image version):
-	
-	```
-	PECAN=local docker-compose -p pecan up -d
-	```
-	
-	...and open the PEcAn web interface by browsing to http://localhost:8000/pecan/
-
-3. Now, make some changes to the PEcAn R source code. Make sure the changes are saved, and then, build a new `pecan/base:local_develop` image based on the existing `pecan/base:local` image:
-
-   ```
-   docker build -t pecan/base:local_develop -f docker/base/Dockerfile.base --build-arg IMAGE_VERSION=local --build-arg FROM_IMAGE=base .
-   docker build -t pecan/executor:local_develop -f docker/base/Dockerfile.executor --build-arg IMAGE_VERSION=local_develop .
-   docker tag pecan/web:local pecan/web:local_develop
+   ```yml
+   version: "3"
+   services:
+     executor:
+       volumes:
+         - .:/pecan
    ```
    
-   In the first two commands, the `FROM_IMAGE=base IMAGE_VERSION=local` indicates that, instead of building `pecan/base` off of `pecan/develop` (the default), we will build it on top of the existing `pecan/base:local` image.
-   This has the effect of only re-building PEcAn packages that have changed, similar to the standard behavior of `make`.
-   The last line is necessary because the `PECAN` variable also applies to the `pecan/web` image in the `docker-compose.yml`, so without it, `docker-compose` will look for `pecan/web:local_develop` but won't be able to find it.
-
-4. As before, launch the PEcAn stack with `docker-compose`, but this time with `PECAN=local_develop`:
-
-   ```
-   PECAN=local_develop docker-compose -p pecan up -d
-   ```
+   This will mount the current directory `.` to the `/pecan` directory in the `executor` container.
+   The special `docker-compose.override.yml` file is read automatically by `docker-compose` and overrides or extends any instructions set in the original `docker-compose.yml` file.
+   It provides a convenient way to host server-specific configurations without having to modify the project-wide (and version-controlled) default configuration.
+   For more details, see the [Docker Compose documentation](https://docs.docker.com/compose/extends/).
    
-As long as you have a `pecan/depends:local` image, you can skip steps 1 and 2 and only do steps 3 and 4 while you are developing.
-To save some keystrokes if you do this frequently, you can combine steps 3 and 4 into a shell script:
+2. Update your PEcAn Docker stack with `docker-compose up -d`.
+   If the stack is already running, this should only restart your `executor` instance while leaving the remaining containers running.
+   
+3. To update to the latest local code, run `./scripts/docker_rebuild.sh`.
+   Under the hood, this uses `curl` to post a RabbitMQ message to a running Docker instance.
+   By default, the scripts assumes that username and password are both `guest` and that the RabbitMQ URL is `http://localhost:8000/rabbitmq`.
+   All of these can be customized by setting the environment variables `RABBITMQ_USER`, `RABBITMQ_PASSWORD`, and `RABBITMQ_URL`, respectively (or running the script prefixed with those variables, e.g. `RABBITMQ_USER=carya RABBITMQ_PASSWORD=illinois ./scripts/docker_rebuild.sh`).
+   This step can be repeated whenever you want to trigger a rebuild of the local code.
+   
+NOTE: The updates with this workflow are _specific to the running container session_; restarting the `executor` container will revert to the previous versions of the installed packages.
+To make persistent changes, you should re-build the `pecan/base` and `pecan/executor` containers against the current version of the source code.
 
-```bash
-#!/bin/bash
+The `docker-compose.override.yml` is useful for some other local modifications.
+For instance, the following adds a custom ED2 "develop" model container.
 
-# rebuild pecan/base
-docker build -t pecan/base:local_develop -f docker/base/Dockerfile.base --build-arg IMAGE_VERSION=local --build-arg FROM_IMAGE=base .
+```yml
+services:
+  # ...
+  ed2devel:
+    image: pecan/model-ed2-develop:latest
+    build:
+      context: ../ED2  # Or wherever ED2 source code is found
+    networks:
+      - pecan
+    depends_on:
+      - rabbitmq
+    volumes:
+      - pecan:/data
+    restart: unless-stopped
+```
 
-# rebuild pecan/executor
-docker build -t pecan/executor:local_develop -f docker/base/Dockerfile.executor --build-arg IMAGE_VERSION=local_develop .
+Similarly, this snippet modifies the `pecan` network to use a custom IP subnet mask.
+This is required on the PNNL cluster because its servers' IP addresses often clash with Docker's default IP mask.
 
-# launch the PEcAn stack
-PECAN=local_develop docker-compose -p pecan up -d
+```yml
+networks:
+  pecan:
+    ipam:
+      config:
+        - subnet: 10.17.1.0/24
 ```

--- a/docker/receiver.py
+++ b/docker/receiver.py
@@ -25,7 +25,7 @@ def callback(ch, method, properties, body):
         logging.info("Rebuilding PEcAn with make")
         application = 'make'
         folder = '/pecan'
-    if custom_application is not None:
+    elif custom_application is not None:
         application = custom_application
     else:
         logging.info("Running default command: %s" % default_application)

--- a/scripts/docker_rebuild.sh
+++ b/scripts/docker_rebuild.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Send a "rebuild" message to a running Dockerized PEcAn instance.
+
+RABBITMQ_USER=${RABBITMQ_USER:-guest}
+RABBITMQ_PASSWORD=${RABBITMQ_PASSWORD:-guest}
+RABBITMQ_HOST=${RABBITMQ_HOST:-"http://localhost:8000/rabbitmq/"}
+
+curl --anyauth --user ${RABBITMQ_USER}:${RABBITMQ_PASSWORD} \
+     -d '{"properties" : {"delivery_mode" : 2}, "routing_key": "pecan", "payload" : "{\"rebuild\" : \"true\"}", "payload_encoding" : "string"}' \
+     -H "Content-Type: application/json" \
+     -X POST "${RABBITMQ_HOST}/api/exchanges/%2f//publish"

--- a/scripts/docker_rebuild.sh
+++ b/scripts/docker_rebuild.sh
@@ -4,7 +4,7 @@
 
 RABBITMQ_USER=${RABBITMQ_USER:-guest}
 RABBITMQ_PASSWORD=${RABBITMQ_PASSWORD:-guest}
-RABBITMQ_HOST=${RABBITMQ_HOST:-"http://localhost:8000/rabbitmq/"}
+RABBITMQ_HOST=${RABBITMQ_HOST:-"http://localhost:8000/rabbitmq"}
 
 curl --anyauth --user ${RABBITMQ_USER}:${RABBITMQ_PASSWORD} \
      -d '{"properties" : {"delivery_mode" : 2}, "routing_key": "pecan", "payload" : "{\"rebuild\" : \"true\"}", "payload_encoding" : "string"}' \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Enable (and describe) a development workflow where the user mounts her local PEcAn source code as a volume onto the `executor` container, and then triggers workflow rebuilds using a special `rebuild` RabbitMQ message. This leverages the `docker-compose.override.yml` functionality, described [here](https://docs.docker.com/compose/extends/), to avoid having to edit any version-controlled files.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This should make it easier to develop and test with Docker.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [X] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the CHANGELOG.md.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
