### PR TITLE
ED2: Pass arbitrary binary arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - Fixed error in `read_web_config` which would filter out all variables.
 - Docker:
   - Make sure web interface posts RabbitMQ messages even after editing files (fixes #2151)
+- ED2:
+  - Add ability to pass arbitrary arguments to the ED binary through the `pecan.xml` (#2183; fixes #2146).
 
 ### Added
 - Lots of new documentation for running PEcAn using Docker

--- a/book_source/06_reference/02_models/ed.Rmd
+++ b/book_source/06_reference/02_models/ed.Rmd
@@ -30,7 +30,10 @@ The following sections of the PEcAn XML are relevant to the ED model:
   - `jobtemplate`
   - `prerun`
   - `postrun`
-  - `binary`
+  - `binary` -- The full path to the ED2 binary on the target machine.
+  - `binary_args` -- Additional arguments to be passed to the ED2 binary. Some common arguments are:
+    - `-s` -- Delay OpenMPI initialization until the last possible moment. This is needed when running ED2 in a Docker container. It is included by default when the host is `rabbitmq`.
+    - `-f /path/to/ED2IN` -- Full path to a specific ED2IN namelist file. Typically, this is not needed because, by default, ED searches for the ED2IN in the current directory and the PEcAn workflow places the ED2IN file and a symbolic link to the ED executable in the same (run) directory for you.
 - `run/site`
   - `lat` -- Latitude coordinate of site
   - `lon` -- Longitude coordinate of site

--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -477,7 +477,7 @@ write.config.xml.ED2 <- function(settings, trait.values, defaults = settings$con
 #' run$host$rundir, run$host$outdir, run$host$scratchdir,
 #' run$host$clearscratch, model$jobtemplate, model$job.sh, run$host$job.sh,
 #' run$site$lat, run$site$lon, run$inputs$met$path, run$start.date,
-#' run$end.date, model$binary
+#' run$end.date, model$binary, model$binary_args
 #' @param run.id PEcAn run ID
 #' @return Character vector containing job.sh file
 #' @author David LeBauer, Shawn Serbin, Carl Davidson, Alexey Shiklomanov
@@ -547,6 +547,17 @@ write.config.jobsh.ED2 <- function(settings, run.id) {
   jobsh <- gsub("@OUTDIR@", outdir, jobsh)
   jobsh <- gsub("@RUNDIR@", rundir, jobsh)
   
+  if (is.null(settings$model$binary_args)) {
+    # If argument is missing but running on RabbitMQ, assume you need
+    # -s flag. If you want to force run ED without -s, use a blank
+    # binary_args tag.
+    if (!is.null(settings$host$rabbitmq)) {
+      settings$model$binary_args <- "-s"
+    } else {
+      settings$model$binary_args <- ""
+    }
+  }
+  jobsh <- gsub("@BINARY_ARGS@", settings$model$binary_args, jobsh)
   jobsh <- gsub("@BINARY@", settings$model$binary, jobsh)
   
   pft_names <- unlist(sapply(settings$pfts, `[[`, "name"))

--- a/models/ed/inst/template.job
+++ b/models/ed/inst/template.job
@@ -24,7 +24,7 @@ export GFORTRAN_UNBUFFERED_PRECONNECTED=yes
 if [ ! -e "@OUTDIR@/history.xml" ]; then
   cd "@RUNDIR@"
   
-  "@BINARY@"
+  "@BINARY@" "@BINARY_ARGS@"
   STATUS=$?
   if [ $STATUS == 0 ]; then
     if grep -Fq '=== Time integration ends; Total elapsed time=' "@OUTDIR@/logfile.txt"; then

--- a/models/ed/man/write.config.jobsh.ED2.Rd
+++ b/models/ed/man/write.config.jobsh.ED2.Rd
@@ -11,7 +11,7 @@ write.config.jobsh.ED2(settings, run.id)
 run$host$rundir, run$host$outdir, run$host$scratchdir,
 run$host$clearscratch, model$jobtemplate, model$job.sh, run$host$job.sh,
 run$site$lat, run$site$lon, run$inputs$met$path, run$start.date,
-run$end.date, model$binary}
+run$end.date, model$binary, model$binary_args}
 
 \item{run.id}{PEcAn run ID}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Add ability to pass ED2 executable arguments via PEcAn settings list (`pecan.xml`). This is primarily useful by adding ability to pass `-s` flag, which delays MPI initialization, and prevents Dockerized ED2 runs from crashing immediately after startup.

NOTE: All of the Docker/RabbitMQ-related changes are from #2182. This PR is a superset of those changes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2146.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [X] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
