### PR TITLE
ED2: Minor revisions and additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
   - Can specify name of docker cluster using PECAN_FQDN and PECAN_NAME (fixes #2128)
   - Fixed issue where setting username/password for rabbitmq would break web submit (fixes #2185)
 - ED2:
-  - Add ability to pass arbitrary arguments to the ED binary through the `pecan.xml` (#2183; fixes #2146).
+  - Fix processing of `ed2in_tags` from XML. Now numbers (e.g. `<TRAIT_PLASTICITY_SCHEME>0</TRAIT_PLASTICITY_SCHEME>`) and numeric vectors (e.g. `<INCLUDE_THESE_PFT>9,10,11,12</INCLUDE_THESE_PFT>`) are correctly written to ED2IN _without_ quotes.
 
 ### Added
 - NEW FEATURE: PEcAn R API (PR #2192). Features include:
@@ -32,6 +32,11 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - Added a prototype of the THREDDS data server (TDS) to the PEcAn Docker stack.
 - Added portainer to the PEcAn Docker stack to easily look at running containers.
 - Added ability to specify short name for a host (hostlist->displayname)
+- ED2:
+  - Add ability to pass arbitrary arguments to the ED binary through the `pecan.xml` (#2183; fixes #2146).
+  - Add new `model` tag `<all_pfts>`. If "false" (default), set ED2IN's `INCLUDE_THESE_PFT` to only PFTs explicitly configured through PEcAn. If "true", use all 17 of ED2's PFTs.
+  - Add new `model` tag `<barebones_ed2in>`. If "true", only write ED2IN tags, and do not include comment annotations. If "false" (default), try to transfer comments from ED2IN template to target ED2IN. Because of comments are written by matching line numbers, leaving this as "false" can lead to unexpected results whenever `<ed2in_tags>` contains tags missing from the `ED2IN` template.
+  - Add some additional documentation for ED2 `pecan.xml` tags.
 
 ### Removed
 

--- a/Makefile.depends
+++ b/Makefile.depends
@@ -24,6 +24,7 @@ $(call depends,modules/priors): | .install/base/utils .install/base/logger
 $(call depends,modules/rtm): | .install/base/logger .install/modules/assim.batch
 $(call depends,modules/uncertainty): | .install/base/utils .install/modules/priors .install/base/db .install/modules/emulator .install/base/logger
 $(call depends,models/biocro): | .install/base/logger .install/base/remote .install/base/utils .install/base/settings .install/modules/data.atmosphere .install/modules/data.land
+$(call depends,models/template): | .install/base/logger .install/base/utils
 $(call depends,models/cable): | .install/base/logger .install/base/utils
 $(call depends,models/clm45): | .install/base/logger .install/base/utils
 $(call depends,models/dalec): | .install/base/logger .install/base/remote .install/base/utils

--- a/book_source/06_reference/02_models/ed.Rmd
+++ b/book_source/06_reference/02_models/ed.Rmd
@@ -18,18 +18,40 @@ The following sections of the PEcAn XML are relevant to the ED model:
 
 - `model`
   - `id` -- BETY model ID. Each ID corresponds to a different revision of ED (see below)
-  - `revision` -- The revision (a.k.a. release) number of ED (e.g. "r82"). "rgit" indicates the latest code on the ED repository
-  - `ed2in` -- Path and filename of the ED2IN configuration file
+  - `revision` -- The revision (a.k.a. release) number of ED (e.g. "r82"). "rgit" indicates the latest code on the ED repository.
+  - `edin` -- Name of the template ED2IN configuration file. If this is a functional path that points to a specific file, that file is used. If no file is found following the path literally, the workflow will try the path relative to the `PEcAn.ED2` package using `system.file` (recall that files in `inst` are moved in the package root, but all other directory structure is preserved). If this is omitted, `PEcAn.ED2::write.configs.ED2` will look for a file called `ED2IN.<revision>` (e.g. `ED2IN.rgit`, `ED2IN.r86`) in the `PEcAn.ED2` package.
+    - **Example**: `<edin>ED2IN.rgit</edin>` will use the `ED2IN.rgit` file shipped with `PEcAn.ED2` _regardless of the revision of ED used_. (Note however that if a file called `ED2IN.rgit` exists in the workflow runtime directory, that file will be used instead). 
   - `start.date` -- Run start date
   - `end.date` -- Run end date
   - `phenol.scheme`
   - `phenol`
   - `phenol.start`
   - `phenol.end`
-  - `ed2in_tags` -- Named list of additional tags in the ED2IN to be modified. These modifications override any of those set by the standard PEcAn workflow.
+  - `ed2in_tags` -- Named list of additional tags in the ED2IN to be modified. These modifications override any of those set by other parts of the PEcAn workflow. These tags must be in all caps. Any tags that are not already in the ED2IN file will be added; this makes this an effective way to run newer versions of ED2 that have new ED2IN parameters without having to provide an entire new ED2IN. For example:
+  
+    ```xml
+    <model>
+      <ed2in_tags>
+        <IOOUTPUT>0</IOOUTPUT>
+        <PLANT_HYDRO_SCHEME>0</PLANT_HYDRO_SCHEME>
+        <ISTOMATA_SCHEME>0</ISTOMATA_SCHEME>
+        <ISTRUCT_GROWTH_SCHEME>0</ISTRUCT_GROWTH_SCHEME>
+        <TRAIT_PLASTICITY_SCHEME>0</TRAIT_PLASTICITY_SCHEME>
+      </ed2in_tags>
+    </model>
+    ```
+  - `barebones_ed2in` -- Whether or not to try to annotate the ED2IN file with comments. If "true", skip all comments and only write the tags themselves. If "false" (default), try to transfer comments from the template file into the target file.
   - `jobtemplate`
-  - `prerun`
-  - `postrun`
+  - `prerun` -- String of commands to be added to the `job.sh` model execution script before the model is run. Multiple commands should be separated by proper `bash` syntax -- i.e. either with `&&` or `;`.
+    - One common use of this argument is to load modules on some HPC systems -- for instance:
+      ```xml
+      <prerun>module load git hdf5</prerun>
+      ```
+    - If your particular version of ED is failing early during execution with a mysterious "Segmentation fault", that may indicate that its process is exceeding its stack limit. In this case, you may need to remove the stack limit restriction with a `prerun` command like the following:
+      ```xml
+      <prerun>ulimit -s unlimited</prerun>
+      ```
+  - `postrun` -- Same as `<prerun>`, but for commands to be run _after_ model execution.
   - `binary` -- The full path to the ED2 binary on the target machine.
   - `binary_args` -- Additional arguments to be passed to the ED2 binary. Some common arguments are:
     - `-s` -- Delay OpenMPI initialization until the last possible moment. This is needed when running ED2 in a Docker container. It is included by default when the host is `rabbitmq`.
@@ -38,7 +60,7 @@ The following sections of the PEcAn XML are relevant to the ED model:
   - `lat` -- Latitude coordinate of site
   - `lon` -- Longitude coordinate of site
 - `inputs`
-	- `met/path` -- Path to ED_MET_DRIVER_HEADER file
+	- `met/path` -- Path to `ED_MET_DRIVER_HEADER` file
 	- `pss`: [required] location of patch file
 	- `css`: [required] location of cohort file
 	- `site`: [optional] location of site file

--- a/models/ed/R/modify_ed2in.R
+++ b/models/ed/R/modify_ed2in.R
@@ -6,7 +6,9 @@
 #' defined explicitly (see "Parameters"), and those that do not match explicit 
 #' arguments will be ignored with a warning. Because the lowercase arguments 
 #' come with additional validity checks, they are recommended over modifying 
-#' the ED2IN file directly via uppercase arguments.
+#' the ED2IN file directly via uppercase arguments. For all lowercase
+#' arguments, the default (`NULL`) means to use whatever is currently
+#' in the input `ed2in`.
 #'
 #' Namelist arguments are applied last, and will silently overwrite any 
 #' arguments set by special case arguments.
@@ -48,6 +50,15 @@
 #'(history) files
 #' @param run_dir Directory in which to store run-related config files (e.g. `config.xml`).
 #' @param runtype ED initialization mode; either "INITIAL" or "HISTORY"
+#' @param run_name Give the run an informative name/description. Sets
+#'   the ED2IN `EXPNME` tag. (default is `NULL`)
+#' @param include_these_pft Numeric vector describing the PFTs to
+#'   include in ED. Note that this is in addition to any PFTs
+#'   specified by the `config.xml` -- regardless of what this is set
+#'   to, those PFTs will be included, so if you want to only use PFTs
+#'   defined in `config.xml`, set this to `numeric(0)`. The default
+#'   (`NULL`) means to use whatever is already in the current ED2IN
+#'   file, which is usually all (1-17) of ED's PFTs.
 #' @param pecan_defaults Logical. If `TRUE`, set common `ED2IN` defaults.
 #' @param add_if_missing Logical. If `TRUE`, all-caps arguments not found in 
 #'existing `ed2in` list will be added to the end.  Default = `FALSE`.

--- a/models/ed/R/modify_ed2in.R
+++ b/models/ed/R/modify_ed2in.R
@@ -69,6 +69,7 @@ modify_ed2in <- function(ed2in, ...,
                          run_dir = NULL,
                          runtype = NULL,
                          run_name = NULL,
+                         include_these_pft = NULL,
                          pecan_defaults = FALSE,
                          add_if_missing = FALSE,
                          check_paths = TRUE,
@@ -212,6 +213,11 @@ modify_ed2in <- function(ed2in, ...,
     dir.create(run_dir, showWarnings = FALSE)
     ed2in[["IEDCNFGF"]] <- file.path(normalizePath(run_dir), "config.xml")
     ed2in[["EVENT_FILE"]] <- file.path(normalizePath(run_dir), "myevents.xml")
+  }
+
+  if (!is.null(include_these_pft)) {
+    if (!is.numeric(include_these_pft)) PEcAn.logger::logger.severe("include_these_pft must be numeric vector")
+    ed2in[["INCLUDE_THESE_PFT"]] <- include_these_pft
   }
 
   namelist_args <- dots[is_upper]

--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -297,6 +297,32 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
     add_if_missing = TRUE,
     check_paths = check
   )
+
+  ##---------------------------------------------------------------------
+  # Use all PFTs, or just the ones configured in config.xml?
+  all_pfts <- settings$model$all_pfts
+  if (!is.null(all_pfts) && tolower(all_pfts) != "false") {
+    # Use all ED PFTs
+    use_pfts <- 1:17
+    PEcAn.logger::logger.debug("Running with all PFTs (1:17)")
+  } else {
+    # Use only PFTs configured in ED2 config.xml
+    # xml object (`config.xml`) created above. Here, we pull out the
+    # <num> tags from each PFT to get the numbers.
+    #
+    # I'm sure there is a better way to pull values out of an XML node
+    # object, but I have no idea what it is. If you know, please fix this.
+    use_pfts <- numeric(length(xml))
+    for (i in seq_along(xml)) {
+      use_pfts[i] <- as.numeric(XML::xmlValue(xml[[i]][['num']]))
+    }
+    use_pfts <- use_pfts[is.finite(use_pfts)]
+    PEcAn.logger::logger.debug(
+      "Running with only these PFTs (set by config.xml): ",
+      paste(use_pfts, collapse = ", ")
+    )
+  }
+  ed2in.text <- modify_ed2in(ed2in.text, include_these_pft = use_pfts)
   
   ##---------------------------------------------------------------------
   # Modify any additional tags provided in settings$model$ed2in_tags

--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -302,9 +302,21 @@ write.config.ED2 <- function(trait.values, settings, run.id, defaults = settings
   # Modify any additional tags provided in settings$model$ed2in_tags
   custom_tags <- settings$model$ed2in_tags
   if (!is.null(custom_tags)) {
+    # Convert numeric tags to numeric
+    # Anything that isn't converted to NA via `as.numeric` is numeric
     try_numeric <- suppressWarnings(vapply(custom_tags, as.numeric, numeric(1)))
     are_numeric <- !is.na(try_numeric)
     custom_tags[are_numeric] <- lapply(custom_tags[are_numeric], as.numeric)
+    # Figure out what is a numeric vector
+    # Look for a list of numbers like: "1,2,5"
+    # Works for decimals, and arbitrary spacing: "1.3,2.6,   7.8  ,  8.1"
+    numvec_rxp <- paste0("^ *[[:digit:]]+.?[[:digit:]]*",
+                         "([[:space:]]*,[[:space:]]*[[:digit:]]+.?[[:digit:]]*)+")
+    are_numvec <- vapply(custom_tags, function(x) grepl(numvec_rxp, x), logical(1))
+    custom_tags[are_numvec] <- lapply(
+      custom_tags[are_numvec],
+      function(x) as.numeric(strsplit(x, ",")[[1]])
+    )
     ed2in.text <- modify_ed2in(ed2in.text, .dots = custom_tags, add_if_missing = TRUE, check_paths = check)
   }
   

--- a/models/ed/R/write_ed2in.R
+++ b/models/ed/R/write_ed2in.R
@@ -19,7 +19,7 @@ write_ed2in <- function(ed2in, filename, custom_header = character(), barebones 
 #' @export
 write_ed2in.ed2in <- function(ed2in, filename, custom_header = character(), barebones = FALSE) {
   tags_values_vec <- tags2char(ed2in)
-  if (barebones) {
+  if (isTRUE(barebones)) {
     write_ed2in.default(ed2in, filename, custom_header, barebones)
     return(NULL)
   }

--- a/models/ed/man/modify_ed2in.Rd
+++ b/models/ed/man/modify_ed2in.Rd
@@ -43,6 +43,17 @@ and \code{THSUMS_DATABASE} files.}
 
 \item{runtype}{ED initialization mode; either "INITIAL" or "HISTORY"}
 
+\item{run_name}{Give the run an informative name/description. Sets
+the ED2IN \code{EXPNME} tag. (default is \code{NULL})}
+
+\item{include_these_pft}{Numeric vector describing the PFTs to
+include in ED. Note that this is in addition to any PFTs
+specified by the \code{config.xml} -- regardless of what this is set
+to, those PFTs will be included, so if you want to only use PFTs
+defined in \code{config.xml}, set this to \code{numeric(0)}. The default
+(\code{NULL}) means to use whatever is already in the current ED2IN
+file, which is usually all (1-17) of ED's PFTs.}
+
 \item{pecan_defaults}{Logical. If \code{TRUE}, set common \code{ED2IN} defaults.}
 
 \item{add_if_missing}{Logical. If \code{TRUE}, all-caps arguments not found in
@@ -63,7 +74,9 @@ are inserted directly into the \code{ed2in} list objects. Lowercase arguments ar
 defined explicitly (see "Parameters"), and those that do not match explicit
 arguments will be ignored with a warning. Because the lowercase arguments
 come with additional validity checks, they are recommended over modifying
-the ED2IN file directly via uppercase arguments.
+the ED2IN file directly via uppercase arguments. For all lowercase
+arguments, the default (\code{NULL}) means to use whatever is currently
+in the input \code{ed2in}.
 }
 \details{
 Namelist arguments are applied last, and will silently overwrite any

--- a/models/ed/man/modify_ed2in.Rd
+++ b/models/ed/man/modify_ed2in.Rd
@@ -8,8 +8,8 @@ modify_ed2in(ed2in, ..., veg_prefix = NULL, latitude = NULL,
   longitude = NULL, met_driver = NULL, start_date = NULL,
   end_date = NULL, EDI_path = NULL, output_types = NULL,
   output_dir = NULL, run_dir = NULL, runtype = NULL,
-  run_name = NULL, pecan_defaults = FALSE, add_if_missing = FALSE,
-  check_paths = TRUE, .dots = list())
+  run_name = NULL, include_these_pft = NULL, pecan_defaults = FALSE,
+  add_if_missing = FALSE, check_paths = TRUE, .dots = list())
 }
 \arguments{
 \item{...}{Namelist arguments (see Description and Details)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
- Fix processing of `ed2in_tags` from XML. Now numbers (e.g. `<TRAIT_PLASTICITY_SCHEME>0</TRAIT_PLASTICITY_SCHEME>`) and numeric vectors (e.g. `<INCLUDE_THESE_PFT>9,10,11,12</INCLUDE_THESE_PFT>`) are correctly written to ED2IN _without_ quotes.
  
- Add new `model` tag `<all_pfts>`. If "false" (default), set ED2IN's `INCLUDE_THESE_PFT` to only PFTs explicitly configured through PEcAn. If "true", use all 17 of ED2's PFTs.
- Add new `model` tag `<barebones_ed2in>`. If "true", only write ED2IN tags, and do not include comment annotations. If "false" (default), try to transfer comments from ED2IN template to target ED2IN. Because of comments are written by matching line numbers, leaving this as "false" can lead to unexpected results whenever `<ed2in_tags>` contains tags missing from the `ED2IN` template.
- Add some additional documentation for ED2 `pecan.xml` tags.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Makes it easier to customize ED runs via the PEcAn XML, and fixes some minor bugs.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [X] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the CHANGELOG.md.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
