### PR TITLE
Sipnet model2netcdf bug fix 

### DIFF
--- a/models/sipnet/R/model2netcdf.SIPNET.R
+++ b/models/sipnet/R/model2netcdf.SIPNET.R
@@ -72,7 +72,7 @@ model2netcdf.SIPNET <- function(outdir, sitelat, sitelon, start_date, end_date, 
     # get the run dates based on the sipnet output.  we assume that even if the run is partial, the origin is still day 1 of the subset year
     start_month <- lubridate::month(as.Date(sub.sipnet.output$day[1], origin = paste0(y,"-01-01"))) # gets month
     ## using this approach to attempt to deal with inconsistent start index 0/1
-    model_start_date <- base::as.Date(paste0(y,"-",start_month,"-",ifelse(sub.sipnet.output$day[1]==0,1,sub.sipnet.output$day[1])))  
+    model_start_date <- base::as.Date(ifelse(sub.sipnet.output$day[1]==0,1,sub.sipnet.output$day[1]), origin = paste0(y,"-01-01"))
     sub_date_range <- seq(model_start_date, by = "day", length.out = length(unique(sub.sipnet.output$day))) ## create new date range in POSIX format
     # this catches the fact that the number of outputs per day may be different at the end of the year with leap years, if day starts at 1
     day_repeats <- as.vector(base::table(sub.sipnet.output$day))  


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
Fixed a day of year bug in model2netcdf.SIPNET. The updated DOY from met2model.SIPNET was throwing an error because line 75 in model2netcdf was trying to create a date with a DOY instead of day of month. 

## Motivation and Context
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [X] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
