### PR TITLE
DOCKER: Fix trailing backslash in Dockerfile.monitor

### DIFF
--- a/docker/base/Dockerfile.monitor
+++ b/docker/base/Dockerfile.monitor
@@ -4,7 +4,8 @@ ENV RABBITMQ_URI="amqp://guest:guest@rabbitmq/%2F" \
     RABBITMQ_MGMT_PORT="15672" \
     RABBITMQ_MGMT_PATH="/rabbitmq/" \
     POSTGRES_PARAM="host=postgres dbname=bety user=bety password=bety connect_timeout=10" \
-    FQDN="pecan" \
+    FQDN="pecan"
+
 EXPOSE 9999
 
 RUN pip install pika==0.11.2 \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
`Dockerfile.monitor` doesn't read the `EXPOSE` argument (for the port) correctly because of a backslash on the preceding line (interpreted as a command continuation).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`docker build monitor` doesn't work.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [X] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
