### PR TITLE
Exclude PEcAn.data.mining from build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ addons:
     sources:
       - sourceline: 'ppa:nschloe/hdf5-backports'
       - sourceline: 'ppa:ubuntugis/ppa' # for GDAL 2 binaries
-      - sourceline: 'ppa:opencpu/imagemagick'
     packages:
       - bc
       - curl
@@ -48,7 +47,6 @@ addons:
       - libnetcdf-dev
       - libproj-dev
       - libudunits2-dev
-      - libmagick++-dev
       - netcdf-bin
       - pandoc
       - python-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 
 ### Removed
 - Removed unused function `PEcAn.visualization::points2county`, thus removing many indirect dependencies by no longer importing the `earth` package.
+- Removed package `PEcAn.data.mining` from the Make build. It can still be installed directly from R if desired, but is skipped by default because it is in early development, does not yet export any functions, and creates a dependency on the (large, often annoying to install) ImageMagick library.
 
 ## [1.7.0] - 2018-12-09
 

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,18 @@ NCPUS ?= 1
 
 BASE := logger utils db settings visualization qaqc remote workflow
 
-MODELS := biocro clm45 dalec ed fates gday jules linkages \
-				lpjguess maat maespa preles sipnet dvmdostem template
+MODELS := biocro clm45 dalec dvmdostem ed fates gday jules linkages \
+				lpjguess maat maespa preles sipnet template
 
 MODULES := allometry assim.batch assim.sequential benchmark \
 				 data.atmosphere data.hydrology data.land \
-				 data.mining data.remote emulator meta.analysis \
+				 data.remote emulator meta.analysis \
 				 photosynthesis priors rtm uncertainty
+
+# Components not currently included in the build
+# (Most need more development first)
+# 	models: cable
+#	modules: data.mining, DART
 
 SHINY := $(dir $(wildcard shiny/*/.))
 SHINY := $(SHINY:%/=%)

--- a/modules/data.mining/DESCRIPTION
+++ b/modules/data.mining/DESCRIPTION
@@ -7,9 +7,8 @@ Date: 2018-12-03
 Authors@R: c(person("Mike","Dietze"))
 Author: Mike Dietze
 Maintainer: Mike Dietze <dietze@bu.edu>
-Depends:
-    dplR
 Imports:
+    dplR,
     PEcAn.logger
 Suggests:
     PEcAn.utils,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description

Removes data.mining from the Make build, and therefore also from testing on Travis, to save build time and signal its not-yet-maintained status.

## Motivation and Context

Proximal issue: installing the `magick` R package and its required ImageMagick libraries is eating a *lot* of build time, contributing significantly to our Travis timeout problem.

Medial issue: ImageMagick is needed because `data.mining` imports `dplR`, which imports `animation`, which imports `magick`. Only one dplR functions actually uses animation, and `data.mining` doesn't call it. I emailed the maintainer of dplR to suggest they move `animation` to their Suggests so that we can skip installing it, and they agreed that this is a good idea but they don't yet have a timeline for their next CRAN release.

Ultimate issue: `data.mining` isn't yet used by any other PEcAn components, and in fact it doesn't even export any functions (all its code currently lives in `inst`), so we really don't need to be installing its dependencies every push. 

When development on data.mining starts again we should absolutely re-add it to the build and evaluate its dependencies -- hopefully by that time dplR will be less expensive to install.


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [x] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 