### PR TITLE
Travis: Build against multiple R versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,17 +135,26 @@ before_script:
 
 script:
   - set -e
-  - echo 'Installing PEcAn packages'
   - Rscript scripts/generate_makefile_deps.R
+  - echo 'Installing PEcAn packages' && echo -en 'travis_fold:start:install_pkgs\\r'
   # TODO: Would probably be faster to use -j2 NCPUS=1 as for other steps,
   # but many dependency compilations seem not parallel-safe.
   # More debugging needed.
   - NCPUS=2 make -j1
-  - echo 'Testing PEcAn packages'
+  - echo -en 'travis_fold:end:install_pkgs\\r'
+  #
+  - echo 'Testing PEcAn packages' && echo -en 'travis_fold:start:test_pkgs\\r'
   - make test
+  - echo -en 'travis_fold:end:test_pkgs\\r'
+  #
+  - echo 'Checking PEcAn packages' && echo -en 'travis_fold:start:check_pkgs\\r'
   - REBUILD_DOCS=FALSE make check
-  - echo 'Testing Integration'
+  - echo -en 'travis_fold:end:check_pkgs\\r'
+  #
+  - echo 'Testing Integration' && echo -en 'travis_fold:start:integration_test\\r'
   - ./tests/integration.sh travis
+  - echo -en 'travis_fold:end:integration_test\\r'
+  #
   - if [[ `git status -s` ]]; then 
       echo "These files were changed by the build process:";
       git status -s;

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ script:
   - NCPUS=2 make -j1
   - echo 'Testing PEcAn packages'
   - make test
-  - make check
+  - REBUILD_DOCS=FALSE make check
   - echo 'Testing Integration'
   - ./tests/integration.sh travis
   - if [[ `git status -s` ]]; then 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,12 @@ env:
     - PGHOST=localhost
     - RGL_USE_NULL=TRUE # Keeps RGL from complaining it can't find X11
 
+matrix:
+  fast_finish: true
+  allow_failures:
+    - r: devel
+    - r: oldrel
+
 cache: 
   - directories:
     - .install

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,10 @@ addons:
       - r-bioc-biocinstaller
       - r-cran-ape
       - r-cran-curl
+      - r-cran-data.table
       - r-cran-devtools
       - r-cran-dplyr
+      - r-cran-gap
       - r-cran-ggplot2
       - r-cran-httr
       - r-cran-igraph
@@ -79,7 +81,10 @@ addons:
       - r-cran-redland
       - r-cran-rncl
       - r-cran-roxygen2
+      - r-cran-rsqlite
+      - r-cran-sf
       - r-cran-shiny
+      - r-cran-sirt
       - r-cran-testthat
       - r-cran-tidyverse
       - r-cran-xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     # When Travis updates, check for Make 4 and add -O if available.
     - MAKEFLAGS="-j2"
     - PGHOST=localhost
+    - RGL_USE_NULL=TRUE # Keeps RGL from complaining it can't find X11
 
 cache: 
   - directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@
 
 language: r
 r:
-  - 3.5
+  - release
+  - devel
+  - oldrel
 
 # TRUSTY: Change version when 16.04 image is available.
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ addons:
       - libgmp-dev
       - libhdf5-dev
       - liblapack-dev
-      - libmagick++-dev
       - libnetcdf-dev
       - libproj-dev
       - libudunits2-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,8 +114,6 @@ install:
   - rm configure
   - R CMD INSTALL .
   - popd
-  # temporary until remotes 2.0.2 binary reaches C2D4U
-  - Rscript -e 'if(packageVersion("remotes") <= "2.0.1"){install.packages("remotes", repos = "http://cran.rstudio.com")}'
   
 before_script:
   - sudo service postgresql stop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 ## [Unreleased]
 
 ### Changed
-- Automatic build are currently done using R version 3.5 and most development will be done with version 3.5 as well. It still might be possible to use R version 3.4 however we will not guarantee future compatibility with 3.4.
+- Improved testing (#2264). Automatic Travis CI builds of PEcAn on are now run using three versions of R in parallel. This should mean fewer issues with new releases and better backwards compatibility, but note that we still only guarantee full compatibility with the current release version of R. The tested versions are:
+  - `release`, the current public release of R (currently R 3.5). Build failures in this version are fixed before merging the change that caused them. When we say PEcAn is fully tested and working, this is the build we mean.
+  - `devel`, the newest available development build of R. We will fix issues with this version before the next major R release.
+  - `oldrel`, the previous major release of R (currently R 3.4). We will fix issues with this version as time allows, but we do not guarantee that it will stay compatible.
 - Reverting back from PR #2137 to fix issues with MAAT wrappers.
 - Moved docker files for models into model specific folder, for example Dockerfile for sipnet now is in models/sipnet/Dockerfile.
 - `PEcAn.utils`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 ## [Unreleased]
 
 ### Changed
-- Improved testing (#2264). Automatic Travis CI builds of PEcAn on are now run using three versions of R in parallel. This should mean fewer issues with new releases and better backwards compatibility, but note that we still only guarantee full compatibility with the current release version of R. The tested versions are:
+- Improved testing (#2281). Automatic Travis CI builds of PEcAn on are now run using three versions of R in parallel. This should mean fewer issues with new releases and better backwards compatibility, but note that we still only guarantee full compatibility with the current release version of R. The tested versions are:
   - `release`, the current public release of R (currently R 3.5). Build failures in this version are fixed before merging the change that caused them. When we say PEcAn is fully tested and working, this is the build we mean.
   - `devel`, the newest available development build of R. We will fix issues with this version before the next major R release.
   - `oldrel`, the previous major release of R (currently R 3.4). We will fix issues with this version as time allows, but we do not guarantee that it will stay compatible.

--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,9 @@ depends_R_pkg = time Rscript -e " \
 	deps <- if (grepl('base/utils', '$(1)')) { c('Depends', 'Imports', 'LinkingTo') } else { TRUE }; \
 	devtools::install_deps('$(strip $(1))', Ncpus = ${NCPUS}, dependencies = deps);"
 install_R_pkg = time Rscript -e "devtools::install('$(strip $(1))', Ncpus = ${NCPUS});"
-check_R_pkg = Rscript scripts/check_with_errors.R $(strip $(1))
-test_R_pkg = Rscript -e "devtools::test('"$(strip $(1))"', stop_on_failure = TRUE, stop_on_warning = FALSE)" # TODO: Raise bar to stop_on_warning = TRUE when we can
-doc_R_pkg = Rscript -e "devtools::document('"$(strip $(1))"')"
+check_R_pkg = time Rscript scripts/check_with_errors.R $(strip $(1))
+test_R_pkg = time Rscript -e "devtools::test('"$(strip $(1))"', stop_on_failure = TRUE, stop_on_warning = FALSE)" # TODO: Raise bar to stop_on_warning = TRUE when we can
+doc_R_pkg = time Rscript -e "devtools::document('"$(strip $(1))"')"
 
 $(ALL_PKGS_I) $(ALL_PKGS_C) $(ALL_PKGS_T) $(ALL_PKGS_D): | .install/devtools .install/roxygen2 .install/testthat
 

--- a/scripts/check_with_errors.R
+++ b/scripts/check_with_errors.R
@@ -6,6 +6,7 @@ pkg <- arg[1]
 # check() sets its own values for `_R_CHECK_*` environment variables, without
 # checking whether any are already set. It winds up string-concatenating new
 # onto old (e.g. "FALSE TRUE") instead of either respecting or overriding them.
+# (Fixed in devtools 2.0.1.9000; remove these lines after next CRAN release)
 Sys.unsetenv(
     c('_R_CHECK_CRAN_INCOMING_',
     '_R_CHECK_CRAN_INCOMING_REMOTE_',
@@ -13,6 +14,7 @@ Sys.unsetenv(
 
 log_level <- Sys.getenv('LOGLEVEL', unset = NA)
 die_level <- Sys.getenv('DIELEVEL', unset = NA)
+redocument <- as.logical(Sys.getenv('REBUILD_DOCS', unset = NA))
 
 # message('log_level = ', log_level)
 # message('die_level = ', die_level)
@@ -33,7 +35,7 @@ die_warn <- !is.na(die_level) && die_level == 'warn'
 
 log_notes <- !is.na(log_level) && log_level == 'all'
 
-chk <- devtools::check(pkg, quiet = TRUE, error_on = "never")
+chk <- devtools::check(pkg, quiet = TRUE, error_on = "never", document = redocument)
 
 errors <- chk[['errors']]
 n_errors <- length(errors)


### PR DESCRIPTION
## Description

* Run Travis tests against three versions of R in parallel
* Fold up successful log sections so it's easier to find what failed
* Report time used by each make step (deps/install/document/check) within every package. Especially useful for debugging timed-out builds
* `make check` now skips rebuilding documentation if env var `$REBUILD_DOCS` is false  
* General cleanup: Remove unused packages, delete some build hacks that have outlived their purpose, etc.

## Motivation and Context

### R versions

The major change here is a transition from testing against one R version (hopefully the one most users have) to defining a *build matrix* so that we can test in multiple environments at once. The build matrix concept could be extended in the future to include different OSes, Postgres versions, environment variables, etc, but for this PR the matrix is one-dimensional and contains three R versions: `release`, `devel`, and `oldrel`. These are aliases defined by Travis and currently point respectively to R 3.5, nightly, and 3.4, but versions are updated each release. 

**Opinions, please:** I currently have the devel and oldrel builds marked as `allow_failures`, which means the build is always *run* on all three versions, but will report success as long as it finishes successfully on R-release. My rationale is that this will let us keep an eye on how it's doing in other versions but won't commit us to maintaining them. Is this what we want?
 
* Pro: If R-devel introduces breaking changes we might want to defer fixes until it's clear the change will actually be released, and similarly if R-oldrel stops working we might want to reserve the right to say "OK, WONTFIX, PEcAn doesn't support that version anymore". 
* Con: Any build that's *allowed* to fail will likely *keep* failing and become harder to fix later, so if we do want to commit to supporting devel or oldrel then we should commit now and require that they pass for every merge.

### Skip documentation

I've updated `scripts/check_with_errors.R` to recognize an environment variable `$REBUILD_DOCS` and pass its logical value to the `document` argument of `devtools::check`. This is primarily to save a few seconds per package on Travis, where documentation is always freshly-built at check time, but feel free to use it any other time `make check` fails to document/not document things the way you want.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [x] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 