### PR TITLE
Added features requested in #2291

### DIFF
--- a/scripts/backup.bety.sh
+++ b/scripts/backup.bety.sh
@@ -23,6 +23,7 @@ mkdir -p ${BACKUPDIR}
 # some handy variables
 HOUR=$( date +"%H" )
 TODAY=$( date +"%d" )
+YESTERDAY=$( date -d "yesterday" +"%d" )
 TOMORROW=$( date -d "tomorrow" +"%d" )
 DOW=$( date +"%u" )
 WEEK=$( date +"%W" )
@@ -58,7 +59,7 @@ pg_dump -U ${BETYUSER} -d ${DATABASE} ${PG_OPT} | gzip -9 > ${DUMP_PATH}
 
 # HANDLING DAILY FOR WHEN WE HAVE HOURLY BACKUPS
 if [ "${HOURLY}" != "" -a "${HOUR}" == "00" ]; then
-  cp -fp ${DUMP_PATH} ${BACKUPDIR}/bety-d-${TODAY}.sql.gz
+  cp -fp ${DUMP_PATH} ${BACKUPDIR}/bety-d-${YESTERDAY}.sql.gz
 fi
 
 # WEEKLY BACKUP

--- a/scripts/backup.bety.sh
+++ b/scripts/backup.bety.sh
@@ -32,15 +32,17 @@ YEAR=$( date +"%Y" )
 # Psql options
 # This allows you to add any other options
 PG_OPT=${PG_OPT:-""}
+HOURLY=${HOURLY:-""}
 
 # Parse command line options
-while getopts ho:p: opt; do
+while getopts ho:p:H opt; do
   case $opt in
   h)
     echo "$0 [-h] [-p psql options]"
     echo " -h this help page"
-    echo " -o output folder where dumped data is written, default is named backup"
+    echo " -o output folder where dumped data is written, default folder is 'backup'"
     echo " -p additional psql command line options, default is empty"
+    echo " -H perform an hourly backup, defaults to daily backup"
     exit 0
     ;;
   o)
@@ -48,6 +50,9 @@ while getopts ho:p: opt; do
     ;;
   p)
     PG_OPT="$OPTARG"
+    ;;
+  H)
+    HOURLY="true"
     ;;
   esac
 done

--- a/scripts/backup.bety.sh
+++ b/scripts/backup.bety.sh
@@ -3,6 +3,7 @@
 # simple script to creat backups of the bety database. This script will
 # create a copy of the datbase daily, weekly, monthly and yearly. The
 # files will be called:
+# - bety-h-X, hourly backup, where X is the hour of the day (24 hour time).
 # - bety-d-X, daily backup, where X is the day of the month.
 # - bety-w-X, weekly backup, where X is the week number in the year
 # - bety-m-X, montly backup, where X is the month of the year
@@ -20,6 +21,7 @@ mkdir -p ${BACKUPDIR}
 #export PATH=<location to postgresql>/bin;${PATH}
 
 # some handy variables
+HOUR=$( date +"%H" )
 TODAY=$( date +"%d" )
 TOMORROW=$( date -d "tomorrow" +"%d" )
 DOW=$( date +"%u" )
@@ -27,20 +29,49 @@ WEEK=$( date +"%W" )
 MONTH=$( date +"%m" )
 YEAR=$( date +"%Y" )
 
-# DAILY BACKUP
-pg_dump -U ${BETYUSER} -d ${DATABASE} | gzip -9 > ${BACKUPDIR}/bety-d-${TODAY}.sql.gz
+# psql options
+# this allows you to add any other options
+PG_OPT=${PG_OPT:-""}
+
+# parse command line options
+while getopts hp: opt; do
+  case $opt in
+  h)
+    echo "$0 [-h] [-p psql options]"
+    echo " -h this help page"
+    echo " -p additional psql command line options, default is empty"
+    exit 0
+    ;;
+  p)
+    PG_OPT="$OPTARG"
+    ;;
+  esac
+done
+
+# THE BACKUP
+if [ "${HOURLY}" != "" ]; then
+  DUMP_PATH=${BACKUPDIR}/bety-h-${HOUR}.sql.gz
+else
+  DUMP_PATH=${BACKUPDIR}/bety-d-${TODAY}.sql.gz
+fi
+pg_dump -U ${BETYUSER} -d ${DATABASE} ${PG_OPT} | gzip -9 > ${DUMP_PATH}
+
+# HANDLING DAILY FOR WHEN WE HAVE HOURLY BACKUPS
+if [ "${HOURLY}" != "" -a "${HOUR}" == "00" ]; then
+  cp -fp ${DUMP_PATH} ${BACKUPDIR}/bety-d-${TODAY}.sql.gz
+fi
 
 # WEEKLY BACKUP
 if [ "${DOW}" == "7" ]; then
-  pg_dump -U ${BETYUSER} -d ${DATABASE} | gzip -9 > ${BACKUPDIR}/bety-w-${WEEK}.sql.gz
+  cp -fp ${DUMP_PATH} ${BACKUPDIR}/bety-w-${WEEK}.sql.gz
 fi
 
 # MONTHLY BACKUP
 if [ "${TOMORROW}" == "01" ]; then
-  pg_dump -U ${BETYUSER} -d ${DATABASE} | gzip -9 > ${BACKUPDIR}/bety-m-${MONTH}.sql.gz
+  cp -fp ${DUMP_PATH} ${BACKUPDIR}/bety-m-${MONTH}.sql.gz
 fi
 
 # YEARLY BACKUP
 if [ "${TOMORROW}" == "01"  -a "${MONTH}" == "12" ]; then
-  pg_dump -U ${BETYUSER} -d ${DATABASE} | gzip -9 > ${BACKUPDIR}/bety-y-${YEAR}.sql.gz
+  cp -fp ${DUMP_PATH} ${BACKUPDIR}/bety-y-${YEAR}.sql.gz
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
- Added check for HOURLY environment variable to enable an hourly-labeled database dump
- If making an hourly dump, set the filename with 'h' and the hour (in 24 hour time format). For example, `bety-h-14.sql.gz`
- If **not** making an hourly dump, assume making a daily dump
- If making an hourly dump, copy hourly dump to daily dump at hour 00
- Changed other dump commands to copy the original dump (hour or daily) to correct name
- Added `-p` command line option for additional psql command line parameters
- Added `-h` command line option to display help
- Added '-o' command line option to specify output location override

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Can now make an hourly dump of the database
- Can run in non-standard environments, such as a machine hosting Pecan in docker containers
- Using **cp** saves time
- Showing help is nice

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
