### PR TITLE
rstudio behind nginx-proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,8 +157,19 @@ services:
       - "traefik.backend=bety"
 
   # ----------------------------------------------------------------------
-  # Pecan-RStudio
+  # RStudio
   # ----------------------------------------------------------------------
+  rstudio-nginx:
+    image: pecan/rstudio-nginx:${PECAN_VERSION:-latest}
+    networks:
+      - pecan
+    labels:
+      - "traefik.enable=true"
+      - "traefik.backend=rstudio"
+      - "traefik.port=80"
+      - "traefik.frontend.rule=${TRAEFIK_FRONTEND_RULE:-}PathPrefix:/rstudio"
+      - "traefik.website.frontend.whiteList.sourceRange=${TRAEFIK_IPFILTER:-172.16.0.0/12}"
+
   rstudio:
     image: pecan/base:${PECAN_VERSION:-latest}
     restart: unless-stopped
@@ -167,15 +178,10 @@ services:
     environment:
       - USER=${PECAN_RSTUDIO_USER:-carya}
       - PASSWORD=${PECAN_RSTUDIO_PASS:-ilinois}
-    depends_on:
-      - bety
     entrypoint: /init
-    labels:
-      - "traefik.enable=true"
-      - "traefik.backend=rstudio"
-      - "traefik.port=8787"
-      - "traefik.frontend.rule=${TRAEFIK_FRONTEND_RULE:-}PathPrefix:/rstudio"
-      - "traefik.website.frontend.whiteList.sourceRange=${TRAEFIK_IPFILTER:-172.16.0.0/12}"
+    volumes:
+      - pecan:/data
+      - rstudio:/home
  
   # ----------------------------------------------------------------------
   # PEcAn application
@@ -329,3 +335,4 @@ volumes:
     #   type: none
     #   device: ${DATA_DIR:-/tmp}/portainer
     #   o: bind
+  rstudio:

--- a/docker.sh
+++ b/docker.sh
@@ -149,7 +149,7 @@ for x in base web docs; do
 done
 
 # all files in subfolder
-for x in models executor data thredds monitor; do
+for x in models executor data thredds monitor rstudio-nginx; do
     ${DEBUG} docker build \
         --tag pecan/$x:${IMAGE_VERSION} \
         --build-arg IMAGE_VERSION="${IMAGE_VERSION}" \

--- a/docker/rstudio-nginx/Dockerfile
+++ b/docker/rstudio-nginx/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:alpine
+MAINTAINER Rob Kooper <kooper@illinois.edu>
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/docker/rstudio-nginx/nginx.conf
+++ b/docker/rstudio-nginx/nginx.conf
@@ -1,0 +1,18 @@
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  ''      close;
+}
+
+server {
+  listen 80;
+
+  location /rstudio/ {
+    rewrite ^/rstudio/(.*)$ /$1 break;
+    proxy_pass http://rstudio:8787;
+    proxy_redirect http://rstudio:8787/ $scheme://$host/rstudio/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 20d;
+  }
+}


### PR DESCRIPTION
put rstudio behind nginx to make /rstudio work. See https://docs.rstudio.com/ide/server-pro/access-and-security.html#running-with-a-proxy
