### PR TITLE
Full support for `RPostgres`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,22 +12,22 @@ For more information about this file see also [Keep a Changelog](http://keepacha
   - `release`, the current public release of R (currently R 3.5). Build failures in this version are fixed before merging the change that caused them. When we say PEcAn is fully tested and working, this is the build we mean.
   - `devel`, the newest available development build of R. We will fix issues with this version before the next major R release.
   - `oldrel`, the previous major release of R (currently R 3.4). We will fix issues with this version as time allows, but we do not guarantee that it will stay compatible.
-- Reverting back from PR #2137 to fix issues with MAAT wrappers.
+- Reverting back from PR (#2137) to fix issues with MAAT wrappers.
 - Moved docker files for models into model specific folder, for example Dockerfile for sipnet now is in models/sipnet/Dockerfile.
-- `PEcAn.utils`
+- `PEcAn.utils`:
   - Remove, or make "Suggests", a bunch of relatively underutilized R package dependencies.
 - Add template for documentation issues and add button to edit book.
 - Conditionally skip unit tests for downloading raw met data or querying the database when the required remote connection is not available.
 - Reorganization of docker folder
   - All dockerfiles now live in their own folder
-  - scripts/generate_dependencies.R is now used to generate dependencies for make and docker
+  - `scripts/generate_dependencies.R` is now used to generate dependencies for make and docker
 
 ### Added
-- Models will not advertise themselvs, so no need to register them a-priori with the database #2158
-- Added simple Docker container to show all containers that are available (http://localhost:8000/monitor/). This will also take care of registering the models with the BETY database.
+- Models will not advertise themselvs, so no need to register them a-priori with the database (#2158)
+- Added simple Docker container to show all containers that are available (`http://localhost:8000/monitor/`). This will also take care of registering the models with the BETY database.
 - Added unit tests for `met2model.<MODEL>` functions for most models.
 - Added MAESPA model to docker build
-- `PEcAn.DB` functions now support `RPostgres` (in addition to `RPostgreSQL`).
+- PEcAn has more robust support for `RPostgres::Postgres` backend. The backend is officially supported by `db.query`, and basic workflows run top-to-bottom with the `Postgres` backend. However, `RPostgreSQL` is still the default until we do more robust testing of all modules.
 - `PEcAn.DB::db.query` now optionally supports prepared statements (#395).
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - Added simple Docker container to show all containers that are available (http://localhost:8000/monitor/). This will also take care of registering the models with the BETY database.
 - Added unit tests for `met2model.<MODEL>` functions for most models.
 - Added MAESPA model to docker build
+- `PEcAn.DB` functions now support `RPostgres` (in addition to `RPostgreSQL`).
 
 ### Removed
 - Removed unused function `PEcAn.visualization::points2county`, thus removing many indirect dependencies by no longer importing the `earth` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - Added unit tests for `met2model.<MODEL>` functions for most models.
 - Added MAESPA model to docker build
 - `PEcAn.DB` functions now support `RPostgres` (in addition to `RPostgreSQL`).
+- `PEcAn.DB::db.query` now optionally supports prepared statements (#395).
 
 ### Removed
 - Removed unused function `PEcAn.visualization::points2county`, thus removing many indirect dependencies by no longer importing the `earth` package.

--- a/base/db/R/query.trait.data.R
+++ b/base/db/R/query.trait.data.R
@@ -269,26 +269,31 @@ rename_jags_columns <- function(data) {
 ##' @param data input data
 ##' @return dataframe with sequential treatments
 ##' @export
-##' @author David LeBauer, Carl Davidson
+##' @author David LeBauer, Carl Davidson, Alexey Shiklomanov
 assign.treatments <- function(data){
-  data$trt_id[which(data$control == 1)] <- 'control'
+  data$trt_id[which(data$control == 1)] <- "control"
   sites <- unique(data$site_id)
-  for(ss in sites){
+  # Site IDs may be returned as `integer64`, which the `for` loop
+  # type-coerces to regular integer, which turns it into gibberish.
+  # Looping over the index instead prevents this type coercion.
+  for (si in seq_along(sites)) {
+    ss <- sites[[si]]
     site.i <- data$site_id == ss
     #if only one treatment, it's control
-    if(length(unique(data$trt_id[site.i])) == 1) data$trt_id[site.i] <- 'control'
-    if(!'control' %in% data$trt_id[site.i]){
-      PEcAn.logger::logger.severe('No control treatment set for site_id:',
-                   unique(data$site_id[site.i]),
-                   'and citation id',
-                   unique(data$citation_id[site.i]),
-                   '\nplease set control treatment for this site / citation in database\n')
+    if (length(unique(data$trt_id[site.i])) == 1) data$trt_id[site.i] <- "control"
+    if (!"control" %in% data$trt_id[site.i]){
+      PEcAn.logger::logger.severe(paste0(
+        "No control treatment set for site_id ", unique(data$site_id[site.i]),
+        " and citation id ", unique(data$citation_id[site.i]), ".\n",
+        "Please set control treatment for this site / citation in database.\n"
+      ))
     }
   }
   return(data)
 }
+
 drop.columns <- function(data, columns){
-  return(data[,which(!colnames(data) %in% columns)])
+  return(data[, which(!colnames(data) %in% columns)])
 }
 ##==================================================================================================#
 

--- a/base/db/R/utils_db.R
+++ b/base/db/R/utils_db.R
@@ -113,7 +113,7 @@ db.open <- function(params) {
   if (!driver %in% c("PostgreSQL", "Postgres")) {
     PEcAn.logger::logger.severe(paste0(
       "Driver `", driver, "` is not supported. ",
-      "You must use either `RPostgreSQL` or `Postrgres`."
+      'You must use either `"PostgreSQL"` or `"Postrgres"`.'
     ))
   }
 

--- a/base/db/R/utils_db.R
+++ b/base/db/R/utils_db.R
@@ -113,7 +113,7 @@ db.open <- function(params) {
   if (!driver %in% c("PostgreSQL", "Postgres")) {
     PEcAn.logger::logger.severe(paste0(
       "Driver `", driver, "` is not supported. ",
-      'You must use either `"PostgreSQL"` or `"Postrgres"`.'
+      'You must use either `"PostgreSQL"` or `"Postgres"`.'
     ))
   }
 

--- a/base/db/R/utils_db.R
+++ b/base/db/R/utils_db.R
@@ -129,7 +129,7 @@ db.open <- function(params) {
 
   # Assign the connection a unique ID number between 0 and 1000
   id <- sample(1000, size = 1)
-  while (sum(.db.utils$connections$id == id) > 0) {
+  while (any(.db.utils$connections$id == id)) {
     id <- sample(1000, size = 1)
   }
   attr(c, "pecanid") <- id

--- a/base/db/R/utils_db.R
+++ b/base/db/R/utils_db.R
@@ -240,7 +240,9 @@ db.exists <- function(params, write = TRUE, table = NA) {
     invisible(NULL)
   })
 
-  if (!is.na(table)){
+  if (is.na(table)) {
+    result <- TRUE
+  } else {
     read.perm <- FALSE
     write.perm <- FALSE
 
@@ -321,10 +323,6 @@ db.exists <- function(params, write = TRUE, table = NA) {
     } else {
       result <- TRUE
     }
-  }
-
-  else{
-    result <- TRUE
   }
 
   invisible(result)

--- a/base/db/R/utils_db.R
+++ b/base/db/R/utils_db.R
@@ -87,18 +87,10 @@ db.query <- function(query, con = NULL, params = NULL) {
 ##' db.open(settings$database$bety)
 ##' }
 db.open <- function(params) {
-  if ("dbfiles" %in% names(params)) {
-    PEcAn.logger::logger.warn(
-      "`dbfiles` in the database driver is deprecated. Setting it to NULL."
-    )
-    params[["dbfiles"]] <- NULL
-  }
-  if ("write" %in% names(params)) {
-    PEcAn.logger::logger.warn(
-      "`write` in the database driver is deprecated. Setting it to NULL."
-    )
-    params[["write"]] <- NULL
-  }
+  # These values are used elsewhere, but are not valid arguments to
+  # DBI::dbConnect, so remove them here.
+  params[["dbfiles"]] <- NULL
+  params[["write"]] <- NULL
 
   driver <- params[["driver"]]
   params[["driver"]] <- NULL

--- a/base/db/R/utils_db.R
+++ b/base/db/R/utils_db.R
@@ -101,6 +101,7 @@ db.open <- function(params) {
   }
 
   driver <- params[["driver"]]
+  params[["driver"]] <- NULL
   if (is.null(driver)) {
     PEcAn.logger::logger.info(
       "Missing `driver` argument. ",

--- a/base/db/man/assign.treatments.Rd
+++ b/base/db/man/assign.treatments.Rd
@@ -22,5 +22,5 @@ The algorithm (incorrectly) assumes that each site has a unique set of experimen
 treatments.
 }
 \author{
-David LeBauer, Carl Davidson
+David LeBauer, Carl Davidson, Alexey Shiklomanov
 }

--- a/base/db/man/db.close.Rd
+++ b/base/db/man/db.close.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/utils_db.R
 \name{db.close}
 \alias{db.close}
-\title{Close database connection}
+\title{Generic function to close a database connection}
 \usage{
 db.close(con, showWarnings = TRUE)
 }
@@ -12,12 +12,9 @@ db.close(con, showWarnings = TRUE)
 \item{showWarnings}{logical: report possible issues with connection?}
 }
 \value{
-connection to database
+`TRUE`, invisibly (see [DBI::dbDisconnect()])
 }
 \description{
-Generic function to close a database connection
-}
-\details{
 Close a previously opened connection to a database.
 }
 \examples{

--- a/base/db/man/db.exists.Rd
+++ b/base/db/man/db.exists.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/utils_db.R
 \name{db.exists}
 \alias{db.exists}
-\title{db.exists}
+\title{Test connection to database}
 \usage{
 db.exists(params, write = TRUE, table = NA)
 }
@@ -17,9 +17,6 @@ db.exists(params, write = TRUE, table = NA)
 TRUE if database connection works; else FALSE
 }
 \description{
-Test connection to database
-}
-\details{
 Useful to only run tests that depend on database when a connection exists
 }
 \author{

--- a/base/db/man/db.open.Rd
+++ b/base/db/man/db.open.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/utils_db.R
 \name{db.open}
 \alias{db.open}
-\title{Open database connection}
+\title{Generic function to open a database connection}
 \usage{
 db.open(params)
 }
@@ -13,9 +13,6 @@ db.open(params)
 connection to database
 }
 \description{
-Generic function to open a database connection
-}
-\details{
 Create a connection to a database usign the specified parameters. If the paramters contain
 driver element it will be used as the database driver, otherwise it will use PostgreSQL.
 }

--- a/base/db/man/db.open.Rd
+++ b/base/db/man/db.open.Rd
@@ -2,19 +2,34 @@
 % Please edit documentation in R/utils_db.R
 \name{db.open}
 \alias{db.open}
-\title{Generic function to open a database connection}
+\title{Open a database connection}
 \usage{
 db.open(params)
 }
 \arguments{
-\item{params}{database connection information}
+\item{params}{Named list of database connection options. See details}
 }
 \value{
-connection to database
+Database connection object
 }
 \description{
-Create a connection to a database usign the specified parameters. If the paramters contain
-driver element it will be used as the database driver, otherwise it will use PostgreSQL.
+Create a connection to a database using the specified parameters.
+The `params` list will be passed as arguments to [DBI::dbConnect()].
+}
+\details{
+Typical arguments are as follows:
+- `driver` -- The name of the database driver. Only `"PostgreSQL"`
+and `"Postgres"` are supported. If no driver is specified, default
+to `"PostgreSQL"`.
+- `user` -- The database username. For local instances of PEcAn,
+this is usually `"bety"`.
+- `password` -- The database password. For local instances of
+PEcAn, this is usually `"bety"`.
+- `host` -- The database hostname. For local instances of PEcAn,
+this is usually `"localhost"`. Inside the PEcAn Docker stack, this
+may be `"postgres"`.
+- `port` (optional) -- The port for accessing the database. If
+omitted, this will use the PostgreSQL default (5432).
 }
 \examples{
 \dontrun{

--- a/base/db/man/db.print.connections.Rd
+++ b/base/db/man/db.print.connections.Rd
@@ -7,9 +7,6 @@
 db.print.connections()
 }
 \description{
-Debug method for db.open and db.close
-}
-\details{
 Prints the number of connections opened as well as any connections
 that have never been closes.
 }

--- a/base/db/man/db.query.Rd
+++ b/base/db/man/db.query.Rd
@@ -4,7 +4,7 @@
 \alias{db.query}
 \title{Generic function to query database}
 \usage{
-db.query(query, con = NULL, params = NULL)
+db.query(query, con = NULL, params = NULL, values = NULL)
 }
 \arguments{
 \item{query}{SQL query string}
@@ -13,6 +13,11 @@ db.query(query, con = NULL, params = NULL)
 
 \item{params}{Named list of database connection parameters. See
 `params` argument to [db.open()].}
+
+\item{values}{If using prepared statements, a list of values to
+substitute into the query. If `NULL` (default), execute the
+query directly. See this function's "Details", and documentation
+for [DBI::dbBind()].}
 }
 \value{
 data frame with query results
@@ -21,9 +26,94 @@ data frame with query results
 Given a connection and a query, will return a query as a data frame. Either con or params need
 to be specified. If both are specified it will use con.
 }
+\details{
+This function supports prepared statements, which provide a way to
+pass data into SQL queries without the risk of SQL injection
+attacks. Whenever you are tempted to do something like this:
+
+```
+db.query(paste0(
+  "SELECT * FROM table WHERE mycol = ", somevalue,
+  " AND othercol = ", othervalue
+), con = con)
+```
+
+...use a prepared query instead:
+
+```
+db.query(
+  "SELECT * FROM table WHERE mycol = $1 AND othercol = $2",
+  values = list(somevalue, othervalue),
+  con = con
+)
+```
+
+Besides preventing SQL injections, prepared statements also ensure
+that the input and target types are compatible.
+
+Prepared statements provide an efficient way to operate on
+multiple values at once. For example, the following will return
+all the models whose revision is either "git", "46", or "unk":
+
+```
+db.query(
+  "SELECT * FROM models WHERE revision = $1",
+  values = list(c("git", "46", "unk")),
+  con = con
+)
+```
+
+...and here is an example of inserting multiple values of a given
+trait for a given species:
+
+```
+db.query(
+  "INSERT INTO traits (specie_id, variable_id, mean, n) VALUES ($1, $2, $3)",
+  values = list(938, 396, c(1.7, 3.9, 4.5), 1),
+  con = con
+)
+```
+
+Note that prepared statements **can not be used to select tables
+or columns**. In other words, the following _will not work_
+because of the following placeholders, the only valid one is `$5`:
+
+```
+# This will not work!
+db.query(
+  "SELECT $1, $2 FROM $3 WHERE $4 = $5",
+  values = list("col1", "col2", "mytable", "somecolumn", "somevalue")
+)
+```
+
+Note that prepared statements **are not supported by the
+`RPostgreSQL` package**; only by the newer `RPostgres` package.
+}
 \examples{
 \dontrun{
 db.query("SELECT count(id) FROM traits;", params = settings$database$bety)
+
+# Prepared statements
+con <- db.open(settings$database$bety)
+db.query(
+  "SELECT * FROM table WHERE mycol = $1 AND othercol = $2",
+  values = list(somevalue, othervalue),
+  con = con
+)
+
+# Select multiple values at once; rbind the result
+db.query(
+  "SELECT * FROM models WHERE revision = $1",
+  values = list(c("git", "46", "unk")),
+  con = con
+)
+
+# Efficiently insert multiple values into a table
+db.query(
+  "INSERT INTO traits (specie_id, variable_id, mean, n) VALUES ($1, $2, $3, $4)",
+  values = list(938, 396, rnorm(1000), 1),
+  con = con
+)
 }
 }
 \author{

--- a/base/db/man/db.query.Rd
+++ b/base/db/man/db.query.Rd
@@ -9,9 +9,10 @@ db.query(query, con = NULL, params = NULL)
 \arguments{
 \item{query}{SQL query string}
 
-\item{con}{database connection object}
+\item{con}{Database connection object}
 
-\item{params}{database connection information}
+\item{params}{Named list of database connection parameters. See
+`params` argument to [db.open()].}
 }
 \value{
 data frame with query results
@@ -22,9 +23,9 @@ to be specified. If both are specified it will use con.
 }
 \examples{
 \dontrun{
-db.query('select count(id) from traits;', params=settings$database$bety)
+db.query("SELECT count(id) FROM traits;", params = settings$database$bety)
 }
 }
 \author{
-Rob Kooper
+Rob Kooper, Alexey Shiklomanov
 }

--- a/base/db/man/db.query.Rd
+++ b/base/db/man/db.query.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/utils_db.R
 \name{db.query}
 \alias{db.query}
-\title{Query database}
+\title{Generic function to query database}
 \usage{
 db.query(query, con = NULL, params = NULL)
 }
@@ -17,9 +17,6 @@ db.query(query, con = NULL, params = NULL)
 data frame with query results
 }
 \description{
-Generic function to query database
-}
-\details{
 Given a connection and a query, will return a query as a data frame. Either con or params need
 to be specified. If both are specified it will use con.
 }

--- a/base/db/man/db_merge_into.Rd
+++ b/base/db/man/db_merge_into.Rd
@@ -11,7 +11,7 @@ db_merge_into(values, table, con, by = NULL, drop = FALSE, ...)
 
 \item{table}{Name of target SQL table, as character}
 
-\item{con}{database connection object}
+\item{con}{Database connection object}
 
 \item{by}{Character vector of columns by which to perform merge. Defaults to all columns in `values`}
 
@@ -24,7 +24,7 @@ db_merge_into(values, table, con, by = NULL, drop = FALSE, ...)
   \item{coerce_col_class}{logical, whether or not to coerce local data columns 
 to SQL classes. Default = `TRUE.`}
   \item{drop}{logical. If `TRUE` (default), drop columns not found in SQL table.}
-  \item{con}{database connection object}
+  \item{con}{Database connection object}
 }}
 }
 \value{

--- a/base/db/man/insert_table.Rd
+++ b/base/db/man/insert_table.Rd
@@ -11,7 +11,7 @@ insert_table(values, table, con, coerce_col_class = TRUE, drop = TRUE)
 
 \item{table}{Name of target SQL table, as character}
 
-\item{con}{database connection object}
+\item{con}{Database connection object}
 
 \item{coerce_col_class}{logical, whether or not to coerce local data columns 
 to SQL classes. Default = `TRUE.`}

--- a/base/db/man/match_colnames.Rd
+++ b/base/db/man/match_colnames.Rd
@@ -11,7 +11,7 @@ match_colnames(values, table, con)
 
 \item{table}{Name of target SQL table, as character}
 
-\item{con}{database connection object}
+\item{con}{Database connection object}
 }
 \description{
 Match names of local data frame to SQL table

--- a/base/db/man/match_dbcols.Rd
+++ b/base/db/man/match_dbcols.Rd
@@ -11,7 +11,7 @@ match_dbcols(values, table, con, coerce_col_class = TRUE, drop = TRUE)
 
 \item{table}{Name of target SQL table, as character}
 
-\item{con}{database connection object}
+\item{con}{Database connection object}
 
 \item{coerce_col_class}{logical, whether or not to coerce local data columns 
 to SQL classes. Default = `TRUE.`}

--- a/modules/uncertainty/R/ensemble.R
+++ b/modules/uncertainty/R/ensemble.R
@@ -42,8 +42,8 @@ read.ensemble.output <- function(ensemble.size, pecandir, outdir, start.year, en
   ensemble.output <- list()
   for (row in rownames(ens.run.ids)) {
     run.id <- ens.run.ids[row, "id"]
-    PEcAn.logger::logger.info("reading ensemble output from run id: ", run.id)
-    
+    PEcAn.logger::logger.info("reading ensemble output from run id: ", format(run.id))
+
     for(var in seq_along(variables)){
       out.tmp <- PEcAn.utils::read.output(run.id, file.path(outdir, run.id), start.year, end.year, variables[var])
       assign(variables[var], out.tmp[[variables[var]]])
@@ -365,15 +365,15 @@ write.ensemble.configs <- function(defaults, ensemble.samples, settings, model,
       dir.create(file.path(settings$modeloutdir, run.id), recursive = TRUE)
       # write run information to disk
       cat("runtype     : ensemble\n",
-          "workflow id : ", workflow.id, "\n",
-          "ensemble id : ", ensemble.id, "\n",
+          "workflow id : ", format(workflow.id), "\n",
+          "ensemble id : ", format(ensemble.id), "\n",
           "run         : ", i, "/", settings$ensemble$size, "\n",
-          "run id      : ", run.id, "\n",
-          "pft names   : ", as.character(lapply(settings$pfts, function(x) x[['name']])), "\n",
+          "run id      : ", format(run.id), "\n",
+          "pft names   : ", as.character(lapply(settings$pfts, function(x) x[["name"]])), "\n",
           "model       : ", model, "\n",
-          "model id    : ", settings$model$id, "\n",
+          "model id    : ", format(settings$model$id), "\n",
           "site        : ", settings$run$site$name, "\n",
-          "site  id    : ", settings$run$site$id, "\n",
+          "site  id    : ", format(settings$run$site$id), "\n",
           "met data    : ", samples$met$samples[[i]], "\n",
           "start date  : ", settings$run$start.date, "\n",
           "end date    : ", settings$run$end.date, "\n",
@@ -395,8 +395,8 @@ write.ensemble.configs <- function(defaults, ensemble.samples, settings, model,
                                             run.id = run.id
       )
       )
-      cat(run.id, file = file.path(settings$rundir, "runs.txt"), sep = "\n", append = TRUE)
-      
+      cat(format(run.id), file = file.path(settings$rundir, "runs.txt"), sep = "\n", append = TRUE)
+
     }
     return(invisible(list(runs = runs, ensemble.id = ensemble.id, samples=samples)))
     #------------------------------------------------- if we already have everything ------------------        


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

(NOTE: This PR is a superset of #2317 and #2316. Those should be reviewed and merged first).

## Description
<!--- Describe your changes in detail -->
Minor tweaks that allow workflows to use the `RPostgres::Postgres` database backend. For the most part, these changes are driven by the fact that `RPostgres` returns long integer columns as the `integer64` class, which is basically a `double` with some additional attributes. This causes problems because many low-level base R functions (`for (...)`, `apply`, `cat`) will silently strip away those attributes, leaving gibberish doubles that break downstream code.

Note that this will only affect users that _explicitly_ say they want to use `Postgres` (via `<driver>Postgres</driver>`. Nothing that defaults to `PostgreSQL` has changed. However, I think it's worth moving in that direction, so once this gets merged, I would encourage folks to try testing new code against the `Postgres` backend.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using prepared statements (#2317) requires the `RPostgres` backend.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [X] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
