### PR TITLE
Small fix for prepare setting function

### DIFF
--- a/base/settings/R/site_pft_link_settings.R
+++ b/base/settings/R/site_pft_link_settings.R
@@ -36,7 +36,7 @@ site.pft.link.settings <- function(settings) {
      new.pfts <-  pft.l %>%
        purrr::discard(~.x %in% def.pfts) %>%
        purrr::map(~list(name = as.character(.x), constants = 1)) %>%
-       setNames(rep("pft", length(pft.l)))
+       setNames(rep("pft", length(.)))
      
     #add them to the list
     settings$pfts <- c(settings$pfts, new.pfts)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The conversion about this function started here :https://github.com/PecanProject/pecan/pull/2309#discussion_r263871328, which resulted a bunch of bugs. Here is a small fix for the cases that the `prepare.settings`  crashed. The error comes from the point where `purrr::discard` changes the length of `pft.l` but in the last line this was not taken that into account.


<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
