### PR TITLE
WIP: Remove echo argument to display code chunks in book

### DIFF
--- a/book_source/index.Rmd
+++ b/book_source/index.Rmd
@@ -12,7 +12,7 @@ author: "By: PEcAn Team"
 
 **Ecosystem science, policy, and management informed by the best available data and models**
 
-```{r, out.height= "50%", out.width="50%", fig.align='center'}
+```{r, echo=FALSE, out.height= "50%", out.width="50%", fig.align='center'}
 knitr::include_graphics(rep("figures/PecanLogo.png"))
 ```
 

--- a/book_source/index.Rmd
+++ b/book_source/index.Rmd
@@ -12,7 +12,7 @@ author: "By: PEcAn Team"
 
 **Ecosystem science, policy, and management informed by the best available data and models**
 
-```{r, echo=FALSE,out.height= "50%", out.width="50%", fig.align='center'}
+```{r, out.height= "50%", out.width="50%", fig.align='center'}
 knitr::include_graphics(rep("figures/PecanLogo.png"))
 ```
 

--- a/documentation/tutorials/AnalyzeOutput/modelVSdata.Rmd
+++ b/documentation/tutorials/AnalyzeOutput/modelVSdata.Rmd
@@ -34,7 +34,7 @@ Within both the run and out folders there will be one folder for each unique mod
 ## Read in settings From an XML file
 
 
-```{r,eval=FALSE}
+```{r, eval=FALSE, echo=TRUE}
 ## Read in the xml
 
 settings<-PEcAn.settings::read.settings("~/output/PEcAn_99000000001/pecan.CONFIGS.xml")
@@ -65,7 +65,7 @@ The arguments to read.output are the run ID, the folder where the run is located
 
 **First** _load up the observations_ and take a look at the contents of the file
 
-```{r,  eval=FALSE}
+```{r,  eval=FALSE, echo=TRUE}
 File_format<-PEcAn.DB::query.format.vars(bety = bety, format.id = 5000000002) #This matches the file with a premade "format" or a template that describes how the information in the file is organized
 
 site<-PEcAn.DB::query.site(site.id,bety$con) #This tells PEcAn where the data comes from
@@ -81,13 +81,13 @@ You could query for diffent kinds of formats that exist in bety or [make your ow
 Here 772 is the database site ID for Niwot Ridge Forest, which tells pecan where the data is from and what time zone to assign any time data read in. 
 
 **Second** _apply a conservative u* filter to observations_
-```{r,eval=FALSE}
+```{r, eval=FALSE, echo=TRUE}
 observations$NEE[observations$UST<0.2]<-NA
 ```
 
 **Third** _align model output and observations_
 
-```{r, eval=FALSE}
+```{r, eval=FALSE, echo=TRUE}
 aligned_dat = PEcAn.benchmark::align_data(model.calc = model, obvs.calc = observations, var ="NEE", align_method = "match_timestep")
 
 ```
@@ -95,7 +95,7 @@ When we aligned the data, we got a dataframe with the variables we requested in 
 
 **Fourth**, _plot model predictions vs. observations_ and compare this to a 1:1 line 
 
-```{r,eval=FALSE}
+```{r,eval=FALSE, echo=TRUE}
 ## predicted vs observed plot
 plot(aligned_dat$NEE.m, aligned_dat$NEE.o)
 abline(0,1,col="red")  ## intercept=0, slope=1
@@ -103,14 +103,14 @@ abline(0,1,col="red")  ## intercept=0, slope=1
 
 **Fifth**, _calculate the Root Mean Square Error (RMSE)_ between the model and the data
 
-```{r, eval=FALSE}
+```{r, eval=FALSE, echo=TRUE}
 rmse = sqrt(mean((aligned_dat$NEE.m-aligned_dat$NEE.o)^2,na.rm = TRUE))
 ```
 *na.rm* makes sure we don’t include missing or screened values in either time series.
 
 **Finally**, _plot time-series_ of both the model and data together
 
-```{r, eval=FALSE}
+```{r, eval=FALSE, echo=TRUE}
 ## plot aligned data
 plot(aligned_dat$posix, aligned_dat$NEE.o, type="l")
 lines(aligned_dat$posix,aligned_dat$NEE.m, col = "red")
@@ -123,7 +123,7 @@ Try RMSE against monthly NEE instead of half-hourly. In this case, first average
 
 **NOTE**: Align_data uses two seperate alignment function, match_timestep and mean_over_larger_timestep. Match_timestep will use only that data that is present in both the model and the observation. This is helpful for sparse observations. Mean_over_larger_timestep aggregates the values over the largest timestep present. If you were to look at averaged monthly data, you would use mean_over_larger_timestep.
 
-```{r, eval = FALSE}
+```{r, eval = FALSE, echo=TRUE}
 monthlyNEEobs<-aggregate(observations, by= list(month(observations$posix)), simplify=TRUE, FUN =mean, na.rm= TRUE)
 plottable<-align_data(model.calc = model, obvs.calc = monthlyNEEobs, align_method = "mean_over_larger_timestep", var= "NEE")
 head(plottable)


### PR DESCRIPTION
I'm not sure if this works because I can't build the book locally, so someone should test this. 

## Description
In the PEcAn book, chunks of R code don't show up. For example, [section 42.1 in the develop version](https://pecanproject.github.io/pecan-documentation/develop/data-assimilation-concepts.html#fitting-the-model) of the book should show code for setting up, plotting, and modeling data with the photosynthesis model. 

## Motivation and Context
Users need to be able to see the relevant code in order to understand/replicate the instructions in the book. See #2243 

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) #2243 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
