### PR TITLE
UTILS: Refactor `read_web_config` and add unit test

### DIFF
--- a/base/utils/R/read_web_config.R
+++ b/base/utils/R/read_web_config.R
@@ -1,45 +1,52 @@
-#' read_web_config
+#' Read `config.php` file into an R list 
 #'
-#' @author Michael Dietze and Rob Kooper
-#' @param php.config Path to `config.php`
-#'
-#' @return config.list
+#' @author Alexey Shiklomanov, Michael Dietze, Rob Kooper
+#' @param php.config Path to `config.php` file
+#' @param parse Logical. If `TRUE` (default), try to parse numbers and
+#'   unquote strings.
+#' @param expand Logical. If `TRUE` (default), try to perform some
+#'   variable substitutions. 
+#' @return Named list of variable-value pairs set in `config.php`
 #' @export
-#'
-#'
-read_web_config = function(php.config = "../../web/config.php") {
+#' @examples
+#' # Read Docker configuration and extract the `dbfiles` and output folders.
+#' docker_config <- read_web_config(file.path("..", "..", "docker", "web", "config.docker.php"))
+#' docker_config[["dbfiles_folder"]]
+#' docker_config[["output_folder"]]
+read_web_config <- function(php.config = "../../web/config.php",
+                            parse = TRUE,
+                            expand = TRUE) {
 
-  ## Read PHP config file for webserver
-  config <- scan(php.config, what = "character", sep = "\n")
+  config <- readLines(php.config)
   config <- config[grep("^\\$", config)]  ## find lines that begin with $ (variables)
 
-  ## replacements
-  config <- gsub("^\\$", "", config)  ## remove leading $
-  config <- gsub(";.*$", "", config)  ## remove ; and everything afterwards
-  config <- sub("false", "FALSE", config, fixed = TRUE)  ##  Boolean capitalization
-  config <- sub("true", "TRUE", config, fixed = TRUE)  ##  Boolean capitalization
-  config <- gsub(pattern = "DIRECTORY_SEPARATOR",replacement = "/",config)
+  rxp <- paste0("^\\$([[:graph:]]+?)[[:space:]]*",
+                "=[[:space:]]*(.*?);?(?:[[:space:]]*//+.*)?$")
+  rxp_matches <- regexec(rxp, config, perl = TRUE)
+  results <- regmatches(config, rxp_matches)
+  list_names <- vapply(results, `[[`, character(1), 2, USE.NAMES = FALSE)
+  config_list <- lapply(results, `[[`, 3)
+  names(config_list) <- list_names
 
-  ## subsetting
-  config <- config[!grepl("exec", config, fixed = TRUE)]  ## lines 'exec' fail
-  config <- config[!grepl("dirname", config, fixed = TRUE)]  ## lines 'dirname' fail
-  config <- config[!grepl("array", config, fixed = TRUE)]  ## lines 'array' fail
+  # Convert to numeric if possible
+  if (parse) {
+    # Remove surrounding quotes
+    config_list <- lapply(config_list, gsub,
+                          pattern = "\"(.*?)\"", replacement = "\\1")
 
-  ##references
-  ref <- grep("$", config, fixed = TRUE)
-  if(length(ref) > 0){
-    refsplit = strsplit(config[ref],split = " . ",fixed=TRUE)[[1]]
-    refsplit = sub(pattern = '\"',replacement = "",x = refsplit)
-    refsplit = sub(pattern = '$',replacement = '\"',refsplit,fixed=TRUE)
-    config[ref] <- paste0(refsplit,collapse = "")  ## lines with variable references fail
+    # Try to convert numbers to numeric
+    config_list <- lapply(
+      config_list,
+      function(x) tryCatch(as.numeric(x), warning = function(e) x)
+    )
   }
 
-  ## convert to list
-  config.list <- eval(parse(text = paste("list(", paste0(config, collapse = ","), ")")))
+  if (expand) {
+    # Replace $output_folder with its value, and concatenate strings
+    config_list <- lapply(config_list, gsub,
+                          pattern = "\\$output_folder *\\. *",
+                          replacement = config_list[["output_folder"]])
+  }
 
-  ## replacements
-  config.list <- lapply(X = config.list,FUN = sub,pattern="output_folder",replacement=config.list$output_folder,fixed=TRUE)
-
-  return(config.list)
+  config_list
 }
-

--- a/base/utils/R/read_web_config.R
+++ b/base/utils/R/read_web_config.R
@@ -9,10 +9,12 @@
 #' @return Named list of variable-value pairs set in `config.php`
 #' @export
 #' @examples
-#' # Read Docker configuration and extract the `dbfiles` and output folders.
-#' docker_config <- read_web_config(file.path("..", "..", "docker", "web", "config.docker.php"))
+#' # Read Docker configuration and extract the `dbfiles` and output folders
+#' \dontrun{
+#' docker_config <- read_web_config("/home/carya/web/config.php")
 #' docker_config[["dbfiles_folder"]]
 #' docker_config[["output_folder"]]
+#' }
 read_web_config <- function(php.config = "../../web/config.php",
                             parse = TRUE,
                             expand = TRUE) {

--- a/base/utils/man/read_web_config.Rd
+++ b/base/utils/man/read_web_config.Rd
@@ -14,7 +14,7 @@ read_web_config(php.config = "../../web/config.php", parse = TRUE,
 unquote strings.}
 
 \item{expand}{Logical. If \code{TRUE} (default), try to perform some
-variable substitutions.}
+variable substitutions (only done if parse = TRUE).}
 }
 \value{
 Named list of variable-value pairs set in \code{config.php}
@@ -23,10 +23,12 @@ Named list of variable-value pairs set in \code{config.php}
 Read \code{config.php} file into an R list
 }
 \examples{
-# Read Docker configuration and extract the `dbfiles` and output folders.
-docker_config <- read_web_config(file.path("..", "..", "docker", "web", "config.docker.php"))
+# Read Docker configuration and extract the `dbfiles` and output folders
+\dontrun{
+docker_config <- read_web_config("/home/carya/web/config.php")
 docker_config[["dbfiles_folder"]]
 docker_config[["output_folder"]]
+}
 }
 \author{
 Alexey Shiklomanov, Michael Dietze, Rob Kooper

--- a/base/utils/man/read_web_config.Rd
+++ b/base/utils/man/read_web_config.Rd
@@ -2,19 +2,32 @@
 % Please edit documentation in R/read_web_config.R
 \name{read_web_config}
 \alias{read_web_config}
-\title{read_web_config}
+\title{Read \code{config.php} file into an R list}
 \usage{
-read_web_config(php.config = "../../web/config.php")
+read_web_config(php.config = "../../web/config.php", parse = TRUE,
+  expand = TRUE)
 }
 \arguments{
-\item{php.config}{Path to \code{config.php}}
+\item{php.config}{Path to \code{config.php} file}
+
+\item{parse}{Logical. If \code{TRUE} (default), try to parse numbers and
+unquote strings.}
+
+\item{expand}{Logical. If \code{TRUE} (default), try to perform some
+variable substitutions.}
 }
 \value{
-config.list
+Named list of variable-value pairs set in \code{config.php}
 }
 \description{
-read_web_config
+Read \code{config.php} file into an R list
+}
+\examples{
+# Read Docker configuration and extract the `dbfiles` and output folders.
+docker_config <- read_web_config(file.path("..", "..", "docker", "web", "config.docker.php"))
+docker_config[["dbfiles_folder"]]
+docker_config[["output_folder"]]
 }
 \author{
-Michael Dietze and Rob Kooper
+Alexey Shiklomanov, Michael Dietze, Rob Kooper
 }

--- a/base/utils/tests/testthat/test.read_web_config.R
+++ b/base/utils/tests/testthat/test.read_web_config.R
@@ -1,0 +1,19 @@
+context("Read web config")
+
+# `here` package needed to correctly set path relative to package
+skip_if_not_installed("here")
+pecan_root <- normalizePath(here::here("..", ".."))
+
+test_that("Read example config file", {
+  php_config_example <- file.path(pecan_root, "web", "config.example.php")
+  cfg_example <- read_web_config(php_config_example)
+  expect_equal(cfg_example[["output_folder"]], "/home/carya/output/")
+  expect_equal(cfg_example[["dbfiles_folder"]], "/home/carya/output//dbfiles")
+})
+
+test_that("Read docker config file", {
+  php_config_docker <- file.path(pecan_root, "docker", "web", "config.docker.php")
+  cfg_docker <- read_web_config(php_config_docker)
+  expect_equal(cfg_docker[["output_folder"]], "/data/workflows")
+  expect_equal(cfg_docker[["dbfiles_folder"]], "/data/dbfiles")
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Make `PEcAn.utils::read_web_config` more robust and safe by using regular expressions and setting names directly, rather than using the highly unsafe and unreliable `eval(parse(...))` structure. Also, give it a unit test.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previous code was failing to parse the default Docker config file. More generally, since we use this function in our Shiny apps, @tonygardella's batch test script, and possibly other places, I figured it was worth cleaning up.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [X] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
