### PR TITLE
Use Xenial for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ cache:
 addons:
   apt:
     sources:
-      - sourceline: 'ppa:nschloe/hdf5-backports'
       - sourceline: 'ppa:ubuntugis/ppa' # for GDAL 2 binaries
     packages:
       - bc

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ r:
   - devel
   - oldrel
 
+dist: xenial
 sudo: required
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,12 @@
 # Follow instructions on:
 # https://blog.rstudio.org/2016/03/09/r-on-travis-ci/
 
-# A few blocks in here can be removed when Travis updates its Ubuntu image past 
-# trusty. They are marked with TRUSTY for easy grepping.
-
 language: r
 r:
   - release
   - devel
   - oldrel
 
-# TRUSTY: Change version when 16.04 image is available.
-dist: trusty
 sudo: required
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ addons:
       - jags
       - libcurl4-openssl-dev
       - libgdal-dev
+      - libgl1-mesa-dev
       - libgmp-dev
       - libhdf5-dev
       - liblapack-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ addons:
       - libcurl4-openssl-dev
       - libgdal-dev
       - libgl1-mesa-dev
+      - libglu1-mesa-dev
       - libgmp-dev
       - libhdf5-dev
       - liblapack-dev


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description

* Specify Ubuntu 16 (Xenial) for Travis build container (was 14 AKA Trusty)
* Install openGL headers (previously provided by default), 
* Drop hdf5-backports PPA (was only needed because Trusty)

## Motivation and Context

After long delay, Travis CI now supports using Ubuntu 16 instead of the now-EOL Ubuntu 14. This is a good thing and we should take advantage of it, to keep our testing platform at least vaguely in the same generation as the OSes on which PEcAn is actually used.


## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Build update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 