### PR TITLE
DB: Correctly format PFT ID in query.priors

### DIFF
--- a/base/db/R/get.trait.data.R
+++ b/base/db/R/get.trait.data.R
@@ -323,7 +323,7 @@ get.trait.data.pft <- function(pft, modeltype, dbfiles, dbcon, trait.names,
   PEcAn.logger::logger.debug(
     "The following posterior files found in PFT outdir ",
     "(", shQuote(pft[["outdir"]]), ") will be registered in BETY ",
-    "under posterior ID ", format(pft[["posteriorid"]]), ": ",
+    "under posterior ID ", format(pft[["posteriorid"]], scientific = FALSE), ": ",
     paste(shQuote(store_files), collapse = ", "), ". ",
     "The following files (if any) will not be registered because they already existed: ",
     paste(shQuote(intersect(store_files, old.files)), collapse = ", "),
@@ -388,7 +388,7 @@ get.trait.data <- function(pfts, modeltype, dbfiles, database, forceupdate,
     # to double by `lapply`. This works fine if we switch to
     # `query_priors`, but haven't done so yet because that requires
     # prepared statements and therefore requires the Postgres driver. 
-    all_priors_list <- lapply(format(pft_ids), query.priors,
+    all_priors_list <- lapply(format(pft_ids, scientific = FALSE), query.priors,
                               con = dbcon, trstr = trait.names)
     trait.names <- unique(unlist(lapply(all_priors_list, rownames)))
     # Eventually, can replace with this:

--- a/base/db/R/query.prior.R
+++ b/base/db/R/query.prior.R
@@ -35,7 +35,7 @@ query.priors <- function(pft, trstr = NULL, con = NULL, ...){
 
   if (inherits(pft, "integer64")) {
     # Convert to character with correct representation
-    pft <- format(pft)
+    pft <- format(pft, scientific = FALSE)
   }
   
   if (is.null(con)) {
@@ -62,7 +62,7 @@ query.priors <- function(pft, trstr = NULL, con = NULL, ...){
       "JOIN variables ON priors.variable_id = variables.id",
       "JOIN pfts_priors ON pfts_priors.prior_id = priors.id",
       "JOIN pfts ON pfts.id = pfts_priors.pft_id",
-      "WHERE pfts.id = ", format(pft))
+      "WHERE pfts.id = ", format(pft, scientific = FALSE))
 
   if (!is.null(trstr) && trstr != "''") {
     if (length(trstr) > 1) {

--- a/base/remote/R/stamp.R
+++ b/base/remote/R/stamp.R
@@ -7,7 +7,7 @@
 #' @export
 stamp_started <- function(con, run) {
   if (!is.null(con)) {
-    run_id_string <- format(run, scientific = TRUE)
+    run_id_string <- format(run, scientific = FALSE)
     db.query(query = paste("UPDATE runs SET started_at = NOW() WHERE id = ", run_id_string), con = con)
   } else {
     PEcAn.logger::logger.debug("Connection is null. Not actually writing timestamps to database")
@@ -18,7 +18,7 @@ stamp_started <- function(con, run) {
 #' @export
 stamp_finished <- function(con, run) {
   if (!is.null(con)) {
-    run_id_string <- format(run, scientific = TRUE)
+    run_id_string <- format(run, scientific = FALSE)
     db.query(query = paste("UPDATE runs SET finished_at = NOW() WHERE id = ", run_id_string), con = con)
   } else {
     PEcAn.logger::logger.debug("Connection is null. Not actually writing timestamps to database")

--- a/modules/uncertainty/R/ensemble.R
+++ b/modules/uncertainty/R/ensemble.R
@@ -42,7 +42,7 @@ read.ensemble.output <- function(ensemble.size, pecandir, outdir, start.year, en
   ensemble.output <- list()
   for (row in rownames(ens.run.ids)) {
     run.id <- ens.run.ids[row, "id"]
-    PEcAn.logger::logger.info("reading ensemble output from run id: ", format(run.id))
+    PEcAn.logger::logger.info("reading ensemble output from run id: ", format(run.id, scientific = FALSE))
 
     for(var in seq_along(variables)){
       out.tmp <- PEcAn.utils::read.output(run.id, file.path(outdir, run.id), start.year, end.year, variables[var])
@@ -365,15 +365,15 @@ write.ensemble.configs <- function(defaults, ensemble.samples, settings, model,
       dir.create(file.path(settings$modeloutdir, run.id), recursive = TRUE)
       # write run information to disk
       cat("runtype     : ensemble\n",
-          "workflow id : ", format(workflow.id), "\n",
-          "ensemble id : ", format(ensemble.id), "\n",
+          "workflow id : ", format(workflow.id, scientific = FALSE), "\n",
+          "ensemble id : ", format(ensemble.id, scientific = FALSE), "\n",
           "run         : ", i, "/", settings$ensemble$size, "\n",
-          "run id      : ", format(run.id), "\n",
+          "run id      : ", format(run.id, scientific = FALSE), "\n",
           "pft names   : ", as.character(lapply(settings$pfts, function(x) x[["name"]])), "\n",
           "model       : ", model, "\n",
-          "model id    : ", format(settings$model$id), "\n",
+          "model id    : ", format(settings$model$id, scientific = FALSE), "\n",
           "site        : ", settings$run$site$name, "\n",
-          "site  id    : ", format(settings$run$site$id), "\n",
+          "site  id    : ", format(settings$run$site$id, scientific = FALSE), "\n",
           "met data    : ", samples$met$samples[[i]], "\n",
           "start date  : ", settings$run$start.date, "\n",
           "end date    : ", settings$run$end.date, "\n",
@@ -397,7 +397,7 @@ write.ensemble.configs <- function(defaults, ensemble.samples, settings, model,
                                             run.id = run.id
       )
       )
-      cat(format(run.id), file = file.path(settings$rundir, "runs.txt"), sep = "\n", append = TRUE)
+      cat(format(run.id, scientific = FALSE), file = file.path(settings$rundir, "runs.txt"), sep = "\n", append = TRUE)
 
     }
     return(invisible(list(runs = runs, ensemble.id = ensemble.id, samples=samples)))


### PR DESCRIPTION
Fixes a bug reported by @istfer. Without `scientific = FALSE`, `format(<long integer>)` uses scientific notation, which fails in the SQL query.