### PR TITLE
LINKAGES pecan misc. met conversion fixes

### DIFF
--- a/models/linkages/R/met2model.LINKAGES.R
+++ b/models/linkages/R/met2model.LINKAGES.R
@@ -29,6 +29,11 @@ met2model.LINKAGES <- function(in.path, in.prefix, outfolder, start_date, end_da
   out.file <- file.path(outfolder, "climate.Rdata")
   # out.file <- file.path(outfolder, paste(in.prefix, strptime(start_date, '%Y-%m-%d'),
   # strptime(end_date, '%Y-%m-%d'), 'dat', sep='.'))
+  
+  # get start/end year since inputs are specified on year basis
+  # use years to check if met data contains all of the necessary years 
+  start_year <- lubridate::year(start_date)
+  end_year <- lubridate::year(end_date)
 
   results <- data.frame(file = c(out.file),
                         host = c(PEcAn.remote::fqdn()),
@@ -42,8 +47,17 @@ met2model.LINKAGES <- function(in.path, in.prefix, outfolder, start_date, end_da
   print(results)
 
   if (file.exists(out.file) && !overwrite) {
-    PEcAn.logger::logger.debug("File '", out.file, "' already exists, skipping to next file.")
-    return(invisible(results))
+    
+    # get year span for current data file
+    load(out.file)
+    data_start = min(rownames(temp.mat))
+    data_end = max(rownames(temp.mat))
+    
+    # check to see if needed years fall into the current data year span; if not, rewrite
+    if ((data_start <= start_year) & (data_end >= end_year)){
+      PEcAn.logger::logger.debug("File '", out.file, "' already exists, skipping to next file.")
+      return(invisible(results))
+    }
   }
 
   library(PEcAn.data.atmosphere)
@@ -55,18 +69,13 @@ met2model.LINKAGES <- function(in.path, in.prefix, outfolder, start_date, end_da
 
   out <- NULL
 
-  # get start/end year since inputs are specified on year basis
-  start_year <- lubridate::year(start_date)
-  end_year <- lubridate::year(end_date)
-
   year <- sprintf("%04d", seq(start_year, end_year, 1))
   month <- sprintf("%02d", seq(1, 12, 1))
 
   nyear <- length(year)  # number of years to simulate
 
   month_matrix_precip <- matrix(NA, nyear, 12)
-  DOY_vec_hr <- c(1, c(32, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 365) * 24)
-
+  
   if(nchar(in.prefix)>0 & substr(in.prefix,nchar(in.prefix),nchar(in.prefix)) != ".") in.prefix = paste0(in.prefix,".")
 
   for (i in seq_len(nyear)) {
@@ -79,6 +88,10 @@ met2model.LINKAGES <- function(in.path, in.prefix, outfolder, start_date, end_da
     sec <- udunits2::ud.convert(sec, unlist(strsplit(ncin$dim$time$units, " "))[1], "seconds")
     dt <- PEcAn.utils::seconds_in_year(as.numeric(year[i])) / length(sec)
     tstep <- 86400 / dt
+    
+    # adjust vector depending on the time step of data 
+    # assumes evenly-spaced measurements
+    DOY_vec_hr <- c(1, c(32, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 365) * as.integer(tstep))
 
     ncprecipf <- ncdf4::ncvar_get(ncin, "precipitation_flux")  # units are kg m-2 s-1
     for (m in 1:12) {

--- a/models/linkages/R/write.config.LINKAGES.R
+++ b/models/linkages/R/write.config.LINKAGES.R
@@ -104,8 +104,8 @@ write.config.LINKAGES <- function(defaults = NULL, trait.values, settings, run.i
     load(climate_file) 
   }
   
-  temp.mat <- temp.mat[which(rownames(temp.mat)%in%start.year:end.year),]
-  precip.mat <- precip.mat[which(rownames(precip.mat)%in%start.year:end.year),]
+  temp.mat <- matrix(temp.mat[which(rownames(temp.mat)%in%start.year:end.year),])
+  precip.mat <- matrix(precip.mat[which(rownames(precip.mat)%in%start.year:end.year),])
   
   basesc <- 74
   basesn <- 1.64


### PR DESCRIPTION
I adjusted two different scripts to fix three different issues identified in converting met for the LINKAGES model. 

In **met2model.LINKAGES**, when the script checks to see if there is already met input files extracted of the same type of met for the same site (lines 44-46), I added a check to make sure that the input file contains the required years for the current model run. If it does not include the years needed, it will overwrite the file so that it does. 

In that same script, I also adjusted how the script determines which data values are included in the monthly temperature and precipitation summations (lines 68-90, changed variable DOY_vec_hr). Instead of assuming the values are hourly, the script determines how frequently measurements are taken annually and uses that information to determine how many measurements should be summed for each month. My adjustment assumes the measurements are evenly spaced. 

Finally, in the **write.config.LINKAGES script**, I made a simple adjustment to how the temperature and precipitation storage matrices are created (lines 107-108). This ensures the matrices are two-dimensional (expected by linkages model) even if only one year of data is given. 

Thank you! Let me know if there is other information I should be including in these requests. 

Marissa
