### PR TITLE
Travis: Rebuild packages as needed on R 3.5

### DIFF
--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -3,6 +3,15 @@
 set -e
 . $( dirname $0 )/func.sh
 
+# FIXING R BINARIES
+(
+    travis_time_start "pkg_version_check" "Checking R package binaries"
+
+    Rscript scripts/travis/rebuild_pkg_binaries.R
+
+    travis_time_end
+)
+
 # INSTALLING SIPNET
 (
     travis_time_start "install_sipnet" "Installing SIPNET for testing"

--- a/scripts/travis/rebuild_pkg_binaries.R
+++ b/scripts/travis/rebuild_pkg_binaries.R
@@ -1,0 +1,35 @@
+#!/usr/bin/env Rscript
+
+# ¡ugly hack!
+#
+# Travis setup uses many prebuilt R packages from c2d4u3.5, which despite its
+# name now contains some packages that were built for R 3.6. When loaded in
+# R 3.5.x, these throw error `rbind(info, getNamespaceInfo(env, "S3methods")):
+# number of columns of matrices must match`.
+#
+# We resolve this the slow brute-force way: By running this script before
+# attempting to load any R packages, thereby reinstalling from source any
+# package whose binary was built with R >= 3.6.
+#
+# In principle it's *always* unsafe to use a package built for a different R
+# version, so it might be safest to rebuild any binary that fails the
+# wrong_build test. But rebuilding is slooow and *probably* only needed for
+# this special case, so we only do this check if run with R < 3.6.
+#
+# TODO: Remove this when c2d4u situation improves or we drop support for R 3.5.
+
+if (getRversion() < "3.6") {
+  wrong_build <- function(pkgname) {
+    # Typical packageDescription(pkgname)$Built result:
+    # "R 3.4.4; x86_64-apple-darwin15.6.0; 2019-03-18 04:41:51 UTC; unix"
+    build_ver <- substr(packageDescription(pkgname)$Built, start = 3, stop = 7)
+    build_ver > getRversion()
+  }
+  all_pkgs <- installed.packages()[,1]
+  needs_rebuild <- vapply(all_pkgs, wrong_build, logical(1))
+
+  if (any(needs_rebuild)) {
+    print("Found R packages that were built for a later R version. Reinstalling these from source.")
+    install.packages(all_pkgs[needs_rebuild], repos = "cloud.r-project.org", dependencies = FALSE)
+  }
+}


### PR DESCRIPTION
## Description
Avoids Travis failures on R-oldrel by checking the build information on all binary-installed R packages before attempting to load them, and rebuilding from source any that were built for a later R version than is currently running.

## Motivation and Context
All our Travis builds on R-oldrel (currently R 3.5) are failing with this cryptic error: 

```
Error in rbind(info, getNamespaceInfo(env, "S3methods")) : 
number of columns of matrices must match (see arg 2)
Calls: :: ... tryCatch -> tryCatchList -> tryCatchOne -> <Anonymous>
```

The exact cause is kind of tedious...
<details>
 The process of loading an installed R package involves reading namespace its namespace info and adding all declared S3 methods to an internal table... and that table is apparently a 3-column matrix in R 3.5 and a four-column matrix in R 3.6.

Turns out that for reasons I don't understand, the `c2d4u3.5` package archive, despite its name, [now contains](https://twitter.com/marutterstat/status/1147478689904562176) a mix of packages built with R 3.5 and R 3.6. When we try to load a package built with R 3.6 into an R 3.5 session, the S3 method list has too many columns and the error happens.
</details>

...but [basically](https://stat.ethz.ch/pipermail/r-devel/2019-February/077298.html) when you see this message you should think "broken package that needs to be reinstalled." So that's what I do here: Immediately after apt finishes installing prebuilt R package binaries and before trying to load any of them, we check the "Built" field of their package descriptions and if any were built in a later version of R than is currently running, we suck it up and rebuild them. This is very slow the first time but they stay in the Travis cache for future builds.

Note that in *theory* it's unsafe to load any R package into a session with a different version than the one it was built for, but in practice we can often get away from it (note that I claimed c2d4u still contains some packages built for R 3.5, but the R 3.6 build doesn't seem to be having any trouble with them) and rebuilding packages is very slow, so for the moment I've implemented this check to only run when `getRversion()` is less than 3.6.

## N.B.
<del>This PR is built on top of the changes from #2400; please merge that before this one.</del><ins>Done!</ins>


## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
