### PR TITLE
Return error message if no meta-analysis posterior exists

### DIFF
--- a/base/db/R/get.trait.data.R
+++ b/base/db/R/get.trait.data.R
@@ -111,11 +111,18 @@ get.trait.data.pft <- function(pft, modeltype, dbfiles, dbcon, trait.names,
   # check to see if we need to update
   if (!forceupdate) {
     if (is.null(pft$posteriorid)) {
-      pft$posteriorid <- dplyr::tbl(dbcon, "posteriors") %>%
-        dplyr::filter(pft_id == !!pftid) %>%
-        dplyr::arrange(dplyr::desc(created_at)) %>%
-        head(1) %>%
-        dplyr::pull(id)
+      recent_posterior <- dplyr::tbl(dbcon, "posteriors") %>%
+        dplyr::filter(pft_id == !!pftid) %>% 
+        dplyr::collect()
+      if (length(recent_posterior) > 0) {
+        pft$posteriorid <- dplyr::tbl(dbcon, "posteriors") %>%
+          dplyr::filter(pft_id == !!pftid) %>%
+          dplyr::arrange(dplyr::desc(created_at)) %>%
+          head(1) %>%
+          dplyr::pull(id)
+      } else {
+        PEcAn.logger::logger.info("No previous posterior found. Forcing update")
+      } 
     }
     if (!is.null(pft$posteriorid)) {
       files <- dbfile.check(type = "Posterior", container.id = pft$posteriorid, con = dbcon,


### PR DESCRIPTION
When pulling trait data from the database, we ran into the following error: 
```[PEcAn.DB::get.trait.data] : 
   `trait.names` is NULL, so retrieving all traits that have at least one 
   prior for these PFTs. 
Error in .subset2(x, i) : subscript out of bounds
```

This occurred because we were using a new PFT that had no data associated with it, so the meta-analysis didn't produce any posteriors. 

## Description
Changed `get.trait.data.pft` so that, if the posterior table has no rows, it returns a message ("No previous posterior found. Forcing update") instead of an error due to an empty table. 

## Motivation and Context
Though it probably won't be common for people to run new PFTs with no data, it's possible for it to happen like it did in our case and there's no reason for it to disrupt the workflow. 

## Review Time Estimate

- [ ] Immediately
- [x] Within one week
- [ ] When possible
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I need help with making sure this is the best way to check if there are posteriors (lines 114-116) and with writing the test for this part of the function. 