### PR TITLE
Update symmetric_setdiff.R

### DIFF
--- a/base/db/R/symmetric_setdiff.R
+++ b/base/db/R/symmetric_setdiff.R
@@ -53,7 +53,7 @@ symmetric_setdiff <- function(x, y, xname = "x", yname = "y",
   }
   if (simplify_types) {
     x <- dplyr::mutate_if(x, ~!is.numeric(.), as.character)
-    y <- dplyr::mutate_if(x, ~!is.numeric(.), as.character)
+    y <- dplyr::mutate_if(y, ~!is.numeric(.), as.character)
   }
   namecol <- dplyr::sym(namecol)
   xy <- dplyr::setdiff(x, y) %>%


### PR DESCRIPTION
Typo found. Now this function will actually find the differences between data frames because it won't set them equal to each other!