### PR TITLE
ED2: Add minimum_height to convert.samples

### DIFF
--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -56,6 +56,10 @@ convert.samples.ED <- function(trait.samples) {
     # model version compatibility (rrr and rrf are the same)
     trait.samples[["root_respiration_factor"]] <- trait.samples[["root_respiration_rate"]]
   }
+
+  if ("minimum_height" %in% names(trait.samples)) {
+    trait.samples[["repro_min_h"]] <- trait.samples[["minimum_height"]]
+  }
   
   if ("Vcmax" %in% names(trait.samples)) {
     vcmax <- as.numeric(trait.samples[["Vcmax"]])


### PR DESCRIPTION
Currently, the trait `minimum_height` will silently go unused by ED2. This converts the BETY trait `minimum_height` to the ED2 variable `repro_min_h`.

https://github.com/edmodel/ed2/blob/master/ED/src/io/ed_xml_config.f90#L663