### PR TITLE
Adding the posterior files tag

### DIFF
--- a/base/workflow/DESCRIPTION
+++ b/base/workflow/DESCRIPTION
@@ -33,6 +33,7 @@ Imports:
 	PEcAn.settings,
 	PEcAn.uncertainty,
 	PEcAn.utils,
+	purrr (>= 0.2.3),
 	XML
 Suggests:
 	testthat,

--- a/base/workflow/R/run.write.configs.R
+++ b/base/workflow/R/run.write.configs.R
@@ -26,8 +26,6 @@ run.write.configs <- function(settings, write = TRUE, ens.sample.method = "unifo
                               posterior.files = rep(NA, length(settings$pfts)), 
                               overwrite = TRUE) {
   
-
-  
   ## Which posterior to use?
   for (i in seq_along(settings$pfts)) {
     ## if posterior.files is specified us that
@@ -43,7 +41,7 @@ run.write.configs <- function(settings, write = TRUE, ens.sample.method = "unifo
             "Connection requested, but failed to open with the following error: ",
             conditionMessage(e))
         })
-          
+  
         files <- PEcAn.DB::dbfile.check("Posterior",
                               settings$pfts[[i]]$posteriorid, 
                               con, settings$host$name, return.all = TRUE)
@@ -63,6 +61,7 @@ run.write.configs <- function(settings, write = TRUE, ens.sample.method = "unifo
   model <- settings$model$type
   scipen <- getOption("scipen")
   options(scipen = 12)
+
   PEcAn.uncertainty::get.parameter.samples(settings, posterior.files, ens.sample.method)
   load(file.path(settings$outdir, "samples.Rdata"))
   

--- a/base/workflow/R/runModule.run.write.configs.R
+++ b/base/workflow/R/runModule.run.write.configs.R
@@ -17,7 +17,17 @@ runModule.run.write.configs <- function(settings, overwrite = TRUE) {
     # double check making sure we have method for parameter sampling
     if (is.null(settings$ensemble$samplingspace$parameters$method)) settings$ensemble$samplingspace$parameters$method <- "uniform"
     ens.sample.method <-  settings$ensemble$samplingspace$parameters$method
-    return(PEcAn.workflow::run.write.configs(settings, write, ens.sample.method, overwrite = overwrite))
+    
+   
+    #check to see if there are posterior.files tags under pft
+    posterior.files.vec<-settings$pfts %>%
+      purrr::map(purrr::possibly('posterior.files', NA_character_)) %>%
+      purrr::modify_depth(1, function(x) {
+        ifelse(is.null(x), NA_character_, x)
+      }) %>%
+      unlist()
+    
+    return(PEcAn.workflow::run.write.configs(settings, write, ens.sample.method, posterior.files = posterior.files.vec, overwrite = overwrite))
   } else {
     stop("runModule.run.write.configs only works with Settings or MultiSettings")
   }

--- a/book_source/03_topical_pages/03_pecan_xml.Rmd
+++ b/book_source/03_topical_pages/03_pecan_xml.Rmd
@@ -249,6 +249,7 @@ The PEcAn system requires at least 1 plant functional type (PFT) to be specified
       <constants>
         <num>1</num>
       </constants>
+      <posterior.files>Path to a post.distns.*.Rdata or prior.distns.Rdata</posterior.files>
     </pft>
   </pfts>
 ```
@@ -256,6 +257,9 @@ The PEcAn system requires at least 1 plant functional type (PFT) to be specified
 * `name` : (required) the name of the PFT, which must *exactly* match the name in the PEcAn database.
 * `outdir`: (optional) Directory path in which PFT-specific output will be stored during meta-analysis and sensitivity analysis. If not specified (recommended), it will be written into `<outdir>/<pftname>`.
 * `contants`: (optional) this section contains information that will be written directly into the model specific configuration files. For example, some models like ED2 use PFT numbers instead of names for PFTs, and those numbers can be specified here. See documentation for model-specific code for details.
+* `posterior.files` (Optional) this tag helps to signal write.config functions to use specific posterior/prior files (such as HPDA or MA analysis) for generating samples without needing to access to the bety database.
+
+``
 
 This information is currently used by the following PEcAn workflow function:
 

--- a/modules/uncertainty/R/ensemble.R
+++ b/modules/uncertainty/R/ensemble.R
@@ -215,8 +215,7 @@ write.ensemble.configs <- function(defaults, ensemble.samples, settings, model,
     # Open connection to database so we can store all run/ensemble information
     con <-
       try(PEcAn.DB::db.open(settings$database$bety))
-    on.exit(try(PEcAn.DB::db.close(con), silent = TRUE, add = TRUE)
-    )
+    on.exit(try(PEcAn.DB::db.close(con), silent = TRUE), add = TRUE)
     
     # If we fail to connect to DB then we set to NULL
     if (inherits(con, "try-error"))  {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
We just pulled the PR #2288 , which allows us to write config files for the cases where we don't have access to bety. However what I noticed was missing was when we need to specify `posterior.id` under PFT. I'm adding a new tag under `pft` for directly specifying `posterior.files`. I have tested this and this does not affect original functionality but if you define a tag like below, it will bypass the processing of using `posterior.id` for finding `posterior.files` and it will use the file directly.

The file could be any of `post.distns.*Rdata` or `prior.distns.Rdata`.
```
  <pft>
   <name>boreal.coniferous</name>
   <constants>
    <num>1</num>
   </constants>
   <outdir>/fs/data3/hamzed/Projects/HPDA/Outputs/Conifer/pft/boreal.coniferous</outdir>
   <posterior.files>/fs/data1/pecan.data/dbfiles/posterior/1000016680/post.distns.MA.Rdata</posterior.files>
  </pft>
```


<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->


<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
