### PR TITLE
[Build] avoid complaint when fixing one of several existing undefined globals

### DIFF
--- a/scripts/check_with_errors.R
+++ b/scripts/check_with_errors.R
@@ -140,6 +140,10 @@ if (cmp$status != "+") {
         }
     }
 
+    # Each note got its own line above, so this line is redundant
+    # and also causes spurious error when an existing note is fixed
+    cur_msgs <- cur_msgs[!grepl("NOTE: Undefined global functions or variables:", cur_msgs)]
+
     lines_changed <- setdiff(cur_msgs, prev_msgs)
     if (length(lines_changed) > 0) {
         cat("R check of", pkg, "returned new problems:\n")

--- a/scripts/check_with_errors.R
+++ b/scripts/check_with_errors.R
@@ -140,8 +140,8 @@ if (cmp$status != "+") {
         }
     }
 
-    # Each note got its own line above, so this line is redundant
-    # and also causes spurious error when an existing note is fixed
+    # This line is redundant (summarizes issues also reported individually)
+    # and creates a false positive when an existing issue is fixed
     cur_msgs <- cur_msgs[!grepl("NOTE: Undefined global functions or variables:", cur_msgs)]
 
     lines_changed <- setdiff(cur_msgs, prev_msgs)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes an overeager (and, it turns out, redundant) string comparison in `check_with_errors.R` that was killing the build with a spurious "undefined functions or variables" note when the PR is in fact *fixing* undefined globals.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 