### PR TITLE
Fix for get.parameter.samples 

### DIFF
--- a/modules/uncertainty/R/get.parameter.samples.R
+++ b/modules/uncertainty/R/get.parameter.samples.R
@@ -131,7 +131,7 @@ get.parameter.samples <- function(settings,
     PEcAn.logger::logger.info("using ", samples.num, "samples per trait")
     for (prior in priors) {
       if (prior %in% param.names[[i]]) {
-        samples <- as.matrix(trait.mcmc[[prior]][, "beta.o"])
+        samples <- trait.mcmc[[prior]] %>% purrr::map(~ .x[,'beta.o']) %>% unlist() %>% as.matrix()
       } else {
         samples <- PEcAn.priors::get.sample(prior.distns[prior, ], samples.num)
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
I think, @femeunier and I found a change in behavior of base R between 3.4.X and 3.5.X which may result in a bug in near future for pecan running under R 3.5.X .  At line where I'm changing `trait.mcmc[[prior]]` is a list with 4 elements (4 chains for each parameter used in MA or HPDA) which when it's evaluated in R 3.4.X, it combines all lists into one vector. But in R 3.5.X code breaks at this point and it requires a more specific pointer to what elements within this list needs to be taken. I tested this fix for both versions of the R and 2 models and it passed successfully at all of them. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
