### PR TITLE
[Build] switch from devtools::test to testthat::test_dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,12 +111,13 @@ depends_R_pkg = ./scripts/time.sh "${1}" Rscript -e ${SETROPTIONS} \
 install_R_pkg = ./scripts/time.sh "${1}" Rscript -e ${SETROPTIONS} -e "devtools::install('$(strip $(1))', upgrade=FALSE)"
 check_R_pkg = ./scripts/time.sh "${1}" Rscript scripts/check_with_errors.R $(strip $(1))
 
-# Would use devtools::test(), but in devtools 2.2.1 that doesn't accept stop_on_failure=TRUE
-# To work around, we reimplement about half of test() here
+# Would use devtools::test(), but devtools 2.2.1 hardcodes stop_on_failure=FALSE
+# To work around this, we reimplement about half of test() here :(
 test_R_pkg = ./scripts/time.sh "${1}" Rscript \
-	-e "pkg <- devtools::as.package('$(strip $(1))')" \
-	-e "env <- devtools::load_all(pkg[['path']], quiet = TRUE)[['env']]" \
-	-e "testthat::test_dir(paste0(pkg[['path']], '/tests/testthat'), env = env," \
+	-e "if (length(list.files('$(strip $(1))/tests/testthat', 'test.*.[rR]')) == 0) {" \
+	-e		"print('No tests found'); quit('no') }" \
+	-e "env <- devtools::load_all('$(strip $(1))', quiet = TRUE)[['env']]" \
+	-e "testthat::test_dir('$(strip $(1))/tests/testthat', env = env," \
 	-e 		"stop_on_failure = TRUE, stop_on_warning = FALSE)" # TODO: Raise bar to stop_on_warning = TRUE when we can
 
 doc_R_pkg = ./scripts/time.sh "${1}" Rscript -e "devtools::document('"$(strip $(1))"')"


### PR DESCRIPTION
Workaround for devtools#2129: In version 2.2.1 of devtools, `test()` hard-codes the `stop_on_failure` argument to FALSE and throws an error if we try to override it. We need `stop_on_failure` to be TRUE to make the Travis builds stop reliably when tests fail, so this patch switches to directly calling `testthat::test_dir` (which devtools::test is a wrapper around).

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
