### PR TITLE
[Build] default to strict checking when no stored check results present

### DIFF
--- a/scripts/check_with_errors.R
+++ b/scripts/check_with_errors.R
@@ -75,12 +75,14 @@ if (log_notes && n_notes > 0) {
 # To update reference files after fixing an old warning:
 # * Run check_with_errors.R to be sure the check is currently passing
 # * Delete the file you want to update
-# * Uncomment this section, run check_with_errors.R, recomment
+# * Uncomment this section
+# * run `DIELEVEL=never Rscript scripts/check_with_errors.R path/to/package`
+# * recomment this section
 # * Commit updated file
-# if (! file.exists(old_file)) {
-#    cat("No reference check file found. Saving current results as the new standard\n")
-#    cat(chk$stdout, file = old_file)
-#    quit("no")
+# if (!file.exists(old_file)) {
+#     cat("No reference check file found. Saving current results as the new standard\n")
+#     cat(chk$stdout, file = old_file)
+#     quit("no")
 # }
 ###
 

--- a/scripts/check_with_errors.R
+++ b/scripts/check_with_errors.R
@@ -11,7 +11,7 @@ old_file <- file.path(pkg, "tests", "Rcheck_reference.log")
 if (file.exists(old_file)) {
     # Package has old unfixed warnings that we should ignore by default
     # (but if log/die level are explicitly set, respect them)
-    if (is.na(log_level)) log_level <- "warning"
+    if (is.na(log_level)) log_level <- "error"
     if (is.na(die_level)) die_level <- "error"
 } else {
     if (is.na(log_level)) log_level <- "all"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
* When checking a package that has no `tests/Rcheck_reference.log`, default to failing on any new ERROR, WARNING, or NOTE (previous behavior was to fail if file not present)
* When checking a package that does have a reference log, continue to default to allowing old WARNINGs and NOTEs but failing on new ones and on any ERROR
* In either case, can override default behavior by setting environment variables `LOGLEVEL` and `DIELEVEL`
* Minor change from previous behavior: When check fails, output is printed by `devtools::check` not by us and `LOGLEVEL` is ignored. So e.g. if a check fails on a WARNING, it will print the WARNING *and* any NOTEs, even if `LOGLEVEL`=warn.

An apology to reviewers: This PR contains several commits, some with substantive changes and a couple that are strictly code cleanup (whitespace, rearranging lines, and fixing linter warnings). You'll probably want to review the diffs for each commit separately.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
