### PR TITLE
Remove num as a constant to convert in `write.configs.xml.ED`

### DIFF
--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -531,7 +531,9 @@ write.config.xml.ED2 <- function(settings, trait.values, defaults = settings$con
         vals <- modifyList(vals, converted.trait.values)
 
         ## Convert settings constants to ED units
-        converted.defaults <- convert.samples.ED(defaults[[pft]]$constants)
+        constants.to.convert <- defaults[[pft]]$constants
+        constants.to.convert$num <- NULL
+        converted.defaults <- convert.samples.ED(constants.to.convert)
 
         ## Selectively replace defaults and trait values with constants from settings
         if (!is.null(converted.defaults)){


### PR DESCRIPTION
Small but important fix for `write.configs.xml.ED`:

I have been having been experiencing a bug where if I am doing an ED run **through the web interface (and thus purposefully am not manually setting `<ed2_pft_number> in the pecan.xml`)** my PFT is not correctly mapped to it's ED PFT even though it is correctly saved in the `pftmapping.csv`. I finally figured out why. 

### Short summary
The `num` value that is written in the `config.xml` is properly changed to the right PFT number and then changed back to the wrong number. 

### Long version:

Reading through `write.configs.xml.ED`
- The ED PFT number has been identified given the PFT specified in the pecan.xml. 
- By line 525, the list `vals` is defined depending on that PFT. 
- One of the key variables in the list is `num` which is used later on by `write.configs.ed`. 
- `num` is also defined in the pecan.xml under `pfts$constants$num`, but when `settings` are read in, this number does not appear to be already mapped to the correct ED PFT. I don't know where or why it is filled in, perhaps it would be better to leave it blank. 
- Because `num` is already defined, it is read in at the line `converted.defaults <- convert.samples.ED(defaults[[pft]]$constants)` but there is no code to "convert" `num` and so the incorrect `num` value is returned as `converted.defaults` and subsequently overwrites the correct `num` value at the step
        if (!is.null(converted.defaults)){
          vals <- modifyList(vals, converted.defaults)
        }
- `vals` is passed on to `write.configs.ed` with properly converted trait values and constants, but the incorrect PFT `num`.

### I propose

Simply removing `num` from the list of constants before passing them to be converted.

## Review Time Estimate
- [x ] Immediately

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->

