### PR TITLE
Make sure `include_pft` is correct in write.config.xml.ED2

### DIFF
--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -537,6 +537,9 @@ write.config.xml.ED2 <- function(settings, trait.values, defaults = settings$con
         if (!is.null(converted.defaults)){
           vals <- modifyList(vals, converted.defaults)
         }
+        
+        ## Make sure that include_pft is set to 1
+        vals$include_pft = 1
 
         pft.xml <- PEcAn.settings::listToXml(vals, "pft")
         xml <- XML::append.xmlNode(xml, pft.xml)


### PR DESCRIPTION
Values for the config.xml are read in from history files:

`vals <- as.list(edhistory[edhistory$num == pft.number, ])`

But depending on the history file, `include_pft` may be set to 0. However, I'm assuming that if you included the PFT in your `pecan.xml` then you definitely do want `include_pft = 1`. Thus it seems safe to set it to 1 at the end of conversions.
