### PR TITLE
don't write pft->constants->num see #2466

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 
 ### Changed
 - Stricter package checking: `make check` and CI builds will now fail if `R CMD check` returns any ERRORs or any "newly-added" WARNINGs or NOTEs. "Newly-added" is determined by strict string comparison against a check result saved 2019-09-03; messages that exist in the reference result do not break the build but will be fixed as time allows in future refactorings (#2404).
+- No longer writing an arbitrary num for each PFT, this was breaking ED runs potentially.
 
 ### Added
 - BASGRA_N model basic coupling.

--- a/web/04-runpecan.php
+++ b/web/04-runpecan.php
@@ -296,16 +296,11 @@ if ($browndog) {
   fwrite($fh, "  </browndog>" . PHP_EOL);
 }
 
-$pft_id=1;
 fwrite($fh, "  <pfts>" . PHP_EOL);
 foreach($pft as $p) {
 	fwrite($fh, "    <pft>" . PHP_EOL);
 	fwrite($fh, "      <name>${p}</name> " . PHP_EOL);
-	fwrite($fh, "      <constants>" . PHP_EOL);
-	fwrite($fh, "        <num>${pft_id}</num>" . PHP_EOL);
-	fwrite($fh, "      </constants>" . PHP_EOL);
 	fwrite($fh, "    </pft>" . PHP_EOL);
-	$pft_id++;
 }
 fwrite($fh, "  </pfts>" . PHP_EOL);
 


### PR DESCRIPTION
This is a redo of the change in #2466 and will not automatically add a num to the pecan.xml, this was breaking the ED code that uses "smarts" to pick the right pft number. 

This needs testing with multi pft runs.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [X] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
