### PR TITLE
More informative warning on migration date mismatch

### DIFF
--- a/base/settings/R/check.all.settings.R
+++ b/base/settings/R/check.all.settings.R
@@ -228,8 +228,8 @@ check.bety.version <- function(dbcon) {
   if (last_migration_date > pecan_release_date) {
     PEcAn.logger::logger.warn(
       "Last database migration", tail(versions, n = 1),
-      "is more recent than this", pecan_release_date, "release of PEcAn."
-      ". This could result in PEcAn not working as expected.")
+      "is more recent than this", pecan_release_date, "release of PEcAn.",
+      "This could result in PEcAn not working as expected.")
   }
 }
 

--- a/base/settings/R/check.all.settings.R
+++ b/base/settings/R/check.all.settings.R
@@ -223,9 +223,13 @@ check.bety.version <- function(dbcon) {
   }
   
   # check if database is newer
-  if (tail(versions, n=1) > "20141009160121") {
-    PEcAn.logger::logger.warn("Last migration", tail(versions, n=1), "is more recent than expected 20141009160121.",
-                "This could result in PEcAn not working as expected.")
+  last_migration_date <- lubridate::ymd_hms(tail(versions, n = 1))
+  pecan_release_date <- lubridate::ymd(packageDescription("PEcAn.settings")$Date)
+  if (last_migration_date > pecan_release_date) {
+    PEcAn.logger::logger.warn(
+      "Last database migration", tail(versions, n = 1),
+      "is more recent than this", pecan_release_date, "release of PEcAn."
+      ". This could result in PEcAn not working as expected.")
   }
 }
 

--- a/base/settings/R/check.all.settings.R
+++ b/base/settings/R/check.all.settings.R
@@ -224,7 +224,7 @@ check.bety.version <- function(dbcon) {
   
   # check if database is newer
   last_migration_date <- lubridate::ymd_hms(tail(versions, n = 1))
-  pecan_release_date <- lubridate::ymd(packageDescription("PEcAn.settings")$Date)
+  pecan_release_date <- lubridate::ymd(utils::packageDescription("PEcAn.DB")$Date)
   if (last_migration_date > pecan_release_date) {
     PEcAn.logger::logger.warn(
       "Last database migration", tail(versions, n = 1),

--- a/modules/data.atmosphere/R/read.register.R
+++ b/modules/data.atmosphere/R/read.register.R
@@ -8,7 +8,7 @@
 read.register <- function(register.xml, con) {
   
   register <- XML::xmlToList(XML::xmlParse(register.xml))
-  print(as.data.frame(register))
+  PEcAn.logger::logger.debug(as.data.frame(register))
   
   # check scale
   if (is.null(register$scale)) {


### PR DESCRIPTION
It's been quite a while since 20141009160121 was the migration to use. This patch removes the hardcoded version and should stay at least somewhat informative without manual updating, at least as long as future migrations keep being parseable as dates and as long as "this schema version didn't exist yet when we tested this version of PEcAn" is the right cutoff for warning about possible incompatibilities. 

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
