### PR TITLE
met.process: use seq_along not 1:length

### DIFF
--- a/modules/data.atmosphere/R/met.process.R
+++ b/modules/data.atmosphere/R/met.process.R
@@ -288,9 +288,9 @@ met.process <- function(site, input_met, start_date, end_date, model,
   #--------------------------------------------------------------------------------------------------#
   # Change to Site Level - Standardized Met (i.e. ready for conversion to model specific format)
   if (stage$standardize) {
-    standardize_result = list()
+    standardize_result <- list()
     
-    for (i in 1:length(cf.id[[1]])) {
+    for (i in seq_along(cf.id[[1]])) {
 
       if (register$scale == "regional") {
         #### Site extraction
@@ -324,15 +324,15 @@ met.process <- function(site, input_met, start_date, end_date, model,
       }
       
     } # End for loop
-    ready.id = list(input.id = NULL, dbfile.id = NULL)
-    
-    for (i in 1:length(standardize_result)) {
+    ready.id <- list(input.id = NULL, dbfile.id = NULL)
+
+    for (i in seq_along(standardize_result)) {
       ready.id$input.id <- c(ready.id$input.id, standardize_result[[i]]$input.id)
       ready.id$dbfile.id <- c(ready.id$dbfile.id, standardize_result[[i]]$dbfile.id)
     }
     
   } else {
-    ready.id = input_met$id
+    ready.id <- input_met$id
   }
 
   #--------------------------------------------------------------------------------------------------#
@@ -363,14 +363,12 @@ met.process <- function(site, input_met, start_date, end_date, model,
                                     register = register,
                                     ensemble_name = i)
       }
-    
-    
-    
-    model.id = list()
-    model.file.info = list()
-    model.file = list()
-    
-    for (i in 1:length(met2model.result)) {
+
+    model.id <- list()
+    model.file.info <- list()
+    model.file <- list()
+
+    for (i in seq_along(met2model.result)) {
       model.id[[i]]  <- met2model.result[[i]]$model.id
       model.file.info[[i]] <- PEcAn.DB::db.query(paste0("SELECT * from dbfiles where id = ", model.id[[i]]$dbfile.id), con)
       model.file[[i]] <- file.path(model.file.info[[i]]$file_path, model.file.info[[i]]$file_name)
@@ -383,8 +381,8 @@ met.process <- function(site, input_met, start_date, end_date, model,
     
     input_met$id <- list()
     input_met$path <- list()
-    
-    for (i in 1:length(model.id)) {
+
+    for (i in seq_along(model.id)) {
       input_met$id[[paste0("id", i)]] <- model.id[[i]]$input.id
       input_met$path[[as.character(paste0("path", i))]] <- model.file[[i]]
     }


### PR DESCRIPTION
Avoids some cryptic errors when looping over empty vectors in met.process, e.g.

```
Error in standardize_result[[i]] <- .metgapfill.module(cf.id = list(input.id = cf.id$input.id[i],  : 
	  attempt to select less than one element in integerOneIndex
```

Whether the vectors ought to be empty in the first place is a different question, but this should at least make them easier to diagnose...

## Motivation and Context
Saw this error on first attempt to use AmerifluxLBL data in a sorta-cleanish 1.7.1 VM updated to develop @ 601a92611. Have not tried too hard to reproduce in other contexts.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
