### PR TITLE
[build] pin Roxygen version until we are ready to upgrade

### DIFF
--- a/scripts/travis/script.sh
+++ b/scripts/travis/script.sh
@@ -17,6 +17,13 @@ set -e
     Rscript -e 'devtools::install_version("dbplyr", version = "1.3.0", repos = "http://cran.us.r-project.org")'
     Rscript -e 'install.packages("rgdal")' # yes, this is supposed to happen automatically but... doesn't
     travis_time_end
+
+    travis_time_start "pecan_install_roxygen" "Installing Roxygen 6.1.1 to match comitted documentation version"
+    # Later Roxygen versions produce a lot of formatting changes (mostly whitespace), so waiting to upgrade.
+    # When ready we will upgrade to Roxygen 7.0, commit all changes at once,
+    # and make all developers update their own Roxygen installations at the same time.
+    Rscript -e 'devtools::install_version("roxygen2", version = "6.1.1", repos = "http://cran.us.r-project.org")'
+    travis_time_end
 )  
 
 # COMPILE PECAN


### PR DESCRIPTION
## Description

Pins Travis version of Roxygen2 to 6.1.1 for now, to avoid breaking build on changes in output format from newer versions.

## Motivation and Context

The CRAN version of Roxygen2 is now 7.0.0, with a bunch of shiny new features we don't yet use and also a change in how it formats function usage lines: previously on as few lines as possible, now with each parameter on its own line. We *could* upgrade right now and commit the resulting changes (I count 273 files affected), but we'll also want to make all PEcAn committers upgrade Roxygen on their dev machines at the same time. By pinning the Travis version to 6.1, we can defer the change until we're ready to do that.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
