### PR TITLE
Make sure not to overwrite previously set on.exit actions

### DIFF
--- a/api/R/get_model_id.R
+++ b/api/R/get_model_id.R
@@ -13,7 +13,7 @@ get_model_id <- function(con, name, revision, multi_action = "last") {
     "SELECT id FROM models WHERE model_name = $1 and revision = $2 ORDER BY id DESC"
   ))
   res <- DBI::dbBind(qry, list(name, revision))
-  on.exit(DBI::dbClearResult(res))
+  on.exit(DBI::dbClearResult(res), add = TRUE)
   id <- DBI::dbFetch(res)[["id"]]
   if (length(id) == 0) {
     stop("Model ", name, " with revision ", revision, " not found.")

--- a/api/R/prepared_query.R
+++ b/api/R/prepared_query.R
@@ -64,7 +64,7 @@ prepared_query <- function(con, query, params) {
   )
   qry <- DBI::dbSendQuery(con, query)
   res <- DBI::dbBind(qry, params)
-  on.exit(DBI::dbClearResult(res))
+  on.exit(DBI::dbClearResult(res), add = TRUE)
   DBI::dbFetch(res)
 }
 
@@ -79,5 +79,5 @@ prepared_statement <- function(con, query, params) {
   )
   qry <- DBI::dbSendStatement(con, query)
   res <- DBI::dbBind(qry, params)
-  on.exit(DBI::dbClearResult(res))
+  on.exit(DBI::dbClearResult(res), add = TRUE)
 }

--- a/base/db/R/clone_pft.R
+++ b/base/db/R/clone_pft.R
@@ -32,7 +32,7 @@ clone_pft <- function(parent.pft.name,
   }
 
   con <- db.open(settings$database$bety)
-  on.exit(db.close(con))
+  on.exit(db.close(con), add = TRUE)
 
   parent.pft <- (dplyr::tbl(con, "pfts")
     %>% dplyr::filter(name == !!parent.pft.name)

--- a/base/db/R/get.trait.data.R
+++ b/base/db/R/get.trait.data.R
@@ -42,7 +42,7 @@ get.trait.data <- function(pfts, modeltype, dbfiles, database, forceupdate,
   }
   
   dbcon <- db.open(database)
-  on.exit(db.close(dbcon))
+  on.exit(db.close(dbcon), add = TRUE)
   
   if (is.null(trait.names)) {
     PEcAn.logger::logger.debug(paste0(

--- a/base/db/R/query.data.R
+++ b/base/db/R/query.data.R
@@ -24,7 +24,7 @@ query.data <- function(trait, spstr, extra.columns = 'ST_X(ST_CENTROID(sites.geo
   if (is.null(con)) {
     PEcAn.logger::logger.error("No open database connection passed in.")
     con <- db.open(settings$database$bety)
-    on.exit(db.close(con))
+    on.exit(db.close(con), add = TRUE)
   }
   id_type = if (ids_are_cultivars) {"cultivar_id"} else {"specie_id"}
   

--- a/base/db/R/query.traits.R
+++ b/base/db/R/query.traits.R
@@ -33,7 +33,7 @@ query.traits <- function(ids, priors, con = NULL,
   
   if(is.null(con)){
     con <- db.open(settings$database$bety)
-    on.exit(db.close(con))
+    on.exit(db.close(con), add = TRUE)
   }
   if(is.list(con)){
     print("query.traits")

--- a/base/db/R/try2sqlite.R
+++ b/base/db/R/try2sqlite.R
@@ -75,7 +75,7 @@ try2sqlite <- function(try_files, sqlite_file = "try.sqlite") {
 
   PEcAn.logger::logger.info("Writing tables to SQLite database...")
   con <- DBI::dbConnect(RSQLite::SQLite(), sqlite_file)
-  on.exit(DBI::dbDisconnect(con))
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
   PEcAn.logger::logger.info("Writing values table...")
   DBI::dbWriteTable(con, "values", data_values)
   PEcAn.logger::logger.info("Writing traits table...")

--- a/base/db/R/utils_db.R
+++ b/base/db/R/utils_db.R
@@ -125,7 +125,7 @@ db.query <- function(query, con = NULL, params = NULL, values = NULL) {
       PEcAn.logger::logger.severe("No parameters or connection specified")
     }
     con <- db.open(params)
-    on.exit(db.close(con))
+    on.exit(db.close(con), add = TRUE)
   }
   if (.db.utils$showquery) {
     PEcAn.logger::logger.debug(query)
@@ -318,7 +318,7 @@ db.exists <- function(params, write = TRUE, table = NA) {
   if (is.null(con)) {
     return(invisible(FALSE))
   } else {
-    on.exit(db.close(con))
+    on.exit(db.close(con), add = TRUE)
   }
 
   #check table's privilege about read and write permission

--- a/base/remote/R/start.model.runs.R
+++ b/base/remote/R/start.model.runs.R
@@ -66,7 +66,7 @@ start.model.runs <- function(settings, write = TRUE, stop.on.error = TRUE) {
   # create database connection
   if (write) {
     dbcon <- db.open(settings$database$bety)
-    on.exit(db.close(dbcon))
+    on.exit(db.close(dbcon), add = TRUE)
   } else {
     dbcon <- NULL
   }

--- a/base/settings/R/check.all.settings.R
+++ b/base/settings/R/check.all.settings.R
@@ -22,7 +22,7 @@ check.inputs <- function(settings) {
 
   # get list of inputs associated with model type
   dbcon <- PEcAn.DB::db.open(settings$database$bety)
-  on.exit(PEcAn.DB::db.close(dbcon))
+  on.exit(PEcAn.DB::db.close(dbcon), add = TRUE)
 
   inputs <- PEcAn.DB::db.query(
     paste0(
@@ -291,7 +291,7 @@ check.settings <- function(settings, force = FALSE) {
   }
 
   scipen <- getOption("scipen")
-  on.exit(options(scipen = scipen))
+  on.exit(options(scipen = scipen), add = TRUE)
   options(scipen = 12)
 
 
@@ -1057,7 +1057,7 @@ check.database.settings <- function(settings) {
 
       # Connect to database
       dbcon <- PEcAn.DB::db.open(settings$database$bety)
-      on.exit(PEcAn.DB::db.close(dbcon))
+      on.exit(PEcAn.DB::db.close(dbcon), add = TRUE)
 
       # check database version
       check.bety.version(dbcon)

--- a/base/utils/R/convert.input.R
+++ b/base/utils/R/convert.input.R
@@ -221,18 +221,23 @@ convert.input <-
                                       verbose = TRUE,R = Rbinary, scratchdir = outfolder)
       
       successful <- FALSE
-      on.exit(if (exists("successful") && successful) {
-        PEcAn.logger::logger.info("Conversion successful, with overwrite=TRUE. Deleting old files.")
-        PEcAn.remote::remote.execute.R( file.deletion.commands$delete.tmp, 
-                                        host, user = NA, 
-                                        verbose = TRUE,  R = Rbinary, scratchdir = outfolder )
-      } else {
-        PEcAn.logger::logger.info("Conversion failed. Replacing old files.")
-        PEcAn.remote::remote.execute.R( file.deletion.commands$replace.from.tmp, 
-                                        host, user = NA, 
-                                        verbose = TRUE, R = Rbinary, scratchdir = outfolder )
-      }
-      )#Close on.exit
+      on.exit(
+        if (exists("successful") && successful) {
+          PEcAn.logger::logger.info(
+            "Conversion successful, with overwrite=TRUE. Deleting old files.")
+          PEcAn.remote::remote.execute.R(
+            file.deletion.commands$delete.tmp,
+            host, user = NA,
+            verbose = TRUE,  R = Rbinary, scratchdir = outfolder)
+        } else {
+          PEcAn.logger::logger.info("Conversion failed. Replacing old files.")
+          PEcAn.remote::remote.execute.R(
+            file.deletion.commands$replace.from.tmp,
+            host, user = NA,
+            verbose = TRUE, R = Rbinary, scratchdir = outfolder)
+        },
+        add = TRUE
+      ) # Close on.exit
     }
     
     # If all of the files for an existing ensemble exist, we'll just use those files.  Otherwise, we'll need to run the function to
@@ -319,18 +324,22 @@ convert.input <-
         
         # Schedule files to be replaced or deleted on exiting the function
         successful <- FALSE
-        on.exit(if (exists("successful") && successful) {
-                PEcAn.logger::logger.info("Conversion successful, with overwrite=TRUE. Deleting old files.")
-                PEcAn.remote::remote.execute.R( file.deletion.commands$delete.tmp, 
-                                  host, user = NA, 
-                                  verbose = TRUE,  R = Rbinary, scratchdir = outfolder )
-        } else {
-                PEcAn.logger::logger.info("Conversion failed. Replacing old files.")
-                PEcAn.remote::remote.execute.R( file.deletion.commands$replace.from.tmp, 
-                                  host, user = NA, 
-                                  verbose = TRUE, R = Rbinary, scratchdir = outfolder )
-        }
-        )#Close on.exit
+        on.exit(
+          if (exists("successful") && successful) {
+            PEcAn.logger::logger.info("Conversion successful, with overwrite=TRUE. Deleting old files.")
+            PEcAn.remote::remote.execute.R(
+              file.deletion.commands$delete.tmp,
+              host, user = NA,
+              verbose = TRUE,  R = Rbinary, scratchdir = outfolder)
+          } else {
+            PEcAn.logger::logger.info("Conversion failed. Replacing old files.")
+            PEcAn.remote::remote.execute.R(
+              file.deletion.commands$replace.from.tmp,
+              host, user = NA,
+              verbose = TRUE, R = Rbinary, scratchdir = outfolder)
+          },
+          add = TRUE
+        ) # Close on.exit
       }
       
       
@@ -436,21 +445,25 @@ convert.input <-
         
         # Schedule files to be replaced or deleted on exiting the function
         successful <- FALSE
-        on.exit(if (exists("successful") && successful) {
-          PEcAn.logger::logger.info("Conversion successful, with overwrite=TRUE. Deleting old files.")
-          PEcAn.remote::remote.execute.R( file.deletion.commands$delete.tmp,
-                            host, user = NA, 
-                            verbose = TRUE,  R = Rbinary, scratchdir = outfolder )
-          
-        } else {
-          
-          PEcAn.logger::logger.info("Conversion failed. Replacing old files.")
-          PEcAn.remote::remote.execute.R( file.deletion.commands$replace.from.tmp,
-                            host, user = NA,
-                            verbose = TRUE, R = Rbinary, scratchdir = outfolder )
-        } 
-        )#close on on.exit
-        
+        on.exit(
+          if (exists("successful") && successful) {
+            PEcAn.logger::logger.info(
+              "Conversion successful, with overwrite=TRUE. Deleting old files.")
+            PEcAn.remote::remote.execute.R(
+              file.deletion.commands$delete.tmp,
+              host, user = NA,
+              verbose = TRUE,  R = Rbinary, scratchdir = outfolder)
+          } else {
+            PEcAn.logger::logger.info(
+              "Conversion failed. Replacing old files.")
+            PEcAn.remote::remote.execute.R(
+              file.deletion.commands$replace.from.tmp,
+              host, user = NA,
+              verbose = TRUE, R = Rbinary, scratchdir = outfolder)
+          },
+          add = TRUE
+        ) # close on.exit
+
       } else if ((start_date >= existing.input$start_date) &&
                  (end_date <= existing.input$end_date)) {
         

--- a/base/utils/R/ensemble.R
+++ b/base/utils/R/ensemble.R
@@ -245,7 +245,7 @@ write.ensemble.configs <- function(defaults, ensemble.samples, settings, model,
     if (inherits(con, "try-error")) {
       con <- NULL
     } else {
-      on.exit(PEcAn.DB::db.close(con))
+      on.exit(PEcAn.DB::db.close(con), add = TRUE)
     }
   } else {
     con <- NULL

--- a/base/utils/R/run.write.configs.R
+++ b/base/utils/R/run.write.configs.R
@@ -33,7 +33,7 @@ run.write.configs <- function(settings, write = TRUE, ens.sample.method = "unifo
   .Deprecated("PEcAn.workflow::run.write.configs")
   
   con <- PEcAn.DB::db.open(settings$database$bety)
-  on.exit(PEcAn.DB::db.close(con))
+  on.exit(PEcAn.DB::db.close(con), add = TRUE)
   
   ## Which posterior to use?
   for (i in seq_along(settings$pfts)) {

--- a/base/utils/R/sensitivity.R
+++ b/base/utils/R/sensitivity.R
@@ -101,7 +101,7 @@ write.sa.configs <- function(defaults, quantile.samples, settings, model,
     if (inherits(con, "try-error")) {
       con <- NULL
     } else {
-      on.exit(PEcAn.DB::db.close(con))
+      on.exit(PEcAn.DB::db.close(con), add = TRUE)
     }
   } else {
     con <- NULL

--- a/base/utils/R/utils.R
+++ b/base/utils/R/utils.R
@@ -488,7 +488,7 @@ as.sequence <- function(x, na.rm = TRUE) {
 ##' @author David LeBauer
 temp.settings <- function(settings.txt) {
   temp <- tempfile()
-  on.exit(unlink(temp))
+  on.exit(unlink(temp), add = TRUE)
   writeLines(settings.txt, con = temp)
   settings <- readLines(temp)
   return(settings)

--- a/base/utils/tests/testthat/helper.R
+++ b/base/utils/tests/testthat/helper.R
@@ -38,7 +38,7 @@ example_netcdf <- function(varnames, file_path) {
                  units = "kg", dim = dims, missval = NA)
   names(vars) <- varnames
   nc <- ncdf4::nc_create(filename = file_path, vars = vars)
-  on.exit(ncdf4::nc_close(nc))
+  on.exit(ncdf4::nc_close(nc), add = TRUE)
   ncdf4::ncatt_put(nc, 0, "description", "strictly for testing")
   for (v in varnames) {
     ncdf4::ncvar_put(nc, varid = vars[[v]], vals = rnorm(n))

--- a/models/linkages/R/write.config.LINKAGES.R
+++ b/models/linkages/R/write.config.LINKAGES.R
@@ -65,7 +65,7 @@ write.config.LINKAGES <- function(defaults = NULL, trait.values, settings, run.i
   texture <- read.csv(system.file("texture.csv", package = "PEcAn.LINKAGES"))
   
   dbcon <- db.open(settings$database$bety)
-  on.exit(db.close(dbcon))
+  on.exit(db.close(dbcon), add = TRUE)
   
   if("soil" %in% names(settings$run$inputs)){
     ## open soil file

--- a/modules/assim.batch/R/pda.bayesian.tools.R
+++ b/modules/assim.batch/R/pda.bayesian.tools.R
@@ -40,7 +40,7 @@ pda.bayesian.tools <- function(settings, params.id = NULL, param.names = NULL, p
     if (inherits(con, "try-error")) {
       con <- NULL
     } else {
-      on.exit(PEcAn.DB::db.close(con))
+      on.exit(PEcAn.DB::db.close(con), add = TRUE)
     }
   } else {
     con <- NULL

--- a/modules/assim.batch/R/pda.bayestools.helpers.R
+++ b/modules/assim.batch/R/pda.bayestools.helpers.R
@@ -160,7 +160,7 @@ correlationPlot <- function(mat, density = "smooth", thin = "auto", method = "pe
   
   panel.hist.dens <- function(x, ...) {
     usr <- graphics::par("usr")
-    on.exit(graphics::par(usr))
+    on.exit(graphics::par(usr), add = TRUE)
     graphics::par(usr = c(usr[1:2], 0, 1.5))
     h <- graphics::hist(x, plot = FALSE)
     breaks <- h$breaks
@@ -173,7 +173,7 @@ correlationPlot <- function(mat, density = "smooth", thin = "auto", method = "pe
   # replaced by spearman
   panel.cor <- function(x, y, digits = 2, prefix = "", cex.cor, ...) {
     usr <- graphics::par("usr")
-    on.exit(graphics::par(usr))
+    on.exit(graphics::par(usr), add = TRUE)
     graphics::par(usr = c(0, 1, 0, 1))
     r <- stats::cor(x, y, use = "complete.obs", method = method)
     txt <- format(c(r, 0.123456789), digits = digits)[1]
@@ -186,7 +186,7 @@ correlationPlot <- function(mat, density = "smooth", thin = "auto", method = "pe
   
   plotEllipse <- function(x, y) {
     usr <- graphics::par("usr")
-    on.exit(graphics::par(usr))
+    on.exit(graphics::par(usr), add = TRUE)
     graphics::par(usr = c(usr[1:2], 0, 1.5))
     cor <- stats::cor(x, y)
     el <- ellipse::ellipse(cor)

--- a/modules/assim.batch/R/pda.emulator.R
+++ b/modules/assim.batch/R/pda.emulator.R
@@ -69,7 +69,7 @@ pda.emulator <- function(settings, external.data = NULL, external.priors = NULL,
     if (inherits(con, "try-error")) {
       con <- NULL
     } else {
-      on.exit(PEcAn.DB::db.close(con))
+      on.exit(PEcAn.DB::db.close(con), add = TRUE)
     }
   } else {
     con <- NULL

--- a/modules/assim.batch/R/pda.mcmc.R
+++ b/modules/assim.batch/R/pda.mcmc.R
@@ -38,7 +38,7 @@ pda.mcmc <- function(settings, params.id = NULL, param.names = NULL, prior.id = 
     if (inherits(con, "try-error")) {
       con <- NULL
     } else {
-      on.exit(PEcAn.DB::db.close(con))
+      on.exit(PEcAn.DB::db.close(con), add = TRUE)
     }
   } else {
     con <- NULL

--- a/modules/assim.batch/R/pda.mcmc.bs.R
+++ b/modules/assim.batch/R/pda.mcmc.bs.R
@@ -45,7 +45,7 @@ pda.mcmc.bs <- function(settings, params.id = NULL, param.names = NULL, prior.id
     if (inherits(con, "try-error")) {
       con <- NULL
     } else {
-      on.exit(PEcAn.DB::db.close(con))
+      on.exit(PEcAn.DB::db.close(con), add = TRUE)
     }
   } else {
     con <- NULL

--- a/modules/assim.batch/R/pda.mcmc.recover.R
+++ b/modules/assim.batch/R/pda.mcmc.recover.R
@@ -33,7 +33,7 @@ pda.mcmc.recover <- function(settings, params.id = NULL, param.names = NULL, pri
       if (inherits(con, "try-error")) {
           con <- NULL
       } else {
-        on.exit(PEcAn.DB::db.close(con))
+        on.exit(PEcAn.DB::db.close(con), add = TRUE)
       }
     } else {
         con <- NULL

--- a/modules/assim.sequential/R/sda.enkf.R
+++ b/modules/assim.sequential/R/sda.enkf.R
@@ -134,7 +134,7 @@ sda.enkf.original <- function(settings, obs.mean, obs.cov, IC = NULL, Q = NULL, 
     if (is(con, "try-error")) {
       con <- NULL
     } else {
-      on.exit(db.close(con))
+      on.exit(db.close(con), add = TRUE)
     }
   } else {
     con <- NULL

--- a/modules/data.atmosphere/R/download.CRUNCEP_Global.R
+++ b/modules/data.atmosphere/R/download.CRUNCEP_Global.R
@@ -67,7 +67,7 @@ download.CRUNCEP <- function(outfolder, start_date, end_date, site_id, lat.in, l
   utils::download.file(mask_url, maskfile)
 
   mask_nc <- ncdf4::nc_open(maskfile)
-  on.exit(ncdf4::nc_close(mask_nc))
+  on.exit(ncdf4::nc_close(mask_nc), add = TRUE)
 
   # Set search radius to up to 2 pixels (1 degree) in any direction
   mask_minlat <- lat_grid - 2

--- a/modules/data.atmosphere/R/download.NARR_site.R
+++ b/modules/data.atmosphere/R/download.NARR_site.R
@@ -109,7 +109,7 @@ prepare_narr_year <- function(dat, file, lat_nc, lon_nc, verbose = FALSE) {
     dims = list(lat_nc, lon_nc, time_nc)
   )
   nc <- ncdf4::nc_create(file, ncvar_list, verbose = verbose)
-  on.exit(ncdf4::nc_close(nc))
+  on.exit(ncdf4::nc_close(nc), add = TRUE)
   purrr::iwalk(nc_values, ~ncdf4::ncvar_put(nc, .y, .x, verbose = verbose))
   invisible(ncvar_list)
 }
@@ -209,7 +209,7 @@ get_NARR_thredds <- function(start_date, end_date, lat.in, lon.in,
 
   # Load dimensions, etc. from first netCDF file
   nc1 <- robustly(ncdf4::nc_open, n = 20, timeout = 0.5)(flx_df$url[1])
-  on.exit(ncdf4::nc_close(nc1))
+  on.exit(ncdf4::nc_close(nc1), add = TRUE)
   xy <- latlon2narr(nc1, lat.in, lon.in)
 
   if (parallel) {
@@ -373,7 +373,7 @@ daygroup <- function(date, flx) {
 get_narr_url <- function(url, xy, flx, pb = NULL) {
   stopifnot(length(xy) == 2, length(url) == 1, is.character(url))
   nc <- ncdf4::nc_open(url)
-  on.exit(ncdf4::nc_close(nc))
+  on.exit(ncdf4::nc_close(nc), add = TRUE)
   timevar <- if (flx) "time" else "reftime"
   dhours <- ncdf4::ncvar_get(nc, timevar)
   # HACK: Time variable seems inconsistent.

--- a/modules/data.atmosphere/R/met.process.R
+++ b/modules/data.atmosphere/R/met.process.R
@@ -93,7 +93,7 @@ met.process <- function(site, input_met, start_date, end_date, model,
                        password = dbparms$password)
   
   con <- bety$con
-  on.exit(PEcAn.DB::db.close(con))
+  on.exit(PEcAn.DB::db.close(con), add = TRUE)
   username <- ifelse(is.null(input_met$username), "pecan", input_met$username)
   machine.host <- ifelse(host == "localhost" || host$name == "localhost", PEcAn.remote::fqdn(), host$name)
   machine <- PEcAn.DB::db.query(paste0("SELECT * from machines where hostname = '", machine.host, "'"), con)

--- a/modules/data.atmosphere/tests/testthat/test.cf-downscaling.R
+++ b/modules/data.atmosphere/tests/testthat/test.cf-downscaling.R
@@ -1,7 +1,7 @@
 context("downscaling")
 
 daily.nc <- ncdf4::nc_open("data/urbana_daily_test.nc")
-on.exit(ncdf4::nc_close(daily.nc))
+on.exit(ncdf4::nc_close(daily.nc), add = TRUE)
 daily.cf <- load.cfmet(met.nc = daily.nc, lat = 39.75, lon = -87.25,
                        start.date = "1951-01-02", end.date = "1951-05-31")
 

--- a/modules/data.atmosphere/tests/testthat/test.load.cfmet.R
+++ b/modules/data.atmosphere/tests/testthat/test.load.cfmet.R
@@ -6,11 +6,11 @@ daily_file <- "data/urbana_daily_test.nc"
 subdaily_file <- "data/urbana_subdaily_test.nc"
 
 daily.nc <- ncdf4::nc_open(daily_file)
-on.exit(ncdf4::nc_close(daily.nc))
+on.exit(ncdf4::nc_close(daily.nc), add = TRUE)
 daily.cf <- load.cfmet(met.nc = daily.nc, lat = 39.75, lon = -87.25,
                        start.date = "1951-01-02", end.date = "1951-05-31")
 subdaily.nc <- ncdf4::nc_open(subdaily_file)
-on.exit(ncdf4::nc_close(subdaily.nc), add=TRUE)
+on.exit(ncdf4::nc_close(subdaily.nc), add = TRUE)
 
 test_that("data extracted from test pecan-cf met files is valid",{
   expect_is(daily.cf, "data.frame")

--- a/modules/data.land/R/ens.veg.module.R
+++ b/modules/data.land/R/ens.veg.module.R
@@ -31,7 +31,7 @@ ens_veg_module <- function(getveg.id, dbparms,
                               password = dbparms$bety$password)
   
   con <- bety$con
-  on.exit(db.close(con))
+  on.exit(db.close(con), add = TRUE)
   
   PEcAn.logger::logger.info("Begin IC sampling, ensemble member: ", n.ensemble)
   

--- a/modules/data.land/R/extract_FIA.R
+++ b/modules/data.land/R/extract_FIA.R
@@ -8,7 +8,7 @@ extract_FIA <- function(lon, lat, start_date, end_date, gridres = 0.075, dbparms
   veg_info <- list()
   
   fia.con <- PEcAn.DB::db.open(dbparms$fia)
-  on.exit(db.close(fia.con), add = T)
+  on.exit(db.close(fia.con), add = TRUE)
   
   lonmin   <- lon - gridres
   lonmax   <- lon + gridres

--- a/modules/data.land/R/fia2ED.R
+++ b/modules/data.land/R/fia2ED.R
@@ -38,7 +38,7 @@ fia.to.psscss <- function(settings,
   
   ## connect to database
   con <- db.open(settings$database$bety)
-  on.exit(db.close(con))
+  on.exit(db.close(con), add = TRUE)
   
   # Check whether inputs exist already
   if(!overwrite) {
@@ -122,7 +122,7 @@ fia.to.psscss <- function(settings,
   
   ## connect to database
   fia.con <- db.open(settings$database$fia)
-  on.exit(db.close(fia.con), add = T)
+  on.exit(db.close(fia.con), add = TRUE)
   
   ##################
   ##              ##

--- a/modules/data.land/R/ic_process.R
+++ b/modules/data.land/R/ic_process.R
@@ -48,7 +48,7 @@ ic_process <- function(settings, input, dir, overwrite = FALSE){
                               password = dbparms$bety$password)
   
   con <- bety$con
-  on.exit(db.close(con))
+  on.exit(db.close(con), add = TRUE)
   
   ## We need two types of start/end dates now
   ## i)  start/end of the run when we have no veg file to begin with (i.e. we'll be querying a DB)

--- a/modules/data.land/R/put.veg.module.R
+++ b/modules/data.land/R/put.veg.module.R
@@ -34,7 +34,7 @@ put_veg_module <- function(getveg.id, dbparms,
                               password = dbparms$bety$password)
   
   con <- bety$con
-  on.exit(db.close(con))
+  on.exit(db.close(con), add = TRUE)
   
   # Determine IC file format name and mimetype
   model_info <- db.query(paste0("SELECT f.name, f.id, mt.type_string from modeltypes as m", " join modeltypes_formats as mf on m.id = mf.modeltype_id", 

--- a/modules/data.land/R/soil_process.R
+++ b/modules/data.land/R/soil_process.R
@@ -31,7 +31,7 @@ soil_process <- function(settings, input, dbfiles, overwrite = FALSE,run.local=T
                               user     = dbparms$bety$user, 
                               password = dbparms$bety$password)
   con <- bety$con
-  on.exit(PEcAn.DB::db.close(con))
+  on.exit(PEcAn.DB::db.close(con), add = TRUE)
   # get site info
   latlon <- PEcAn.data.atmosphere::db.site.lat.lon(site$id, con = con)
   new.site <- data.frame(id = as.numeric(site$id), 

--- a/modules/meta.analysis/R/run.meta.analysis.R
+++ b/modules/meta.analysis/R/run.meta.analysis.R
@@ -185,7 +185,7 @@ run.meta.analysis.pft <- function(pft, iterations, random = TRUE, threshold = 1.
 run.meta.analysis <- function(pfts, iterations, random = TRUE, threshold = 1.2, dbfiles, database, use_ghs = TRUE) {
   # process all pfts
   dbcon <- db.open(database)
-  on.exit(db.close(dbcon))
+  on.exit(db.close(dbcon), add = TRUE)
 
   result <- lapply(pfts, run.meta.analysis.pft, iterations = iterations, random = random, 
                    threshold = threshold, dbfiles = dbfiles, dbcon = dbcon, use_ghs = use_ghs)

--- a/modules/rtm/R/edr.wrapper.R
+++ b/modules/rtm/R/edr.wrapper.R
@@ -145,7 +145,7 @@ EDR <- function(img_path,
 
   oldwd <- getwd()
   setwd(output.path)
-  on.exit(setwd(oldwd))
+  on.exit(setwd(oldwd), add = TRUE)
 
   if (!is.null(img_path)) {
     ex <- PEcAn.ED2::run_ed_singularity(

--- a/modules/rtm/R/invert.auto.R
+++ b/modules/rtm/R/invert.auto.R
@@ -135,7 +135,7 @@ invert.auto <- function(observed, invert.options,
       }
     }
     cl <- parallel::makeCluster(parallel.cores, "FORK", outfile = parallel.output)
-    on.exit(parallel::stopCluster(cl))
+    on.exit(parallel::stopCluster(cl), add = TRUE)
 
     # Initialize random seeds on cluster.
     # Otherwise, chains may start on same seed and end up identical.

--- a/shiny/BrownDog/server.R
+++ b/shiny/BrownDog/server.R
@@ -34,7 +34,7 @@ server <- shinyServer(function(input, output, session) {
   output$modelSelector <- renderUI({
     bety <- betyConnect("../../web/config.php")
     con <- bety$con
-    on.exit(db.close(con))
+    on.exit(db.close(con), add = TRUE)
     models <- db.query("SELECT name FROM modeltypes;", con)
     selectInput("model", "Model", models)
   })
@@ -76,7 +76,7 @@ server <- shinyServer(function(input, output, session) {
     # get all sites name, lat and lon by sitegroups
     bety <- betyConnect("../../web/config.php")
     con <- bety$con
-    on.exit(db.close(con))
+    on.exit(db.close(con), add = TRUE)
     sites <-
       db.query(
         paste0(


### PR DESCRIPTION
## Description
Following up on one of @robkooper's comments on #2483 before I forget about it

## Motivation and Context
IMO the default `on.exit` behavior (of replacing any actions scheduled earlier in the function rather than adding to them) is backwards and for defensive programming we should usually call it with `add = TRUE` unless the situation specifically requires `add = FALSE`


## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
