### PR TITLE
met2model.BIOCRO: Close all years of input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 ## [Unreleased]
 
 ### Fixed
+- Fixed a filehandle leak in multi-year runs of PEcAn.BIOCRO::met2model.BIOCRO: It was only closing the last input file it processed (#2485).
 - Fix issue with cruncep download: use netcdf subset (ncss) method instead of opendap (#2424).
 - The `parse` option to `PEcAn.utils::read_web_config` had no effect when `expand` was TRUE (#2421).
 - Fixed a typo that made `PEcAn.DB::symmetric_setdiff` falsely report no differences (#2428).

--- a/models/biocro/R/close_nc_if_open.R
+++ b/models/biocro/R/close_nc_if_open.R
@@ -1,0 +1,26 @@
+# close file if open, but don't complain if it's already closed.
+# Used by met2model.BIOCRO to allow closing files cleanly on exit
+# without keeping them open longer than needed while looping over other years
+close_nc_if_open <- function(ncfile) {
+
+  if (!inherits(ncfile, "ncdf4")) {
+    PEcAn.logger::logger.error(
+      substitute(ncfile),
+      " is not an NCDF file object. Don't know how to close it.")
+    return(invisible())
+  }
+
+  # Key assumption here: as long as it's an ncdf4 object to start with,
+  # "invalid ID" means the file has been closed already...
+  # or at least that we can't do anything else about it
+  already_closed_msg <- "Error in R_nc4_close: NetCDF: Not a valid ID"
+
+  res <- capture.output(ncdf4::nc_close(ncfile))
+  if (length(res) == 0 || res == already_closed_msg) {
+    # OK, it's closed now
+    return(invisible())
+  } else {
+    PEcAn.logger::logger.error(
+      "Closing NCDF file", ncfile$filename, "failed with message", res)
+  }
+}

--- a/models/biocro/R/close_nc_if_open.R
+++ b/models/biocro/R/close_nc_if_open.R
@@ -15,7 +15,7 @@ close_nc_if_open <- function(ncfile) {
   # or at least that we can't do anything else about it
   already_closed_msg <- "Error in R_nc4_close: NetCDF: Not a valid ID"
 
-  res <- capture.output(ncdf4::nc_close(ncfile))
+  res <- utils::capture.output(ncdf4::nc_close(ncfile))
   if (length(res) == 0 || res == already_closed_msg) {
     # OK, it's closed now
     return(invisible())


### PR DESCRIPTION
Fixes #2485 

The lack of  `@export` on `close_nc_if_open` is intentional -- I think there's a chance but not a certainty that it could be useful to other packages, and it's much easier to export it (probably from a different package) if we need it later than it is to remove an exported function if we change our mind about it.


## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
