### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/data/Dockerfile
+++ b/docker/data/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Rob Kooper <kooper@illinois.edu>
 
 # name to use in the machines table FQDN when registering the data files
 ENV FQDN="" \
-    PSQL="psql -U bety -h postgres -d bety -q -t -"
+    PSQL="psql -U bety -h postgres -d bety -q -t -c"
 
 WORKDIR /work
 


### PR DESCRIPTION
## Description
Fixing a small error in data container Dockerfile

## Motivation and Context
A drooped character in PSQL environment variable is turning "-c" argument for psql command into a "-" which expects standard input into psql shell.  This prevents containerized version of PEcAn from building built when following instructions provided in: https://pecanproject.github.io/pecan-documentation/master/pecan-manual-setup.html failing at 4c ("docker run -ti --rm --network pecan_pecan --volume pecan_pecan:/data --env FQDN=docker pecan/data:develop") stage.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
