### PR TITLE
Enable initial biomass values for Setaria BioCro runs

### DIFF
--- a/models/biocro/R/call_biocro.R
+++ b/models/biocro/R/call_biocro.R
@@ -107,9 +107,20 @@ call_biocro_0.9 <- function(WetDat, genus, year_in_run,
       photoControl = config$pft$photoParms)
 
   } else if (genus %in% c("Sorghum", "Setaria")) {
+    if (year_in_run == 1) {
+      iplant <- config$pft$iPlantControl
+    } else {
+      iplant$iRhizome <- data.table::last(tmp.result$Rhizome)
+      iplant$iRoot <- data.table::last(tmp.result$Root)
+      iplant$iStem <- data.table::last(tmp.result$Stem)
+    }
     ## run BioGro
     tmp.result <- BioCro::BioGro(
       WetDat = WetDat,
+      iRhizome = as.numeric(iplant$iRhizome),
+      iRoot = as.numeric(iplant$iRoot),
+      iStem = as.numeric(iplant$iStem),
+      iLeaf = as.numeric(iplant$iLeaf), 
       day1 = day1,
       dayn = dayn,
       soilControl = l2n(config$pft$soilControl),


### PR DESCRIPTION
`call_biocro` was using the default iPlantControl values when running `BioCro::BioGro` for genera Sorghum and Setaria. 

## Description
Added the code to pull in iPlantControl values from the config.xml to use in `BioGro`. 

## Review Time Estimate
- [ ] Immediately
- [ ] Within one week
- [x] When possible
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)