### PR TITLE
document that compiled packages need make -j1

### DIFF
--- a/book_source/02_demos_tutorials_workflows/05_developer_workflows/01_update_pecan_code.Rmd
+++ b/book_source/02_demos_tutorials_workflows/05_developer_workflows/01_update_pecan_code.Rmd
@@ -40,7 +40,7 @@ The following are some additional `make` tricks that may be useful:
 
 * Force `make` to run, even if package has not changed -- `make -B <command>`
 
-* Run `make` commands in parallel -- `make -j<ncores>`; e.g. `make -j4 install` to install packages using four parallel processes.
+* Run `make` commands in parallel -- `make -j<ncores>`; e.g. `make -j4 install` to install packages using four parallel processes. Note that packages containing compiled code (e.g. PEcAn.RTM, PEcAn.BASGRA) might fail when `j` is greater than 1, because of limitations in the way R calls `make` internally while compiling them. See [GitHub issue 1976](https://github.com/PecanProject/pecan/issues/1976) for more details.
 
 All instructions for the `make` build system are contained in the `Makefile` in the PEcAn root directory.
 For full documentation on `make`, see the man pages by running `man make` from a terminal.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

When building packages with compiled code, R calls Make internally, and those processes don't coordinate with the Make process running the whole PEcAn build. This only causes trouble when our build is called in parallel (`-j` > 1).

I've run into this both for RTM (#1976) and for BASGRA in my experimental GitHub Actions build. It's *possible* that we could make the Makefile be completely parallel-safe for packages with compiled code, but as far as I can tell it'd be an uphill battle and for the moment I advise avoiding the issue by building those two packages with `-j1`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
