### PR TITLE
Remove @inheritParams from list.files.nodir

### DIFF
--- a/models/ed/R/other.helpers.ED2.R
+++ b/models/ed/R/other.helpers.ED2.R
@@ -1,7 +1,12 @@
 #' @title List only files in a directory
-#' 
+#'
+#' Mostly useful when `recursive` and `full.names` are both FALSE:
+#'   The current implementation sets `full.names` internally, and for recursive
+#'   listings `list.files(..., include.dirs = FALSE)` is equivalent and faster.
+#'
 #' @author Alexey Shiklomanov
-#' @inheritParams base::list.files
+#' @param path directory to list
+#' @param ... arguments passed on to base::list.files
 #' @export
 list.files.nodir <- function(path, ...) {
     allfiles <- list.files(path, ...)

--- a/models/ed/man/list.files.nodir.Rd
+++ b/models/ed/man/list.files.nodir.Rd
@@ -2,18 +2,25 @@
 % Please edit documentation in R/other.helpers.ED2.R
 \name{list.files.nodir}
 \alias{list.files.nodir}
-\title{List only files in a directory}
+\title{List only files in a directory
+
+Mostly useful when \code{recursive} and \code{full.names} are both FALSE:
+The current implementation sets \code{full.names} internally, and for recursive
+listings \code{list.files(..., include.dirs = FALSE)} is equivalent and faster.}
 \usage{
 list.files.nodir(path, ...)
 }
 \arguments{
-\item{path}{a character vector of full path names; the default
-    corresponds to the working directory, \code{\link{getwd}()}.  Tilde
-    expansion (see \code{\link{path.expand}}) is performed.  Missing
-    values will be ignored.}
+\item{path}{directory to list}
+
+\item{...}{arguments passed on to base::list.files}
 }
 \description{
 List only files in a directory
+
+Mostly useful when \code{recursive} and \code{full.names} are both FALSE:
+The current implementation sets \code{full.names} internally, and for recursive
+listings \code{list.files(..., include.dirs = FALSE)} is equivalent and faster.
 }
 \author{
 Alexey Shiklomanov


### PR DESCRIPTION
The documentation for base::list.files changed in R 3.6.2, making Roxygen output differ between R versions and therefore causing Travis headaches. This patch resolves this by no providing our own parameter descriptions instead of inheriting them, and adds some usage advice while I was at it.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
