### PR TITLE
[BUILD] list package versions in log

### DIFF
--- a/scripts/travis/script.sh
+++ b/scripts/travis/script.sh
@@ -11,6 +11,18 @@ set -e
     check_git_clean
 )
 
+# DUMP PACKAGE VERSIONS
+(
+    travis_time_start "installed_packages" \
+        "Version info of all installed R packages, for debugging"
+    Rscript -e 'op <- options(width = 1000)' \
+        -e 'pkgs <- as.data.frame(installed.packages())' \
+        -e 'cols <- c("Package", "Version", "MD5sum", "Built", "LibPath")' \
+        -e 'print(pkgs[order(pkgs$Package), cols], row.names = FALSE)' \
+        -e 'options(op)'
+    travis_time_end
+)
+
 # COMPILE PECAN
 (
     travis_time_start "pecan_make_all" "Compiling PEcAn"


### PR DESCRIPTION
Just for convenience when debugging Travis builds, should be especially useful for catching cache gremlins:

Prints all package versions (in a Travis-folded block, to avoid cluttering output)
just before starting the PEcAn make process. Packages may be added or updated after this,
but those will usually show clearly in the log. This at least gives a clear picture of our starting point.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
