### PR TITLE
remove `car` dependency

### DIFF
--- a/docker/depends/pecan.depends
+++ b/docker/depends/pecan.depends
@@ -23,7 +23,6 @@ install2.r -e -s -n -1\
     binaryLogic \
     BioCro \
     bit64 \
-    car \
     coda \
     data.table \
     dataone \

--- a/modules/data.atmosphere/DESCRIPTION
+++ b/modules/data.atmosphere/DESCRIPTION
@@ -19,7 +19,6 @@ Depends:
     methods
 Imports:
     abind (>= 1.4.5),
-    car,
     data.table,
     dplyr,
     geonames (> 0.998),
@@ -39,6 +38,7 @@ Imports:
     PEcAn.remote,
     PEcAn.utils,
     purrr (>= 0.2.3),
+    raster,
     RCurl,
     REddyProc,
     reshape2,

--- a/modules/data.atmosphere/R/extract_local_CMIP5.R
+++ b/modules/data.atmosphere/R/extract_local_CMIP5.R
@@ -92,9 +92,8 @@ extract.local.CMIP5 <- function(outfolder, in.path, start_date, end_date, lat.in
   vars.gcm <- c(vars.gcm.day, vars.gcm.mo)
   
   # Rewriting the dap name to get the closest variable that we have for the GCM (some only give uss stuff at sea level)
-  library(car) # having trouble gettins stuff to work otherwise
-  if(!("huss" %in% vars.gcm)) var$DAP.name <- car::recode(var$DAP.name, "'huss'='hus'")
-  if(!("ps" %in% vars.gcm  )) var$DAP.name <- car::recode(var$DAP.name, "'ps'='psl'")
+  if(!("huss" %in% vars.gcm)) levels(var$DAP.name) <- sub("huss", "hus", levels(var$DAP.name))
+  if(!("ps" %in% vars.gcm  )) levels(var$DAP.name) <- sub("ps", "psl", levels(var$DAP.name))
 
   # Making sure we're only trying to grab the variables we have (i.e. don't try sfcWind if we don't have it)
   var <- var[var$DAP.name %in% vars.gcm,]

--- a/modules/data.atmosphere/tests/Rcheck_reference.log
+++ b/modules/data.atmosphere/tests/Rcheck_reference.log
@@ -38,11 +38,10 @@ Use \uxxxx escapes for other characters.
 * checking whether the namespace can be unloaded cleanly ... OK
 * checking loading without being on the library search path ... OK
 * checking dependencies in R code ... WARNING
-'::' or ':::' import not declared from: ‘raster’
 'library' or 'require' calls not declared from:
-  ‘car’ ‘MASS’ ‘mgcv’
+  ‘MASS’ ‘mgcv’
 'library' or 'require' calls in package code:
-  ‘car’ ‘MASS’ ‘mgcv’
+  ‘MASS’ ‘mgcv’
   Please use :: or requireNamespace() instead.
   See section 'Suggested packages' in the 'Writing R Extensions' manual.
 Package in Depends field not imported from: ‘methods’
@@ -473,4 +472,4 @@ Package has no Sweave vignette sources and no VignetteBuilder field.
 * checking for unstated dependencies in ‘tests’ ... OK
 * checking tests ... SKIPPED
 * DONE
-Status: 9 WARNINGs, 2 NOTEs
+Status: 8 WARNINGs, 2 NOTEs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
For compatibility with R 3.5 and for general paring-down of the number of packages to install: package `car` imports `pbkrtest`, which now requires R >= 3.6.0. Since we only use it for `car::recode` in one function of data.atmosphere, this patch rewrites to use base::levels instead.

Also: While I'm at it, add undeclared `raster` dependency to DESCRIPTION.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
