### PR TITLE
[Travis] rebuild any package not built with this EXACT R version

### DIFF
--- a/scripts/travis/rebuild_pkg_binaries.R
+++ b/scripts/travis/rebuild_pkg_binaries.R
@@ -37,10 +37,9 @@ is_wrong_build <- function(pkgname) {
   # Typical packageDescription(pkgname)$Built result: we only need chars 3-7
   # "R 3.4.4; x86_64-apple-darwin15.6.0; 2019-03-18 04:41:51 UTC; unix"
   built_ver <- R_system_version(substr(built_str, start = 3, stop = 7))
-  sys_ver <- getRversion()
 
-  # major and minor version must match, different patch versions OK
-  built_ver$major != sys_ver$major || built_ver$minor != sys_ver$minor
+  # NB strict comparison: even patch level must agree
+  built_ver != getRversion()
 }
 
 all_pkgs <- installed.packages()[, 1]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Problem: `devtools::install_deps` turns every `warning: package <package> was built under R version <version>` into a build-killing error, and we get a lot of those because c2d4u is serving a mix of packages built with R 3.6.2 and R 3.6.3.

Solution: For now, rebuild every package not built on exactly the same R version as is currently running, and hope we get it back from the Travis cache next time.

At this point I'm not at all sure that c2d4u is actually saving us any time, but am not ready to tear into the scripts enough to try removing it yet.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
