### PR TITLE
Let database generate created_at and updated_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - Update ED docker build, will now build version 2.2.0 and git
 
 ### Changed
+- Functions that update database entries no longer pass `created_at` or `updated_at` timestamps. The database now updates these itself and ensures they are consistently in UTC (#1083).
 - `PEcAn.DB::insert_table` now uses `DBI::dbAppendTable` internally instead of manually constructed SQL (#2552).
 - Rebuilt documentation using Roxygen 7. Readers get nicer formatting of usage sections, writers get more flexible behavior when inheriting parameters and less hassle when maintaining namespaces (#2524).
 - Renamed functions that looked like S3 methods but were not:

--- a/base/db/R/utils_db.R
+++ b/base/db/R/utils_db.R
@@ -446,7 +446,9 @@ db.getShowQueries <- function() {
 ##' @param values values to be queried in fields corresponding to colnames
 ##' @param con database connection object,
 ##' @param create logical: make a record if none found?
-##' @param dates logical: update created_at and updated_at timestamps? Used only if `create` is TRUE
+##' @param dates Ignored.
+##'   Formerly indicated whether to set created_at and updated_at timestamps
+##'   when `create` was TRUE, but the database now always sets them automatically
 ##' @return will numeric
 ##' @export
 ##' @author David LeBauer
@@ -455,16 +457,14 @@ db.getShowQueries <- function() {
 ##' pftid <- get.id("pfts", "name", "salix", con)
 ##' pftid <- get.id("pfts", c("name", "modeltype_id"), c("ebifarm.salix", 1), con)
 ##' }
-get.id <- function(table, colnames, values, con, create=FALSE, dates=FALSE){
+get.id <- function(table, colnames, values, con, create=FALSE, dates=TRUE){
   values <- lapply(values, function(x) ifelse(is.character(x), shQuote(x), x))
   where_clause <- paste(colnames, values , sep = " = ", collapse = " and ")
   query <- paste("select id from", table, "where", where_clause, ";")
   id <- db.query(query = query, con = con)[["id"]]
   if (is.null(id) && create) {
     colinsert <- paste0(colnames, collapse=", ")
-    if (dates) colinsert <- paste0(colinsert, ", created_at, updated_at")
     valinsert <- paste0(values, collapse=", ")
-    if (dates) valinsert <- paste0(valinsert, ", NOW(), NOW()")
     PEcAn.logger::logger.info("INSERT INTO ", table, " (", colinsert, ") VALUES (", valinsert, ")")
     db.query(query = paste0("INSERT INTO ", table, " (", colinsert, ") VALUES (", valinsert, ")"), con = con)
     id <- db.query(query, con)[["id"]]

--- a/base/db/inst/import-try/93.create.try.sites.R
+++ b/base/db/inst/import-try/93.create.try.sites.R
@@ -49,7 +49,7 @@ bety.site.index <- which(names(try.sites) == "bety.site.id")
 
 # f. Loop over rows... 
 radius.query.string <- 'SELECT id, sitename, ST_Y(ST_Centroid(geometry)) AS lat, ST_X(ST_Centroid(geometry)) AS lon, ST_Distance(ST_Centroid(geometry), ST_SetSRID(ST_MakePoint(%2$f, %1$f), 4326)) as distance FROM sites WHERE ST_Distance(ST_Centroid(geometry), ST_SetSRID(ST_MakePoint(%2$f, %1$f), 4326)) <= %3$f'
-insert.query.string <- "INSERT INTO sites(sitename,notes,geometry,user_id,created_at,updated_at) VALUES('%s','%s',ST_Force3D(ST_SetSRID(ST_MakePoint(%f, %f), 4326)),'%s', NOW(), NOW() ) RETURNING id;"
+insert.query.string <- "INSERT INTO sites(sitename,notes,geometry,user_id) VALUES('%s','%s',ST_Force3D(ST_SetSRID(ST_MakePoint(%f, %f), 4326)),'%s' ) RETURNING id;"
 
 message("Looping over sites and adding to BETY")
 pb <- txtProgressBar(0, nrow(try.sites), style=3)

--- a/base/db/inst/import-try/README.md
+++ b/base/db/inst/import-try/README.md
@@ -79,7 +79,5 @@ With a recent-enough R version (> 3.2), we can bring in the following:
           date_day --> ^^
           time_hour --> from measurement time
           time_minute --> ^^
-          created_at --> NOW()
-          updated_at --> NOW()
         2. Store ID at every time step -- match with ObsDataID of TRY? Not perfect because miss time, etc., but may help later.
       

--- a/base/db/man/get.id.Rd
+++ b/base/db/man/get.id.Rd
@@ -4,7 +4,7 @@
 \alias{get.id}
 \title{get.id}
 \usage{
-get.id(table, colnames, values, con, create = FALSE, dates = FALSE)
+get.id(table, colnames, values, con, create = FALSE, dates = TRUE)
 }
 \arguments{
 \item{table}{name of table}
@@ -17,7 +17,9 @@ get.id(table, colnames, values, con, create = FALSE, dates = FALSE)
 
 \item{create}{logical: make a record if none found?}
 
-\item{dates}{logical: update created_at and updated_at timestamps? Used only if `create` is TRUE}
+\item{dates}{Ignored.
+Formerly indicated whether to set created_at and updated_at timestamps
+when `create` was TRUE, but the database now always sets them automatically}
 }
 \value{
 will numeric

--- a/base/db/tests/Rcheck_reference.log
+++ b/base/db/tests/Rcheck_reference.log
@@ -56,7 +56,6 @@ get_users: no visible binding for global variable ‘id’
 get_workflow_ids: no visible binding for global variable ‘workflow_id’
 get.trait.data.pft: no visible binding for global variable ‘pft_id’
 get.trait.data.pft: no visible binding for global variable ‘created_at’
-get.trait.data.pft: no visible global function definition for ‘head’
 get.trait.data.pft: no visible binding for global variable ‘stat’
 get.trait.data.pft: no visible binding for global variable ‘trait’
 insert.format.vars: no visible binding for global variable ‘id’

--- a/base/settings/R/check.all.settings.R
+++ b/base/settings/R/check.all.settings.R
@@ -940,23 +940,22 @@ check.workflow.settings <- function(settings, dbcon = NULL) {
     if (!"workflow" %in% names(settings)) {
       now <- format(Sys.time(), "%Y-%m-%d %H:%M:%S")
       if (is.MultiSettings(settings)) {
-        PEcAn.DB::db.query(
+        insert_result <- PEcAn.DB::db.query(
           paste0(
             "INSERT INTO workflows (",
-              "folder, model_id, hostname, started_at, created_at) ",
+              "folder, model_id, hostname, started_at) ",
             "values ('",
               settings$outdir, "','",
               settings$model$id, "', '",
               settings$host$name, "', '",
-              now, "', '",
-              now, "')"),
+              now, "') RETURNING id"),
           con = dbcon)
       } else {
-        PEcAn.DB::db.query(
+        insert_result <- PEcAn.DB::db.query(
           paste0(
             "INSERT INTO workflows (",
               "folder, site_id, model_id, hostname, start_date, end_date, ",
-              "started_at, created_at) ",
+              "started_at) ",
             "values ('",
               settings$outdir, "','",
               settings$run$site$id, "','",
@@ -964,15 +963,10 @@ check.workflow.settings <- function(settings, dbcon = NULL) {
               settings$host$name, "', '",
               settings$run$start.date, "', '",
               settings$run$end.date, "', '",
-              now, "', '",
-              now, "')"),
+              now, "') RETURNING id"),
           con = dbcon)
       }
-      settings$workflow$id <- PEcAn.DB::db.query(
-        paste0(
-          "SELECT id FROM workflows WHERE created_at='", now,
-          "' ORDER BY id DESC LIMIT 1;"),
-        con = dbcon)[["id"]]
+      settings$workflow$id <- insert_result[["id"]]
       fixoutdir <- TRUE
     }
   } else {

--- a/docker/data/add.util.sh
+++ b/docker/data/add.util.sh
@@ -33,7 +33,7 @@ addFormat() {
     fi
     FORMAT_ID=$( ${PSQL} "SELECT id FROM formats WHERE mimetype_id=${MIME_ID} AND name='$2' LIMIT 1;" )
     if [ "$FORMAT_ID" == "" ]; then
-        ${PSQL} "INSERT INTO formats (mimetype_id, name, created_at, updated_at) VALUES (${MIME_ID}, '$2', NOW(), NOW());"
+        ${PSQL} "INSERT INTO formats (mimetype_id, name) VALUES (${MIME_ID}, '$2');"
         FORMAT_ID=$( ${PSQL} "SELECT id FROM formats WHERE mimetype_id=${MIME_ID} AND name='$2' LIMIT 1;" )
         echo "Added new format with ID=${FORMAT_ID} for mimetype_id=${MIME_ID}, name=$2"
     fi
@@ -62,7 +62,7 @@ addInput() {
     fi
     INPUT_ID=$( ${PSQL} "SELECT id FROM inputs WHERE site_id=$1 AND format_id=$2 AND start_date${START_Q} AND end_date${END_Q} LIMIT 1;" )
     if [ "$INPUT_ID" == "" ]; then
-        ${PSQL} "INSERT INTO inputs (site_id, format_id, name, start_date, end_date, created_at, updated_at) VALUES ($1, $2, '', ${START_I}, ${END_I}, NOW(), NOW());"
+        ${PSQL} "INSERT INTO inputs (site_id, format_id, name, start_date, end_date) VALUES ($1, $2, '', ${START_I}, ${END_I});"
         INPUT_ID=$( ${PSQL} "SELECT id FROM inputs WHERE site_id=$1 AND format_id=$2 AND start_date${START_Q} AND end_date${END_Q} LIMIT 1;" )
         echo "Added new input with ID=${INPUT_ID} for site=$1, format_id=$2, start=$3, end=$4"
     else
@@ -93,8 +93,8 @@ addInputFile() {
     fi
 
     # Make sure host exists
-    ${PSQL} "INSERT INTO machines (hostname, created_at, updated_at)
-        SELECT *, now(), now() FROM (SELECT '${1}') AS tmp WHERE NOT EXISTS ${HOSTID};"
+    ${PSQL} "INSERT INTO machines (hostname)
+        SELECT * FROM (SELECT '${1}') AS tmp WHERE NOT EXISTS ${HOSTID};"
 
     # Add file
     ${PSQL} "INSERT INTO dbfiles (container_type, container_id, file_name, file_path, machine_id) VALUES
@@ -116,16 +116,16 @@ addModelFile() {
   MODELID="(SELECT models.id FROM models, modeltypes WHERE model_name='${2}' AND modeltypes.name='${3}' AND modeltypes.id=models.modeltype_id AND revision='${4}')"
 
 	# Make sure host exists
-	${PSQL} "INSERT INTO machines (hostname, created_at, updated_at)
-		SELECT *, now(), now() FROM (SELECT '${1}') AS tmp WHERE NOT EXISTS ${HOSTID};"
+	${PSQL} "INSERT INTO machines (hostname)
+		SELECT * FROM (SELECT '${1}') AS tmp WHERE NOT EXISTS ${HOSTID};"
 
 	# Make sure modeltype exists
-  ${PSQL}  "INSERT INTO modeltypes (name, created_at, updated_at)
-    SELECT *, now(), now() FROM (SELECT '${3}') AS tmp WHERE NOT EXISTS ${MODELTYPEID};"
+  ${PSQL}  "INSERT INTO modeltypes (name)
+    SELECT * FROM (SELECT '${3}') AS tmp WHERE NOT EXISTS ${MODELTYPEID};"
 
   # Make sure model exists
-	${PSQL}  "INSERT INTO models (model_name, modeltype_id, revision, created_at, updated_at)
-		SELECT *, now(), now() FROM (SELECT '${2}', ${MODELTYPEID}, '${4}') AS tmp WHERE NOT EXISTS ${MODELID};"
+	${PSQL}  "INSERT INTO models (model_name, modeltype_id, revision)
+		SELECT * FROM (SELECT '${2}', ${MODELTYPEID}, '${4}') AS tmp WHERE NOT EXISTS ${MODELID};"
 
   # check if binary already added
   COUNT=$( ${PSQL} "SELECT COUNT(id) FROM dbfiles WHERE container_type='Model' AND container_id=${MODELID} AND file_name='${5}' AND file_path='${6}' and machine_id=${HOSTID};" )

--- a/docker/monitor/monitor.py
+++ b/docker/monitor/monitor.py
@@ -164,8 +164,8 @@ def insert_model(model_info):
         else:
             logging.debug("Adding host")
             cur = conn.cursor()
-            cur.execute('INSERT INTO machines (hostname, created_at, updated_at) '
-                        'VALUES (%s,  now(), now()) RETURNING id', (pecan_fqdn,))
+            cur.execute('INSERT INTO machines (hostname) '
+                        'VALUES (%s) RETURNING id', (pecan_fqdn))
             result = cur.fetchone()
             cur.close()
             if not result:
@@ -184,8 +184,8 @@ def insert_model(model_info):
         else:
             logging.debug("Adding modeltype")
             cur = conn.cursor()
-            cur.execute('INSERT INTO modeltypes (name, created_at, updated_at) '
-                        'VALUES (%s,  now(), now()) RETURNING id', (model_info['type'],))
+            cur.execute('INSERT INTO modeltypes (name) '
+                        'VALUES (%s) RETURNING id', (model_info['type']))
             result = cur.fetchone()
             cur.close()
             if not result:
@@ -205,8 +205,8 @@ def insert_model(model_info):
         else:
             logging.debug("Adding model")
             cur = conn.cursor()
-            cur.execute('INSERT INTO models (model_name, modeltype_id, revision, created_at, updated_at) '
-                        'VALUES (%s, %s, %s, now(), now()) RETURNING id',
+            cur.execute('INSERT INTO models (model_name, modeltype_id, revision) '
+                        'VALUES (%s, %s, %s) RETURNING id',
                         (model_info['name'], model_type_id, model_info['version']))
             result = cur.fetchone()
             cur.close()
@@ -231,8 +231,8 @@ def insert_model(model_info):
             logging.debug("Adding model binary")
             cur = conn.cursor()
             cur.execute("INSERT INTO dbfiles (container_type, container_id, file_name, file_path,"
-                        " machine_id, created_at, updated_at)"
-                        " VALUES ('Model', %s, %s, %s, %s, now(), now()) RETURNING id",
+                        " machine_id)"
+                        " VALUES ('Model', %s, %s, %s, %s) RETURNING id",
                         (model_id, os.path.basename(model_info['binary']),
                          os.path.dirname(model_info['binary']), host_id))
             result = cur.fetchone()

--- a/modules/data.land/inst/LoadFLUXNETsites.R
+++ b/modules/data.land/inst/LoadFLUXNETsites.R
@@ -96,7 +96,7 @@ for(s in 1:nsite){
                   " TOWER_BEGAN =",as.character(AMERIFLUX_table$TOWER_BEGAN[s]),
                   " TOWER_END =",as.character(AMERIFLUX_table$TOWER_END[s])
                   )
-    InsertString = paste0("INSERT INTO sites(sitename,country,mat,map,notes,geometry,user_id,created_at,updated_at) VALUES(",
+    InsertString = paste0("INSERT INTO sites(sitename,country,mat,map,notes,geometry,user_id) VALUES(",
                           "'",sitename,"', ",
                           "'",country,"', ",
                           mat,", ",
@@ -104,7 +104,7 @@ for(s in 1:nsite){
                           "'",notes,"', ",
                           "ST_GeomFromText('POINT(",lon," ",lat," ",elev,")', 4326), ",
                           user.id,
-                          ", NOW(), NOW() );")
+                          ");")
     db.query(InsertString,con)        
   }
     
@@ -185,13 +185,13 @@ for(s in 1:nsite){
     notes = paste0("PI: ",PI,"; ",site.char,"; FLUXNET DESCRIPTION: ",description)
     notes = gsub("'","",notes) # drop single quotes from notes
     
-    InsertString = paste0("INSERT INTO sites(sitename,country,notes,geometry,user_id,created_at,updated_at) VALUES(",
+    InsertString = paste0("INSERT INTO sites(sitename,country,notes,geometry,user_id) VALUES(",
                           "'",sitename,"', ",
                           "'",country,"', ",
                           "'",notes,"', ",
                           "ST_GeomFromText('POINT(",lon," ",lat," ",elev,")', 4326), ",
                           user.id,
-                          ", NOW(), NOW() );")
+                          ");")
     db.query(InsertString,con)
     
   } ## end IF new site

--- a/scripts/add.util.sh
+++ b/scripts/add.util.sh
@@ -38,7 +38,7 @@ addFormat() {
     fi
     FORMAT_ID=$( ${PSQL} "SELECT id FROM formats WHERE mimetype_id=${MIME_ID} AND name='$2' LIMIT 1;" )
     if [ "$FORMAT_ID" == "" ]; then
-        ${PSQL} "INSERT INTO formats (mimetype_id, name, created_at, updated_at) VALUES (${MIME_ID}, '$2', NOW(), NOW());"
+        ${PSQL} "INSERT INTO formats (mimetype_id, name) VALUES (${MIME_ID}, '$2');"
         FORMAT_ID=$( ${PSQL} "SELECT id FROM formats WHERE mimetype_id=${MIME_ID} AND name='$2' LIMIT 1;" )
         echo "Added new format with ID=${FORMAT_ID} for mimetype_id=${MIME_ID}, name=$2"
     fi
@@ -67,7 +67,7 @@ addInput() {
     fi
     INPUT_ID=$( ${PSQL} "SELECT id FROM inputs WHERE site_id=$1 AND format_id=$2 AND start_date${START_Q} AND end_date${END_Q} LIMIT 1;" )
     if [ "$INPUT_ID" == "" ]; then
-        ${PSQL} "INSERT INTO inputs (site_id, format_id, name, start_date, end_date, created_at, updated_at) VALUES ($1, $2, '', ${START_I}, ${END_I}, NOW(), NOW());"
+        ${PSQL} "INSERT INTO inputs (site_id, format_id, name, start_date, end_date) VALUES ($1, $2, '', ${START_I}, ${END_I});"
         INPUT_ID=$( ${PSQL} "SELECT id FROM inputs WHERE site_id=$1 AND format_id=$2 AND start_date${START_Q} AND end_date${END_Q} LIMIT 1;" )
         echo "Added new input with ID=${INPUT_ID} for site=$1, format_id=$2, start=$3, end=$4"
     else
@@ -98,8 +98,8 @@ addInputFile() {
     fi
 
     # Make sure host exists
-    ${PSQL} "INSERT INTO machines (hostname, created_at, updated_at)
-        SELECT *, now(), now() FROM (SELECT '${1}') AS tmp WHERE NOT EXISTS ${HOSTID};"
+    ${PSQL} "INSERT INTO machines (hostname)
+        SELECT * FROM (SELECT '${1}') AS tmp WHERE NOT EXISTS ${HOSTID};"
 
     # Add file
     ${PSQL} "INSERT INTO dbfiles (container_type, container_id, file_name, file_path, machine_id) VALUES
@@ -121,16 +121,16 @@ addModelFile() {
   MODELID="(SELECT models.id FROM models, modeltypes WHERE model_name='${2}' AND modeltypes.name='${3}' AND modeltypes.id=models.modeltype_id AND revision='${4}')"
 
 	# Make sure host exists
-	${PSQL} "INSERT INTO machines (hostname, created_at, updated_at)
-		SELECT *, now(), now() FROM (SELECT '${1}') AS tmp WHERE NOT EXISTS ${HOSTID};"
+	${PSQL} "INSERT INTO machines (hostname)
+		SELECT * FROM (SELECT '${1}') AS tmp WHERE NOT EXISTS ${HOSTID};"
 
 	# Make sure modeltype exists
-  ${PSQL}  "INSERT INTO modeltypes (name, created_at, updated_at)
-    SELECT *, now(), now() FROM (SELECT '${3}') AS tmp WHERE NOT EXISTS ${MODELTYPEID};"
+  ${PSQL}  "INSERT INTO modeltypes (name)
+    SELECT * FROM (SELECT '${3}') AS tmp WHERE NOT EXISTS ${MODELTYPEID};"
 
   # Make sure model exists
-	${PSQL}  "INSERT INTO models (model_name, modeltype_id, revision, created_at, updated_at)
-		SELECT *, now(), now() FROM (SELECT '${2}', ${MODELTYPEID}, '${4}') AS tmp WHERE NOT EXISTS ${MODELID};"
+	${PSQL}  "INSERT INTO models (model_name, modeltype_id, revision)
+		SELECT * FROM (SELECT '${2}', ${MODELTYPEID}, '${4}') AS tmp WHERE NOT EXISTS ${MODELID};"
 
   # check if binary already added
   COUNT=$( ${PSQL} "SELECT COUNT(id) FROM dbfiles WHERE container_type='Model' AND container_id=${MODELID} AND file_name='${5}' AND file_path='${6}' and machine_id=${HOSTID};" )

--- a/web/04-runpecan.php
+++ b/web/04-runpecan.php
@@ -163,9 +163,9 @@ $stmt->closeCursor();
 // create the workflow execution
 $userid=get_userid();
 if ($userid != -1) {
-  $q=$pdo->prepare("INSERT INTO workflows (site_id, model_id, notes, folder, hostname, start_date, end_date, advanced_edit, started_at, created_at, user_id) values (:siteid, :modelid, :notes, '', :hostname, :startdate, :enddate, :advanced_edit, NOW(), NOW(), :userid)");
+  $q=$pdo->prepare("INSERT INTO workflows (site_id, model_id, notes, folder, hostname, start_date, end_date, advanced_edit, started_at, user_id) values (:siteid, :modelid, :notes, '', :hostname, :startdate, :enddate, :advanced_edit, NOW(), :userid)");
 } else {
-  $q=$pdo->prepare("INSERT INTO workflows (site_id, model_id, notes, folder, hostname, start_date, end_date, advanced_edit, started_at, created_at) values (:siteid, :modelid, :notes, '', :hostname, :startdate, :enddate, :advanced_edit, NOW(), NOW())");
+  $q=$pdo->prepare("INSERT INTO workflows (site_id, model_id, notes, folder, hostname, start_date, end_date, advanced_edit, started_at) values (:siteid, :modelid, :notes, '', :hostname, :startdate, :enddate, :advanced_edit, NOW())");
 }
 $q->bindParam(':siteid', $siteid, PDO::PARAM_INT);
 $q->bindParam(':modelid', $modelid, PDO::PARAM_INT);

--- a/web/setups/serversyncscript.php
+++ b/web/setups/serversyncscript.php
@@ -64,12 +64,10 @@ if ($row == false) {
 
   $date = date("Y-m-d H:i:s");
   $stmt = $pdo->prepare("INSERT
-    INTO machines (id, hostname, created_at, updated_at , sync_host_id, sync_url, sync_contact, sync_start, sync_end)
-    VALUES (:id, :hostname, :created_at, :updated_at , :sync_host_id, :sync_url, :sync_contact, :sync_start, :sync_end );");
+    INTO machines (id, hostname, sync_host_id, sync_url, sync_contact, sync_start, sync_end)
+    VALUES (:id, :hostname, :sync_host_id, :sync_url, :sync_contact, :sync_start, :sync_end );");
   $stmt->bindValue(':id', $id, PDO::PARAM_INT);
   $stmt->bindValue(':hostname', $fqdn, PDO::PARAM_STR);
-  $stmt->bindValue(':created_at', $date, PDO::PARAM_STR);
-  $stmt->bindValue(':updated_at', $date, PDO::PARAM_STR);
   $stmt->bindValue(':sync_host_id', $host_id, PDO::PARAM_INT);
   $stmt->bindValue(':sync_url', ' ', PDO::PARAM_STR);
   $stmt->bindValue(':sync_contact', ' ', PDO::PARAM_STR);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Closes #1083 by removing all `created_at` and `updated_at`s from INSERT statements, because the database will handle these for us automatically . 

I have tested locally and confirmed the PEcAn.DB unit tests pass and the add.*.sh scripts still work as expected; I have not test-run the PHP or SDA changes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As discussed in #1038 and elsewhere, this doesn't change the goal to move away from having hand-built SQL in our R code at all. But it does make the SQL we have a bit cleaner and eliminate a source of errors from non-UTC timestamps.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
