### PR TITLE
set locale when comparing check output

### DIFF
--- a/scripts/check_with_errors.R
+++ b/scripts/check_with_errors.R
@@ -1,5 +1,9 @@
 #!/usr/bin/env Rscript
 
+# Avoid some spurious failures from platform-dependent sorting
+invisible(Sys.setlocale("LC_ALL", "en_US.UTF-8")) # sets sorting in this script
+Sys.setenv(LC_ALL = "en_US.UTF-8") # sets sorting in rcmdcheck processes
+
 arg <- commandArgs(trailingOnly = TRUE)
 pkg <- arg[1]
 


### PR DESCRIPTION
Should cut down on failures caused by sort order within lines

Example: reference check result contains `imports not declared from: 'dplyr' 'PEcAn.DB'`,
but on OS X with my default locale the new result becomes `imports not declared from: 'PEcAn.DB' 'dplyr'` and is reported as a failure.

Yes, we have to call both `Sys.setlocale` and `Set.setenv`, because we need to set locale both
inside the current session and for rcmdcheck::rcmdcheck (which runs in its own process).

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
