### PR TITLE
Fixed not triggering of "All values bad" in call_MODIS

### DIFF
--- a/modules/data.remote/R/call_MODIS.R
+++ b/modules/data.remote/R/call_MODIS.R
@@ -244,7 +244,7 @@ call_MODIS <- function(var, product,
       output$qc[i] <- substr(convert, nchar(convert) - 2, nchar(convert))
     }
     good <- which(output$qc %in% c("000", "001"))
-    if (length(good) > 0 || !(is.null(good)))
+    if (length(good) > 0)
     {
       output <- output[good, ]
     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
Even when `good` is an empty vector it does not display "all values bad" message. I have removed `!(is.null(good)))` to fix this.
## Motivation and Context
Fixes #2520  

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
