### PR TITLE
don't override random.effects = TRUE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - When building sipnet model would not set correct model version
 - Update pecan/depends docker image to have latest Roxygen and devtools.
 - Update ED docker build, will now build version 2.2.0 and git
+- Do not override meta-analysis settings random-effects = FALSE https://github.com/PecanProject/pecan/pull/2625
 
 ### Changed
 

--- a/modules/meta.analysis/R/meta.analysis.R
+++ b/modules/meta.analysis/R/meta.analysis.R
@@ -109,11 +109,10 @@ pecan.ma <- function(trait.data, prior.distns,
     ## check for excess missing data
 
     if (all(is.na(data[["obs.prec"]]))) {
-      if (verbose) {
-        writeLines("NO ERROR STATS PROVIDED, DROPPING RANDOM EFFECTS")
-      }
-      data$site <- rep(1, nrow(data))
-      data$trt  <- rep(0, nrow(data))
+      logger.warn("NO ERROR STATS PROVIDED\n Check meta-analysis Model Convergence", 
+                  "and consider turning off Random Effects by", 
+                  "setting <random.effects>FALSE</random.effects>",
+                  "in your pecan.xml settings file ")
     }
 
     if (!random) {

--- a/modules/meta.analysis/R/meta.analysis.R
+++ b/modules/meta.analysis/R/meta.analysis.R
@@ -109,7 +109,7 @@ pecan.ma <- function(trait.data, prior.distns,
     ## check for excess missing data
 
     if (all(is.na(data[["obs.prec"]]))) {
-      logger.warn("NO ERROR STATS PROVIDED\n Check meta-analysis Model Convergence", 
+      PEcAn.logger::logger.warn("NO ERROR STATS PROVIDED\n Check meta-analysis Model Convergence", 
                   "and consider turning off Random Effects by", 
                   "setting <random.effects>FALSE</random.effects>",
                   "in your pecan.xml settings file ")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description

Current behavior: if random effects = TRUE in pecan.xml but none of the trait data have statistics then random effects is set to FALSE. A message is written to the log but this is mostly a hidden assumption that should be up to the user - because it may indicate an incorrect assumption about the data or missing data, or an overspecified model etc.

This was done because models will not converge if there are insufficient data to estimate all of the random effects parameters. 



## Motivation and Context

I think setting random.effects = FALSE should be a decision made by the end uer.

Even when implemented in 2011, it was not clear that this was necessary. See my comment here https://github.com/PecanProject/pecan/commit/f6bcb78ea144e564bae781e32bcc307e9ec793b3#r8861144

Two other options:

1. come up with a more sophisticated rule for identifying data that will lead to underspecified models
  * not really a good idea - I vote pass it back to the user so they can evaluate the data and model
2. upgrade to @ashiklom 's multivariate version of the code
  * Good plan, but this will fix what I currently believe is a bug

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (there is no existing issue - it was found by @KristinaRiemer and discussed in Slack)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
