### PR TITLE
Improve checking for output variable names in model2necdf.ED2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - Update pecan/depends docker image to have latest Roxygen and devtools.
 - Update ED docker build, will now build version 2.2.0 and git
 - Do not override meta-analysis settings random-effects = FALSE https://github.com/PecanProject/pecan/pull/2625
+- model2netcdf.ED2 no longer detecting which varibles names `-T-` files have based on ED2 version (#2623)
 
 ### Changed
 

--- a/models/ed/R/model2netcdf.ED2.R
+++ b/models/ed/R/model2netcdf.ED2.R
@@ -280,9 +280,19 @@ read_T_files <- function(yr, yfiles, tfiles, outdir, start_date, end_date, ...){
     }
   }
   
-  CheckED2Version <- function(nc) {
+  CheckED2Variables <- function(nc) {
+    vars_detected <- NULL
+  
     if ("FMEAN_BDEAD_PY" %in% names(nc$var)) {
-      return("Git")
+      vars_detected <- c(vars_detected,"FMEAN_BDEAD_PY")
+      return("Contains_FMEAN")
+    }
+    if ("FMEAN_SOIL_TEMP_PY" %in% names(nc$var)) {
+      vars_detected <- c(vars_detected, "FMEAN_SOIL_TEMP_PY")
+      return("Contains_FMEAN")
+    }
+    if(!is.null(vars_detected)){
+      PEcAn.logger::logger.warn(paste("Found variable(s): ", paste(vars_detected, collapse = " "), ", now processing FMEAN* named variables. Note that varible naming conventions may change with ED2 version."))
     }
   }
 
@@ -324,8 +334,8 @@ read_T_files <- function(yr, yfiles, tfiles, outdir, start_date, end_date, ...){
     slzdata <- array(c(-2, -1.5, -1, -0.8, -0.6, -0.4, -0.2, -0.1, -0.05))
   }
   
-  ## Check for which version of ED2 we are using.
-  ED2vc <- CheckED2Version(ncT)
+  ## Check for what naming convention of ED2 vars we are using. May change with ED2 version. 
+  ED2vc <- CheckED2Variables(ncT)
   
   ## store for later use, will only use last data
   dz <- diff(slzdata)


### PR DESCRIPTION
model2netcdf.ED2 will only process output with an `FMEAN*` naming convention if it finds the variable `FMEAN_BDEAD_PY`. This causes issues if `FMEAN_BDEAD_PY` is missing. The function is written to assume that all non-"git" builds of ED2 don't have the `FMEAN*` naming convention. 

## Fixes
- added a check for an additional FMEAN Variable
- added a warning 
- changed the check function name from CheckED2Version to CheckED2Variables

## Motivation and Context
Different pecan users have different versions of the ED2 model that they are using. Different ED2 versions, and builds, have different output names as part of the `-T-` file output. The read_T_files function supports two different types of output names, [AVE*](https://github.com/PecanProject/pecan/blob/develop/models/ed/R/model2netcdf.ED2.R#L498) names, and [FMEAN*](https://github.com/PecanProject/pecan/blob/develop/models/ed/R/model2netcdf.ED2.R#L336) names. 

Previously, `read_T_files()` would check for one variable `FMEAN_BDEAD_PY`, and if it existed, it would say the ED2 version was "Git" and switch to the `FMEAN*`  names. This caused issues for me, because I was not producing `FMEAN_BDEAD_PY`, but was using the FMEAN* names. 

This PR is a more general solution to the issue I opened [here](https://github.com/PecanProject/pecan/issues/2623). 

I moved away from the assumption that the version of ED2 is the only thing that is determining variable names, because 1) "Git" is an ED2 build used with pecan, but doesn't map onto an ED2 version clearly 2) people's personal builds of ED2 will deviate from versions anyway 


## Review Time Estimate
<!---When do you want your code reviewed by?-->
This is a very small PR, and should take <5 min to review. 
- [x ] Immediately
- [ ] Within one week
- [x ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
