### PR TITLE
Fix for failing documentation build

### DIFF
--- a/book_source/Makefile
+++ b/book_source/Makefile
@@ -23,7 +23,10 @@ DEMO_1_FIGS := $(wildcard ../documentation/tutorials/01_Demo_Basic_Run/extfiles/
 build: bkdcheck
 	mkdir -p extfiles
 	cp -f ${DEMO_1_FIGS} extfiles/
-	Rscript -e 'bookdown::render_book("index.Rmd", "bookdown::gitbook")'
+	# options call is a workaround for a behavior change and probable bug in bookdown 0.20:
+	# https://stackoverflow.com/a/62583304
+	# Remove when this is fixed in Bookdown
+	Rscript -e 'options(bookdown.render.file_scope=FALSE); bookdown::render_book("index.Rmd", "bookdown::gitbook")'
 
 clean:
 	rm -rf ../book/*
@@ -32,4 +35,4 @@ deploy: build
 	./deploy.sh
 
 pdf: bkdcheck
-	Rscript -e 'bookdown::render_book("index.Rmd", "bookdown::pdf_book")'
+	Rscript -e 'options(bookdown.render.file_scope=FALSE); bookdown::render_book("index.Rmd", "bookdown::pdf_book")'


### PR DESCRIPTION
the PEcAn documentation is not currently building because Travis has updated to bookdown 0.20, which [interacts poorly](https://stackoverflow.com/a/62583304) with our multiple-subdirectory file organization. I predict this will be fixed in the next release of bookdown, but here's a workaround in the meantime.

Thanks to @MukulMaheshwari and @tezansahu for reporting.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
