### PR TITLE
Updating precipitation downscale for NOAA GEFS downscale 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - Update ED docker build, will now build version 2.2.0 and git
 - Do not override meta-analysis settings random-effects = FALSE https://github.com/PecanProject/pecan/pull/2625
 - model2netcdf.ED2 no longer detecting which varibles names `-T-` files have based on ED2 version (#2623)
+ 
 
 ### Changed
 
@@ -40,7 +41,8 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - No longer writing an arbitrary num for each PFT, this was breaking ED runs potentially.
 - The pecan/data container has no longer hardcoded path for postgres
 - PEcAn.JULES: Removed dependency on `ncdf4.helpers` package, which has been removed from CRAN (#2511).
-- data.remote: Arguments to the function `call_MODIS()` have been changed (issue #2519).  
+- data.remote: Arguments to the function `call_MODIS()` have been changed (issue #2519). 
+- Changed precipitaion downscale in `PEcAn.data.atmosphere::download.NOAA_GEFS_downscale`. Precipitation was being downscaled via a spline which was causing fake rain events. Instead the 6 hr precipitation flux values from GEFS are preserved with 0's filling in the hours between. 
 
 ### Added
 

--- a/modules/data.atmosphere/R/download.NOAA_GEFS_downscale.R
+++ b/modules/data.atmosphere/R/download.NOAA_GEFS_downscale.R
@@ -243,12 +243,14 @@ download.NOAA_GEFS_downscale <- function(outfolder, lat.in, lon.in, sitename, st
     dplyr::summarize(surface_downwelling_shortwave_flux_in_air = mean(surface_downwelling_shortwave_flux_in_air))
   
   ## Downscale Precipitation Flux 
+    #fills in the hours between the 6hr GEFS with zeros using the timestamp from downscaled Flux
   precip.hrly <- forecasts %>% 
-    dplyr::select(timestamp, NOAA.member, precipitation_flux) %>%
-    tidyr::complete(timestamp = nonSW.flux.hrly$timestamp, nesting(NOAA.member), fill = list(precipitation_flux = 0)) 
+    dplyr::select(timestamp, NOAA.member, precipitation_flux) %>% 
+    tidyr::complete(timestamp = nonSW.flux.hrly$timestamp, tidyr::nesting(NOAA.member), fill = list(precipitation_flux = 0)) 
   
-  
-  joined<-  dplyr::inner_join(gefs_hour, nonSW.flux.hrly, by = c("NOAA.member", "timestamp"))
+#join together the 4 different downscaled data frames
+  #checks for errors in downscaled data; removes NA times; replaces erroneous values with 0's or NA's 
+  joined<-  dplyr::inner_join(gefs_hour, nonSW.flux.hrly, by = c("NOAA.member", "timestamp")) 
   joined<-  dplyr::inner_join(joined, precip.hrly, by = c("NOAA.member", "timestamp"))
   
   joined <- dplyr::inner_join(joined, ShortWave.ds, by = c("NOAA.member", "timestamp")) %>% 

--- a/modules/data.atmosphere/R/download.NOAA_GEFS_downscale.R
+++ b/modules/data.atmosphere/R/download.NOAA_GEFS_downscale.R
@@ -44,7 +44,7 @@
 ##' 
 
 
-download.NOAA_GEFS_downscale <- function(outfolder, lat.in, lon.in, sitename, start_date = Sys.time(), end_date = (as.POSIXct(start_date, tz="UTC") + lubridate::days(16)),
+download.NOAA_GEFS_downscale <- function(outfolder, lat.in, lon.in, sitename, start_date, end_date,
                                          overwrite = FALSE, verbose = FALSE, ...) {
   
   start_date <- as.POSIXct(start_date, tz = "UTC")
@@ -63,7 +63,7 @@ download.NOAA_GEFS_downscale <- function(outfolder, lat.in, lon.in, sitename, st
     PEcAn.logger::logger.severe("Invalid dates: end date occurs before start date")
   } else if (as.numeric(end_date - start_date, units="hours") < 6) { #Done separately to produce a more helpful error message.
     PEcAn.logger::logger.severe("Times not far enough appart for a forecast to fall between them.  Forecasts occur every six hours; make sure start 
-                                and end dates are at least 6 hours appart.")
+                                and end dates are at least 6 hours apart.")
   }
   
   #Set the end forecast date (default is the full 16 days)
@@ -74,7 +74,7 @@ download.NOAA_GEFS_downscale <- function(outfolder, lat.in, lon.in, sitename, st
   
   #Round the starting date/time down to the previous block of 6 hours.  Adjust the time frame to match.
   forecast_hour = (lubridate::hour(start_date) %/% 6) * 6 #Integer division by 6 followed by re-multiplication acts like a "floor function" for multiples of 6
-  increments = as.integer(as.numeric(end_date - start_date, units = "hours") / 6) #Calculating the number of forecasts between start and end dates.
+  increments = as.integer(as.numeric(end_date - start_date, units = "hours") / 6) #Calculating the number of forecasts between start and end dates 
   increments = increments + ((lubridate::hour(end_date) - lubridate::hour(start_date)) %/% 6) #These calculations are required to use the rnoaa package.
   
   end_hour = sprintf("%04d", ((forecast_hour + (increments * 6)) %% 24) * 100)  #Calculating the starting hour as a string, which is required type to access the 
@@ -87,7 +87,7 @@ download.NOAA_GEFS_downscale <- function(outfolder, lat.in, lon.in, sitename, st
   
   end_date = start_date + lubridate::hours(increments * 6)
   
-
+  
   #Bounds date checking
   #NOAA's GEFS database maintains a rolling 12 days of forecast data for access through this function.
   #We do want Sys.Date() here - NOAA makes data unavaliable days at a time, not forecasts at a time.
@@ -136,12 +136,12 @@ download.NOAA_GEFS_downscale <- function(outfolder, lat.in, lon.in, sitename, st
   noaa_data = list()
   
   #Downloading the data here.  It is stored in a matrix, where columns represent time in intervals of 6 hours, and rows represent
-  #each ensemble member.  Each variable getxs its own matrix, which is stored in the list noaa_data.
- 
+  #each ensemble member.  Each variable gets its own matrix, which is stored in the list noaa_data.
   
-   for (i in 1:length(noaa_var_names)) {
-     noaa_data[[i]] = rnoaa::gefs(noaa_var_names[i], lat.in, lon.in, raw=TRUE, time_idx = seq_len(increments), forecast_time = forecast_hour, date=format(start_date, "%Y%m%d"))$data
-   }
+  
+  for (i in 1:length(noaa_var_names)) {
+    noaa_data[[i]] = rnoaa::gefs(noaa_var_names[i], lat.in, lon.in, raw=TRUE, time_idx = seq_len(increments), forecast_time = forecast_hour, date=format(start_date, "%Y%m%d"))$data
+  }
   
   #Fills in data with NaNs if there happens to be missing columns.
   for (i in 1:length(noaa_var_names)) {
@@ -226,7 +226,8 @@ download.NOAA_GEFS_downscale <- function(outfolder, lat.in, lon.in, sitename, st
   forecasts$wind_speed <- sqrt(forecasts$eastward_wind^ 2 + forecasts$northward_wind^ 2)
   
   ### Downscale state variables 
-  gefs_hour <- PEcAn.data.atmosphere::downscale_spline_to_hourly(df = forecasts, VarNamesStates = c("air_temperature", "wind_speed", "specific_humidity", "precipitation_flux", "air_pressure"))
+  gefs_hour <- PEcAn.data.atmosphere::downscale_spline_to_hourly(df = forecasts, VarNamesStates = c("air_temperature", "wind_speed", "specific_humidity", "air_pressure"))
+  
   
   ## convert longwave to hourly (just copy 6 hourly values over past 6-hour time period)
   nonSW.flux.hrly <- forecasts %>%
@@ -241,8 +242,14 @@ download.NOAA_GEFS_downscale <- function(outfolder, lat.in, lon.in, sitename, st
     dplyr::group_by_at(c("NOAA.member", "timestamp")) %>% 
     dplyr::summarize(surface_downwelling_shortwave_flux_in_air = mean(surface_downwelling_shortwave_flux_in_air))
   
+  ## Downscale Precipitation Flux 
+  precip.hrly <- forecasts %>% 
+    dplyr::select(timestamp, NOAA.member, precipitation_flux) %>%
+    tidyr::complete(timestamp = nonSW.flux.hrly$timestamp, nesting(NOAA.member), fill = list(precipitation_flux = 0)) 
+  
   
   joined<-  dplyr::inner_join(gefs_hour, nonSW.flux.hrly, by = c("NOAA.member", "timestamp"))
+  joined<-  dplyr::inner_join(joined, precip.hrly, by = c("NOAA.member", "timestamp"))
   
   joined <- dplyr::inner_join(joined, ShortWave.ds, by = c("NOAA.member", "timestamp")) %>% 
     dplyr::distinct() %>% 

--- a/modules/data.atmosphere/man/download.NOAA_GEFS_downscale.Rd
+++ b/modules/data.atmosphere/man/download.NOAA_GEFS_downscale.Rd
@@ -9,8 +9,8 @@ download.NOAA_GEFS_downscale(
   lat.in,
   lon.in,
   sitename,
-  start_date = Sys.time(),
-  end_date = (as.POSIXct(start_date, tz = "UTC") + lubridate::days(16)),
+  start_date,
+  end_date,
   overwrite = FALSE,
   verbose = FALSE,
   ...


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- The previous version created fake rain events. This precipitation downscale aligns more with the GEFS 6 hour forecast. The change removes precip from the downscale function and instead uses the 6hr precipitation flux at the 6hr mark and having 0's for the in between times-->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
