### PR TITLE
Roxygenize from PR comments with /document

### DIFF
--- a/.github/workflows/styler-actions.yml
+++ b/.github/workflows/styler-actions.yml
@@ -10,8 +10,8 @@ jobs:
     steps:
       - id: file_changes
         uses: trilom/file-changes-action@v1.2.3
-      - name: testing
-        run: echo '${{ steps.file_changes.outputs.files_modified}}'   
+      - name: list changed files
+        run: echo '${{ steps.file_changes.outputs.files_modified }}'
       - uses: actions/checkout@v2
       - uses: r-lib/actions/pr-fetch@master
         with:
@@ -24,18 +24,11 @@ jobs:
       - name: string operations
         shell: bash
         run: |
-          echo '${{ steps.file_changes.outputs.files_modified}}' > names.txt
-          cat names.txt | tr -d '[]' > changed_files.txt
-          text=$(cat changed_files.txt)
-          IFS=',' read -ra ids <<< "$text"
-          for i in "${ids[@]}"; do if [[ "$i" == *.R\" || "$i" == *.Rmd\" ]]; then echo "$i" >> files_to_style.txt; fi; done
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v1
-        with:
-          name: artifacts
-          path: files_to_style.txt
-      - name: Style
-        run: for i in $(cat files_to_style.txt); do Rscript -e "styler::style_file("$i")"; done
+          for i in ${{ join(steps.file_changes.outputs.files_modified, " ") }}; do;
+            if [[ "$i" == *.R\" || "$i" == *.Rmd\" ]];
+              then Rscript -e "styler::style_file("$i")";
+            fi;
+          done
       - name: commit
         run: |
           git add \*.R
@@ -47,29 +40,27 @@ jobs:
 
 
   check:
-    needs: [style]
+    if: (startsWith(github.event.comment.body, '/style') || startsWith(github.event.comment.body, '/document'))
     runs-on: ubuntu-latest
     container: pecan/depends:develop
     steps:
       - uses: actions/checkout@v2
-      - uses: r-lib/actions/pr-fetch@master
+      - uses: r-lib/actions/pr-fetch@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      # - uses: r-lib/actions/setup-r@v1
-      - name : download artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: artifacts
       - name: update dependency lists
         run: Rscript scripts/generate_dependencies.R
+      - id: file_changes
+        uses: trilom/file-changes-action@v1.2.3
       - name : make
         shell: bash
         run: |
-          cut -d / -f 1-2 artifacts/files_to_style.txt | tr -d '"' > changed_dirs.txt
-          cat changed_dirs.txt
-          sort changed_dirs.txt | uniq > needs_documenting.txt
-          cat needs_documenting.txt      
-          for i in $(cat needs_documenting.txt); do make .doc/${i}; done
+          echo ${{ join(steps.file_changes.outputs.files_modified, "\n") }} \
+          | cut -d / -f 1-2 \
+          | sort \
+          | uniq \
+          | grep -e base -e models -e modules \
+          | xargs -n1 -I{} make .doc/{}
       - name: commit
         run: |
           git config --global user.email "pecan_bot@example.com"

--- a/.github/workflows/styler-actions.yml
+++ b/.github/workflows/styler-actions.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           Rscript -e 'install.packages(c("styler", "devtools"), repos = "cloud.r-project.org")'
-          Rscript -e 'devtools::install_version("roxygen2", version = "7.0.2", repos = "http://cran.us.r-project.org")'
+          Rscript -e 'devtools::install_version("roxygen2", version = "7.0.2", repos = "cloud.r-project.org")'
       - name: string operations
         shell: bash
         run: |
@@ -55,7 +55,7 @@ jobs:
       - uses: r-lib/actions/pr-fetch@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: r-lib/actions/setup-r@v1
+      # - uses: r-lib/actions/setup-r@v1
       - name : download artifacts
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/styler-actions.yml
+++ b/.github/workflows/styler-actions.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: r-lib/actions/pr-fetch@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v1
       - name : download artifacts
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/styler-actions.yml
+++ b/.github/workflows/styler-actions.yml
@@ -21,13 +21,15 @@ jobs:
         run: |
           Rscript -e 'install.packages(c("styler", "devtools"), repos = "cloud.r-project.org")'
           Rscript -e 'devtools::install_version("roxygen2", version = "7.0.2", repos = "cloud.r-project.org")'
-      - name: string operations
+      - name: run styler
         shell: bash
+        env:
+          FILES: ${{ join(fromJSON(steps.file_changes.outputs.files_modified), ' ') }}
         run: |
-          for i in ${{ join(steps.file_changes.outputs.files_modified, " ") }}; do;
-            if [[ "$i" == *.R\" || "$i" == *.Rmd\" ]];
-              then Rscript -e "styler::style_file("$i")";
-            fi;
+          for f in ${FILES}; do
+            if [[ "$f" == *.R\" || "$f" == *.Rmd\" ]]
+              then Rscript -e "styler::style_file("$f")"
+            fi
           done
       - name: commit
         run: |
@@ -39,7 +41,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
 
-  check:
+  document:
     if: (startsWith(github.event.comment.body, '/style') || startsWith(github.event.comment.body, '/document'))
     runs-on: ubuntu-latest
     container: pecan/depends:develop
@@ -54,12 +56,15 @@ jobs:
         uses: trilom/file-changes-action@v1.2.3
       - name : make
         shell: bash
+        env:
+          FILES: ${{ join(fromJSON(steps.file_changes.outputs.files_modified), ' ') }}
         run: |
-          echo ${{ join(steps.file_changes.outputs.files_modified, "\n") }} \
+          echo ${FILES} \
+          | tr ' ' '\n' \
+          | grep -e base -e models -e modules \
           | cut -d / -f 1-2 \
           | sort \
           | uniq \
-          | grep -e base -e models -e modules \
           | xargs -n1 -I{} make .doc/{}
       - name: commit
         run: |

--- a/.github/workflows/styler-actions.yml
+++ b/.github/workflows/styler-actions.yml
@@ -17,10 +17,9 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: r-lib/actions/setup-r@master
-      - name: Install dependencies
+      - name: Install styler
         run: |
-          Rscript -e 'install.packages(c("styler", "devtools"), repos = "cloud.r-project.org")'
-          Rscript -e 'devtools::install_version("roxygen2", version = "7.0.2", repos = "cloud.r-project.org")'
+          Rscript -e 'install.packages("styler", repos = "cloud.r-project.org")'
       - name: run styler
         shell: bash
         env:

--- a/.github/workflows/styler-actions.yml
+++ b/.github/workflows/styler-actions.yml
@@ -26,7 +26,7 @@ jobs:
           FILES: ${{ join(fromJSON(steps.file_changes.outputs.files_modified), ' ') }}
         run: |
           for f in ${FILES}; do
-            if [[ "$f" == *.R\" || "$f" == *.Rmd\" ]]
+            if [[ "$f" == *.R || "$f" == *.Rmd ]]
               then Rscript -e "styler::style_file("$f")"
             fi
           done

--- a/.github/workflows/styler-actions.yml
+++ b/.github/workflows/styler-actions.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           for f in ${FILES}; do
             if [[ "$f" == *.R || "$f" == *.Rmd ]]
-              then Rscript -e "styler::style_file("$f")"
+              then Rscript -e 'styler::style_file("'${f}'")'
             fi
           done
       - name: commit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description

Adds a new command for pull request comments: To update the Roxygen docs for all files touched in a PR, leave a comment that starts with `/document` and the robots will do the rest. You don't even need Roxygen on your local machine!

Technically it was already possible to Roxygenize a PR as part of the `/style` command, but this wasn't documented and sometimes we want to document without touching code formatting. 

I've also streamlined the checking code a bit for hopefully faster results, including removing a few dependencies that I *think* aren't needed -- @rahul799 can you confirm I got this right?

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
