### PR TITLE
API workflow submission bugfixes

### DIFF
--- a/apps/api/R/entrypoint.R
+++ b/apps/api/R/entrypoint.R
@@ -7,7 +7,7 @@
 source("auth.R")
 source("general.R")
 
-root <- plumber::plumber$new()
+root <- plumber::Plumber$new()
 root$setSerializer(plumber::serializer_unboxed_json())
 
 # Filter for authenticating users trying to hit the API endpoints
@@ -20,31 +20,31 @@ root$handle("GET", "/api/ping", ping)
 root$handle("GET", "/api/status", status)
 
 # The endpoints mounted here are related to details of PEcAn models
-models_pr <- plumber::plumber$new("models.R")
+models_pr <- plumber::Plumber$new("models.R")
 root$mount("/api/models", models_pr)
 
 # The endpoints mounted here are related to details of PEcAn sites
-sites_pr <- plumber::plumber$new("sites.R")
+sites_pr <- plumber::Plumber$new("sites.R")
 root$mount("/api/sites", sites_pr)
 
 # The endpoints mounted here are related to details of PEcAn pfts
-pfts_pr <- plumber::plumber$new("pfts.R")
+pfts_pr <- plumber::Plumber$new("pfts.R")
 root$mount("/api/pfts", pfts_pr)
 
 # The endpoints mounted here are related to details of PEcAn formats
-formats_pr <- plumber::plumber$new("formats.R")
+formats_pr <- plumber::Plumber$new("formats.R")
 root$mount("/api/formats", formats_pr)
 
 # The endpoints mounted here are related to details of PEcAn inputs
-inputs_pr <- plumber::plumber$new("inputs.R")
+inputs_pr <- plumber::Plumber$new("inputs.R")
 root$mount("/api/inputs", inputs_pr)
 
 # The endpoints mounted here are related to details of PEcAn workflows
-workflows_pr <- plumber::plumber$new("workflows.R")
+workflows_pr <- plumber::Plumber$new("workflows.R")
 root$mount("/api/workflows", workflows_pr)
 
 # The endpoints mounted here are related to details of PEcAn runs
-runs_pr <- plumber::plumber$new("runs.R")
+runs_pr <- plumber::Plumber$new("runs.R")
 root$mount("/api/runs", runs_pr)
 
 # The API server is bound to 0.0.0.0 on port 8000


### PR DESCRIPTION
I came across these issues while trying to use the API to submit workflows. These are a prerequisite to getting the test suite working.

- Rather than inserting workflows and then querying the last one, insert workflows with a `INSERT ... RETURNING id`, which reduces the number of queries and is more robust.
- Replace `paste`-style queries with prepared statements, which are more robust.
- Standardize the target `bety_params`. Rather than sometimes relying on `config.php` and sometimes relying on `get_postgres_envvvars`, always rely on the later, with sensible defaults (set in the file, in the global variable `.bety_params`)
- Replace `plumber::plumber` with `plumber::Plumber` (to reflect v1.0 update -- this silences a warning and protects us from upcoming deprecation)