### PR TITLE
PEcAn API bugfixes and enhancements

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -20,6 +20,7 @@ RUN   apt-get update \
   &&  rm -rf /var/lib/apt/lists/* \
   &&  Rscript -e "devtools::install_version('promises', '1.1.0', repos = 'http://cran.rstudio.com')" \
   &&  Rscript -e "devtools::install_version('webutils', '1.1', repos = 'http://cran.rstudio.com')" \
+  &&  Rscript -e "install.packages('pool', repos = 'http://cran.rstudio.com')" \
   &&  Rscript -e "devtools::install_github('rstudio/swagger')" \
   &&  Rscript -e "devtools::install_github('rstudio/plumber')"
 

--- a/apps/api/R/auth.R
+++ b/apps/api/R/auth.R
@@ -25,9 +25,10 @@ get_crypt_pass <- function(username, password, secretkey = NULL) {
 #* Check if the encrypted password for the user is valid
 #* @param username Username
 #* @param crypt_pass Encrypted password
+#* @param dbcon Database connection object. Default is global database pool.
 #* @return TRUE if encrypted password is correct, else FALSE
 #* @author Tezan Sahu
-validate_crypt_pass <- function(username, crypt_pass) {
+validate_crypt_pass <- function(username, crypt_pass, dbcon = global_db_pool) {
 
   res <- tbl(dbcon, "users") %>%
     filter(login == username,

--- a/apps/api/R/auth.R
+++ b/apps/api/R/auth.R
@@ -29,15 +29,11 @@ get_crypt_pass <- function(username, password, secretkey = NULL) {
 #* @author Tezan Sahu
 validate_crypt_pass <- function(username, crypt_pass) {
 
-  dbcon <- PEcAn.DB::betyConnect()
-  
   res <- tbl(dbcon, "users") %>%
     filter(login == username,
            crypted_password == crypt_pass) %>%
     collect()
 
-  PEcAn.DB::db.close(dbcon)
-  
   if (nrow(res) == 1) {
     return(res$id)
   }

--- a/apps/api/R/available-models.R
+++ b/apps/api/R/available-models.R
@@ -1,0 +1,46 @@
+library(magrittr, include.only = "%>%")
+
+.bety_params <- PEcAn.DB::get_postgres_envvars(
+  host = "localhost",
+  dbname = "bety",
+  user = "bety",
+  password = "bety",
+  driver = "Postgres"
+)
+
+#' List models available on a specific machine
+#'
+#' @param machine_name Target machine hostname. Default = `"docker"`
+#' @param machine_id Target machine ID. If `NULL` (default), deduced from hostname.
+#' @return `data.frame` of information on available models
+#' @author Alexey Shiklomanov
+#* @get /
+availableModels <- function(machine_name = "docker", machine_id = NULL) {
+  dbcon <- PEcAn.DB::db.open(.bety_params)
+  if (is.null(machine_id)) {
+    machines <- dplyr::tbl(dbcon, "machines")
+    machineid <- machines %>%
+      dplyr::filter(hostname == !!machine_name) %>%
+      dplyr::pull(id)
+    if (length(machineid) > 1) {
+      stop("Found ", length(machineid), " machines with name ", machine_name)
+    }
+    if (length(machineid) < 1) {
+      stop("Found no machines with name ", machine_name)
+    }
+  }
+  dbfiles <- dplyr::tbl(dbcon, "dbfiles") %>%
+    dplyr::filter(machine_id == !!machineid)
+  modelfiles <- dbfiles %>%
+    dplyr::filter(container_type == "Model")
+  models <- dplyr::tbl(dbcon, "models")
+  modeltypes <- dplyr::tbl(dbcon, "modeltypes") %>%
+    dplyr::select(modeltype_id = id, modeltype = name)
+
+  modelfiles %>%
+    dplyr::select(dbfile_id = id, file_name, file_path,
+                  model_id = container_id) %>%
+    dplyr::inner_join(models, c("model_id" = "id")) %>%
+    dplyr::inner_join(modeltypes, "modeltype_id") %>%
+    dplyr::collect()
+}

--- a/apps/api/R/available-models.R
+++ b/apps/api/R/available-models.R
@@ -1,13 +1,5 @@
 library(magrittr, include.only = "%>%")
 
-.bety_params <- PEcAn.DB::get_postgres_envvars(
-  host = "localhost",
-  dbname = "bety",
-  user = "bety",
-  password = "bety",
-  driver = "Postgres"
-)
-
 #' List models available on a specific machine
 #'
 #' @param machine_name Target machine hostname. Default = `"docker"`
@@ -16,7 +8,6 @@ library(magrittr, include.only = "%>%")
 #' @author Alexey Shiklomanov
 #* @get /
 availableModels <- function(machine_name = "docker", machine_id = NULL) {
-  dbcon <- PEcAn.DB::db.open(.bety_params)
   if (is.null(machine_id)) {
     machines <- dplyr::tbl(dbcon, "machines")
     machineid <- machines %>%

--- a/apps/api/R/available-models.R
+++ b/apps/api/R/available-models.R
@@ -4,10 +4,12 @@ library(magrittr, include.only = "%>%")
 #'
 #' @param machine_name Target machine hostname. Default = `"docker"`
 #' @param machine_id Target machine ID. If `NULL` (default), deduced from hostname.
+#' @param dbcon Database connection object. Default is global database pool.
 #' @return `data.frame` of information on available models
 #' @author Alexey Shiklomanov
 #* @get /
-availableModels <- function(machine_name = "docker", machine_id = NULL) {
+availableModels <- function(machine_name = "docker", machine_id = NULL,
+                            dbcon = global_db_pool) {
   if (is.null(machine_id)) {
     machines <- dplyr::tbl(dbcon, "machines")
     machineid <- machines %>%

--- a/apps/api/R/entrypoint.R
+++ b/apps/api/R/entrypoint.R
@@ -47,6 +47,10 @@ root$mount("/api/workflows", workflows_pr)
 runs_pr <- plumber::Plumber$new("runs.R")
 root$mount("/api/runs", runs_pr)
 
+# Available models
+runs_pr <- plumber::Plumber$new("available-models.R")
+root$mount("/api/availableModels", runs_pr)
+
 # The API server is bound to 0.0.0.0 on port 8000
 # The Swagger UI for the API draws its source from the pecanapi-spec.yml file
 root$run(host="0.0.0.0", port=8000, debug=TRUE, swagger = function(pr, spec, ...) {

--- a/apps/api/R/entrypoint.R
+++ b/apps/api/R/entrypoint.R
@@ -18,7 +18,7 @@ source("general.R")
 
 .bety_params$driver <- NULL
 .bety_params$drv <- RPostgres::Postgres()
-dbcon <- do.call(pool::dbPool, .bety_params)
+global_db_pool <- do.call(pool::dbPool, .bety_params)
 
 root <- plumber::Plumber$new()
 root$setSerializer(plumber::serializer_unboxed_json())

--- a/apps/api/R/entrypoint.R
+++ b/apps/api/R/entrypoint.R
@@ -7,6 +7,19 @@
 source("auth.R")
 source("general.R")
 
+# Set up the global database pool
+.bety_params <- PEcAn.DB::get_postgres_envvars(
+  host = "localhost",
+  dbname = "bety",
+  user = "bety",
+  password = "bety",
+  driver = "Postgres"
+)
+
+.bety_params$driver <- NULL
+.bety_params$drv <- RPostgres::Postgres()
+dbcon <- do.call(pool::dbPool, .bety_params)
+
 root <- plumber::Plumber$new()
 root$setSerializer(plumber::serializer_unboxed_json())
 

--- a/apps/api/R/formats.R
+++ b/apps/api/R/formats.R
@@ -7,8 +7,6 @@ library(dplyr)
 #* @get /<format_id>
 getFormat <- function(format_id, res){
   
-  dbcon <- PEcAn.DB::betyConnect()
-  
   Format <- tbl(dbcon, "formats") %>%
     select(format_id = id, name, notes, header, mimetype_id) %>%
     filter(format_id == !!format_id)
@@ -21,7 +19,6 @@ getFormat <- function(format_id, res){
   qry_res <- Format %>% collect()
   
   if (nrow(qry_res) == 0) {
-    PEcAn.DB::db.close(dbcon)
     res$status <- 404
     return(list(error="Format not found"))
   }
@@ -42,8 +39,6 @@ getFormat <- function(format_id, res){
       select(-variable_id, -format_id, -units) %>%
       collect()
     
-    PEcAn.DB::db.close(dbcon)
-    
     response$format_variables <- format_vars
     return(response)
   }
@@ -62,8 +57,6 @@ searchFormats <- function(format_name="", mimetype="", ignore_case=TRUE, res){
   format_name <- URLdecode(format_name)
   mimetype <- URLdecode(mimetype)
   
-  dbcon <- PEcAn.DB::betyConnect()
-  
   Formats <- tbl(dbcon, "formats") %>%
     select(format_id = id, format_name=name, mimetype_id) %>%
     filter(grepl(!!format_name, format_name, ignore.case=ignore_case))
@@ -76,8 +69,6 @@ searchFormats <- function(format_name="", mimetype="", ignore_case=TRUE, res){
     arrange(format_id)
   
   qry_res <- Formats %>% collect()
-  
-  PEcAn.DB::db.close(dbcon)
   
   if (nrow(qry_res) == 0) {
     res$status <- 404

--- a/apps/api/R/formats.R
+++ b/apps/api/R/formats.R
@@ -2,10 +2,11 @@ library(dplyr)
 
 #' Retrieve the details of a PEcAn format, based on format_id
 #' @param format_id Format ID (character)
+#' @param dbcon Database connection object. Default is global database pool.
 #' @return Format details
 #' @author Tezan Sahu
 #* @get /<format_id>
-getFormat <- function(format_id, res){
+getFormat <- function(format_id, res, dbcon = global_db_pool){
   
   Format <- tbl(dbcon, "formats") %>%
     select(format_id = id, name, notes, header, mimetype_id) %>%
@@ -50,10 +51,12 @@ getFormat <- function(format_id, res){
 #' @param format_name Format name search string (character)
 #' @param mimetype Mime type search string (character)
 #' @param ignore_case Logical. If `TRUE` (default) use case-insensitive search otherwise, use case-sensitive search
+#' @param dbcon Database connection object. Default is global database pool.
 #' @return Formats subset matching the model search string
 #' @author Tezan Sahu
 #* @get /
-searchFormats <- function(format_name="", mimetype="", ignore_case=TRUE, res){
+searchFormats <- function(format_name="", mimetype="", ignore_case=TRUE, res,
+                          dbcon = global_db_pool){
   format_name <- URLdecode(format_name)
   mimetype <- URLdecode(mimetype)
   

--- a/apps/api/R/general.R
+++ b/apps/api/R/general.R
@@ -18,7 +18,6 @@ status <- function() {
     if (value == "") default else value
   }
   
-  dbcon <- PEcAn.DB::betyConnect()
   res <- list(host_details = PEcAn.DB::dbHostInfo(dbcon))
   res$host_details$authentication_required = get_env_var("AUTH_REQ")
   

--- a/apps/api/R/get.file.R
+++ b/apps/api/R/get.file.R
@@ -1,6 +1,14 @@
 library(dplyr)
 
-get.file <- function(filepath, userid) {
+#' Download a file associated with PEcAn
+#'
+#' @param filepath Absolute path to file on target machine
+#' @param userid User ID associated with file (typically the same as the user
+#'   running the corresponding workflow)
+#' @param dbcon Database connection object. Default is global database pool.
+#' @return Raw binary file contents
+#' @author Tezan Sehu
+get.file <- function(filepath, userid, dbcon = global_db_pool) {
   # Check if the file path is valid
   if(! file.exists(filepath)){
     return(list(status = "Error", message = "File not found"))

--- a/apps/api/R/get.file.R
+++ b/apps/api/R/get.file.R
@@ -12,8 +12,7 @@ get.file <- function(filepath, userid) {
   run_id <- substr(parent_dir, stringi::stri_locate_last(parent_dir, regex="/")[1] + 1, stringr::str_length(parent_dir))
   
   if(Sys.getenv("AUTH_REQ") == TRUE) {
-    dbcon <- PEcAn.DB::betyConnect()
-    
+
     Run <- tbl(dbcon, "runs") %>%
       filter(id == !!run_id)
     Run <- tbl(dbcon, "ensembles") %>%
@@ -24,8 +23,6 @@ get.file <- function(filepath, userid) {
       select(workflow_id=id, user_id) %>% full_join(Run, by="workflow_id")  %>%
       filter(id == !!run_id) %>%
       pull(user_id)
-    
-    PEcAn.DB::db.close(dbcon)
     
     if(! user_id == userid) {
       return(list(status = "Error", message = "Access forbidden"))

--- a/apps/api/R/inputs.R
+++ b/apps/api/R/inputs.R
@@ -14,8 +14,6 @@ searchInputs <- function(req, model_id=NULL, site_id=NULL, format_id=NULL, host_
     return(list(error = "Invalid value for parameter"))
   }
   
-  dbcon <- PEcAn.DB::betyConnect()
-  
   inputs <- tbl(dbcon, "inputs") %>%
     select(input_name=name, id, site_id, format_id, start_date, end_date)
   
@@ -77,8 +75,6 @@ searchInputs <- function(req, model_id=NULL, site_id=NULL, format_id=NULL, host_
     arrange(id) %>%
     collect()
   
-  PEcAn.DB::db.close(dbcon)
-  
   if (nrow(qry_res) == 0 || as.numeric(offset) >= nrow(qry_res)) {
     res$status <- 404
     return(list(error="Input(s) not found"))
@@ -137,7 +133,6 @@ searchInputs <- function(req, model_id=NULL, site_id=NULL, format_id=NULL, host_
 #* @serializer contentType list(type="application/octet-stream")
 #* @get /<input_id>
 downloadInput <- function(input_id, filename="", req, res){
-  dbcon <- PEcAn.DB::betyConnect()
   db_hostid <- PEcAn.DB::dbHostInfo(dbcon)$hostid
   
   # This is just for temporary testing due to the existing issue in dbHostInfo()
@@ -149,8 +144,6 @@ downloadInput <- function(input_id, filename="", req, res){
     filter(container_type == "Input") %>%
     filter(container_id == !!input_id) %>%
     collect()
-  
-  PEcAn.DB::db.close(dbcon)
   
   if (nrow(input) == 0) {
     res$status <- 404

--- a/apps/api/R/inputs.R
+++ b/apps/api/R/inputs.R
@@ -4,11 +4,13 @@ library(dplyr)
 #' @param model_id Model Id (character)
 #' @param site_id Site Id (character)
 #' @param offset
-#' @param limit 
+#' @param limit
+#' @param dbcon Database connection object. Default is global database pool.
 #' @return Information about Inputs based on model & site
 #' @author Tezan Sahu
 #* @get /
-searchInputs <- function(req, model_id=NULL, site_id=NULL, format_id=NULL, host_id=NULL, offset=0, limit=50, res){
+searchInputs <- function(req, model_id=NULL, site_id=NULL, format_id=NULL, host_id=NULL, offset=0, limit=50, res,
+                         dbcon = global_db_pool){
   if (! limit %in% c(10, 20, 50, 100, 500)) {
     res$status <- 400
     return(list(error = "Invalid value for parameter"))
@@ -128,11 +130,12 @@ searchInputs <- function(req, model_id=NULL, site_id=NULL, format_id=NULL, host_
 #' @param id Input id (character)
 #' @param filename Optional filename specified if the id points to a folder instead of file (character)
 #' If this is passed with an id that actually points to a file, this name will be ignored
+#' @param dbcon Database connection object. Default is global database pool.
 #' @return Input file specified by user
 #' @author Tezan Sahu
 #* @serializer contentType list(type="application/octet-stream")
 #* @get /<input_id>
-downloadInput <- function(input_id, filename="", req, res){
+downloadInput <- function(input_id, filename="", req, res, dbcon = global_db_pool){
   db_hostid <- PEcAn.DB::dbHostInfo(dbcon)$hostid
   
   # This is just for temporary testing due to the existing issue in dbHostInfo()

--- a/apps/api/R/models.R
+++ b/apps/api/R/models.R
@@ -2,10 +2,11 @@ library(dplyr)
 
 #' Retrieve the details of a PEcAn model, based on model_id
 #' @param model_id Model ID (character)
+#' @param dbcon Database connection object. Default is global database pool.
 #' @return Model details
 #' @author Tezan Sahu
 #* @get /<model_id>
-getModel <- function(model_id, res){
+getModel <- function(model_id, res, dbcon = global_db_pool){
   
   Model <- tbl(dbcon, "models") %>%
     select(model_id = id, model_name, revision, modeltype_id) %>%
@@ -44,10 +45,12 @@ getModel <- function(model_id, res){
 #' @param model_name Model name search string (character)
 #' @param revision Model version/revision search string (character)
 #' @param ignore_case Logical. If `TRUE` (default) use case-insensitive search otherwise, use case-sensitive search
+#' @param dbcon Database connection object. Default is global database pool.
 #' @return Model subset matching the model search string
 #' @author Tezan Sahu
 #* @get /
-searchModels <- function(model_name="", revision="", ignore_case=TRUE, res){
+searchModels <- function(model_name="", revision="", ignore_case=TRUE, res,
+                         dbcon = global_db_pool){
   model_name <- URLdecode(model_name)
   revision <- URLdecode(revision)
   

--- a/apps/api/R/models.R
+++ b/apps/api/R/models.R
@@ -7,8 +7,6 @@ library(dplyr)
 #* @get /<model_id>
 getModel <- function(model_id, res){
   
-  dbcon <- PEcAn.DB::betyConnect()
-  
   Model <- tbl(dbcon, "models") %>%
     select(model_id = id, model_name, revision, modeltype_id) %>%
     filter(model_id == !!model_id)
@@ -53,8 +51,6 @@ searchModels <- function(model_name="", revision="", ignore_case=TRUE, res){
   model_name <- URLdecode(model_name)
   revision <- URLdecode(revision)
   
-  dbcon <- PEcAn.DB::betyConnect()
-  
   Models <- tbl(dbcon, "models") %>%
     select(model_id = id, model_name, revision) %>%
     filter(grepl(!!model_name, model_name, ignore.case=ignore_case)) %>%
@@ -63,8 +59,6 @@ searchModels <- function(model_name="", revision="", ignore_case=TRUE, res){
   
   qry_res <- Models %>% collect()
 
-  PEcAn.DB::db.close(dbcon)
-  
   if (nrow(qry_res) == 0) {
     res$status <- 404
     return(list(error="Model(s) not found"))

--- a/apps/api/R/pfts.R
+++ b/apps/api/R/pfts.R
@@ -7,8 +7,6 @@ library(dplyr)
 #* @get /<pft_id>
 getPfts <- function(pft_id, res){
   
-  dbcon <- PEcAn.DB::betyConnect()
-  
   pft <- tbl(dbcon, "pfts") %>%
     select(pft_id = id, pft_name = name, definition, pft_type, modeltype_id) %>%
     filter(pft_id == !!pft_id)
@@ -20,8 +18,6 @@ getPfts <- function(pft_id, res){
   qry_res <- pft %>% 
     select(-modeltype_id) %>% 
     collect()
-  
-  PEcAn.DB::db.close(dbcon)
   
   if (nrow(qry_res) == 0) {
     res$status <- 404
@@ -58,8 +54,6 @@ searchPfts <- function(pft_name="", pft_type="", model_type="", ignore_case=TRUE
     return(list(error = "Invalid pft_type"))
   }
   
-  dbcon <- PEcAn.DB::betyConnect()
-  
   pfts <- tbl(dbcon, "pfts") %>%
     select(pft_id = id, pft_name = name, pft_type, modeltype_id)
   
@@ -74,8 +68,6 @@ searchPfts <- function(pft_name="", pft_type="", model_type="", ignore_case=TRUE
     select(-modeltype_id) %>%
     arrange(pft_id) %>%
     collect()
-  
-  PEcAn.DB::db.close(dbcon)
   
   if (nrow(qry_res) == 0) {
     res$status <- 404

--- a/apps/api/R/pfts.R
+++ b/apps/api/R/pfts.R
@@ -2,10 +2,11 @@ library(dplyr)
 
 #' Retrieve the details of a PEcAn PFT, based on pft_id
 #' @param pft_id PFT ID (character)
+#' @param dbcon Database connection object. Default is global database pool.
 #' @return PFT details
 #' @author Tezan Sahu
 #* @get /<pft_id>
-getPfts <- function(pft_id, res){
+getPfts <- function(pft_id, res, dbcon = global_db_pool){
   
   pft <- tbl(dbcon, "pfts") %>%
     select(pft_id = id, pft_name = name, definition, pft_type, modeltype_id) %>%
@@ -41,10 +42,12 @@ getPfts <- function(pft_id, res){
 #' @param pft_type PFT type (either 'plant' or 'cultivar') (character)
 #' @param model_type Model type serch string (character)
 #' @param ignore_case Logical. If `TRUE` (default) use case-insensitive search otherwise, use case-sensitive search
+#' @param dbcon Database connection object. Default is global database pool.
 #' @return PFT subset matching the searc criteria
 #' @author Tezan Sahu
 #* @get /
-searchPfts <- function(pft_name="", pft_type="", model_type="", ignore_case=TRUE, res){
+searchPfts <- function(pft_name="", pft_type="", model_type="", ignore_case=TRUE, res,
+                       dbcon = global_db_pool){
   pft_name <- URLdecode(pft_name)
   pft_type <- URLdecode(pft_type)
   model_type <- URLdecode(model_type)

--- a/apps/api/R/runs.R
+++ b/apps/api/R/runs.R
@@ -14,8 +14,6 @@ getRuns <- function(req, workflow_id=NULL, offset=0, limit=50, res){
     return(list(error = "Invalid value for parameter"))
   }
 
-  dbcon <- PEcAn.DB::betyConnect()
-  
   Runs <- tbl(dbcon, "runs") %>%
     select(id, model_id, site_id, parameter_list, ensemble_id, start_time, finish_time)
   
@@ -31,8 +29,6 @@ getRuns <- function(req, workflow_id=NULL, offset=0, limit=50, res){
   qry_res <- Runs %>% 
     arrange(id) %>%
     collect()
-  
-  PEcAn.DB::db.close(dbcon)
   
   if (nrow(qry_res) == 0 || as.numeric(offset) >= nrow(qry_res)) {
     res$status <- 404
@@ -88,8 +84,6 @@ getRuns <- function(req, workflow_id=NULL, offset=0, limit=50, res){
 #* @get /<run_id>
 getRunDetails <- function(req, run_id, res){
   
-  dbcon <- PEcAn.DB::betyConnect()
-  
   Runs <- tbl(dbcon, "runs") %>%
     select(-outdir, -outprefix, -setting, -created_at, -updated_at)
   
@@ -106,8 +100,6 @@ getRunDetails <- function(req, run_id, res){
       filter(id == !!run_id) %>%
       pull(user_id)
   }
-  
-  PEcAn.DB::db.close(dbcon)
   
   if (nrow(qry_res) == 0) {
     res$status <- 404
@@ -156,8 +148,6 @@ getRunDetails <- function(req, run_id, res){
 #* @get /<run_id>/input/<filename>
 getRunInputFile <- function(req, run_id, filename, res){
   
-  dbcon <- PEcAn.DB::betyConnect()
-  
   Run <- tbl(dbcon, "runs") %>%
     filter(id == !!run_id)
   
@@ -166,8 +156,6 @@ getRunInputFile <- function(req, run_id, filename, res){
     full_join(Run, by="ensemble_id")  %>%
     filter(id == !!run_id) %>%
     pull(workflow_id)
-  
-  PEcAn.DB::db.close(dbcon)
   
   inputpath <- paste0( Sys.getenv("DATA_DIR", "/data/"), "workflows/PEcAn_", workflow_id, "/run/", run_id, "/", filename)
 
@@ -196,8 +184,6 @@ getRunInputFile <- function(req, run_id, filename, res){
 #* @get /<run_id>/output/<filename>
 getRunOutputFile <- function(req, run_id, filename, res){
   
-  dbcon <- PEcAn.DB::betyConnect()
-  
   Run <- tbl(dbcon, "runs") %>%
     filter(id == !!run_id)
   
@@ -206,8 +192,6 @@ getRunOutputFile <- function(req, run_id, filename, res){
     full_join(Run, by="ensemble_id")  %>%
     filter(id == !!run_id) %>%
     pull(workflow_id)
-  
-  PEcAn.DB::db.close(dbcon)
   
   outputpath <- paste0(Sys.getenv("DATA_DIR", "/data/"), "workflows/PEcAn_", workflow_id, "/out/", run_id, "/", filename)
   
@@ -241,8 +225,6 @@ getRunOutputFile <- function(req, run_id, filename, res){
 
 plotResults <- function(req, run_id, year, y_var, x_var="time", width=800, height=600, res){
   # Get workflow_id for the run
-  dbcon <- PEcAn.DB::betyConnect()
-  
   Run <- tbl(dbcon, "runs") %>%
     filter(id == !!run_id)
   
@@ -258,9 +240,6 @@ plotResults <- function(req, run_id, year, y_var, x_var="time", width=800, heigh
       filter(id == !!workflow_id) %>%
       pull(user_id)
   }
-  
-  
-  PEcAn.DB::db.close(dbcon)
   
   # Check if the data file exists on the host
   datafile <- paste0(Sys.getenv("DATA_DIR", "/data/"), "workflows/PEcAn_", workflow_id, "/out/", run_id, "/", year, ".nc")

--- a/apps/api/R/runs.R
+++ b/apps/api/R/runs.R
@@ -4,11 +4,13 @@ source("get.file.R")
 #' Get the list of runs (belonging to a particuar workflow)
 #' @param workflow_id Workflow id (character)
 #' @param offset
-#' @param limit 
+#' @param limit
+#' @param dbcon Database connection object. Default is global database pool.
 #' @return List of runs (belonging to a particuar workflow)
 #' @author Tezan Sahu
 #* @get /
-getRuns <- function(req, workflow_id=NULL, offset=0, limit=50, res){
+getRuns <- function(req, workflow_id=NULL, offset=0, limit=50, res,
+                    dbcon = global_db_pool){
   if (! limit %in% c(10, 20, 50, 100, 500)) {
     res$status <- 400
     return(list(error = "Invalid value for parameter"))
@@ -82,7 +84,7 @@ getRuns <- function(req, workflow_id=NULL, offset=0, limit=50, res){
 #' @return Details of requested run
 #' @author Tezan Sahu
 #* @get /<run_id>
-getRunDetails <- function(req, run_id, res){
+getRunDetails <- function(req, run_id, res, dbcon = global_db_pool){
   
   Runs <- tbl(dbcon, "runs") %>%
     select(-outdir, -outprefix, -setting, -created_at, -updated_at)
@@ -142,11 +144,12 @@ getRunDetails <- function(req, run_id, res){
 #' Get the input file specified by user for a run
 #' @param run_id Run id (character)
 #' @param filename Name of the input file (character)
+#' @param dbcon Database connection object. Default is global database pool.
 #' @return Input file specified by user for the run
 #' @author Tezan Sahu
 #* @serializer contentType list(type="application/octet-stream")
 #* @get /<run_id>/input/<filename>
-getRunInputFile <- function(req, run_id, filename, res){
+getRunInputFile <- function(req, run_id, filename, res, dbcon = global_db_pool){
   
   Run <- tbl(dbcon, "runs") %>%
     filter(id == !!run_id)
@@ -182,7 +185,7 @@ getRunInputFile <- function(req, run_id, filename, res){
 #' @author Tezan Sahu
 #* @serializer contentType list(type="application/octet-stream")
 #* @get /<run_id>/output/<filename>
-getRunOutputFile <- function(req, run_id, filename, res){
+getRunOutputFile <- function(req, run_id, filename, res, dbcon = global_db_pool){
   
   Run <- tbl(dbcon, "runs") %>%
     filter(id == !!run_id)
@@ -223,7 +226,8 @@ getRunOutputFile <- function(req, run_id, filename, res){
 #* @get /<run_id>/graph/<year>/<y_var>
 #* @serializer contentType list(type='image/png')
 
-plotResults <- function(req, run_id, year, y_var, x_var="time", width=800, height=600, res){
+plotResults <- function(req, run_id, year, y_var, x_var="time", width=800, height=600, res,
+                        dbcon = global_db_pool) {
   # Get workflow_id for the run
   Run <- tbl(dbcon, "runs") %>%
     filter(id == !!run_id)

--- a/apps/api/R/sites.R
+++ b/apps/api/R/sites.R
@@ -2,10 +2,11 @@ library(dplyr)
 
 #' Retrieve the details of a PEcAn site, based on site_id
 #' @param site_id Site ID (character)
+#' @param dbcon Database connection object. Default is global database pool.
 #' @return Site details
 #' @author Tezan Sahu
 #* @get /<site_id>
-getSite <- function(site_id, res){
+getSite <- function(site_id, res, dbcon = global_db_pool){
   
   site <- tbl(dbcon, "sites") %>%
     select(-created_at, -updated_at, -user_id, -geometry) %>%
@@ -33,10 +34,11 @@ getSite <- function(site_id, res){
 #' Search for PEcAn sites containing wildcards for filtering
 #' @param sitename Site name search string (character)
 #' @param ignore_case Logical. If `TRUE` (default) use case-insensitive search otherwise, use case-sensitive search
+#' @param dbcon Database connection object. Default is global database pool.
 #' @return Site subset matching the site search string
 #' @author Tezan Sahu
 #* @get /
-searchSite <- function(sitename="", ignore_case=TRUE, res){
+searchSite <- function(sitename="", ignore_case=TRUE, res, dbcon = global_db_pool){
   sitename <- URLdecode(sitename)
   
   sites <- tbl(dbcon, "sites") %>%

--- a/apps/api/R/sites.R
+++ b/apps/api/R/sites.R
@@ -7,16 +7,12 @@ library(dplyr)
 #* @get /<site_id>
 getSite <- function(site_id, res){
   
-  dbcon <- PEcAn.DB::betyConnect()
-  
   site <- tbl(dbcon, "sites") %>%
     select(-created_at, -updated_at, -user_id, -geometry) %>%
     filter(id == !!site_id)
   
   
   qry_res <- site %>% collect()
-  
-  PEcAn.DB::db.close(dbcon)
   
   if (nrow(qry_res) == 0) {
     res$status <- 404
@@ -43,8 +39,6 @@ getSite <- function(site_id, res){
 searchSite <- function(sitename="", ignore_case=TRUE, res){
   sitename <- URLdecode(sitename)
   
-  dbcon <- PEcAn.DB::betyConnect()
-  
   sites <- tbl(dbcon, "sites") %>%
     select(id, sitename) %>%
     filter(grepl(!!sitename, sitename, ignore.case=ignore_case)) %>%
@@ -52,8 +46,6 @@ searchSite <- function(sitename="", ignore_case=TRUE, res){
   
   
   qry_res <- sites %>% collect()
-  
-  PEcAn.DB::db.close(dbcon)
   
   if (nrow(qry_res) == 0) {
     res$status <- 404

--- a/apps/api/R/submit.workflow.R
+++ b/apps/api/R/submit.workflow.R
@@ -82,12 +82,14 @@ submit.workflow.list <- function(workflowList, userDetails) {
   # Add entry to workflows table in database
   workflow_id <- insert.workflow(workflowList)
   workflowList$workflow$id <- workflow_id
+  workflow_id_str <- format(workflow_id, scientific = FALSE)
 
   # Add entry to attributes table in database
   insert.attribute(workflowList)
 
   # Fix the output directory
-  outdir <- paste0(Sys.getenv("DATA_DIR", "/data/"), "workflows/PEcAn_", workflow_id)
+  outdir <- paste0(Sys.getenv("DATA_DIR", "/data/"), "workflows/PEcAn_",
+                   workflow_id_str)
   workflowList$outdir <- outdir
   
   # Create output diretory
@@ -105,11 +107,11 @@ submit.workflow.list <- function(workflowList, userDetails) {
   res <- file.copy("/work/workflow.R", outdir)
   
   # Post workflow to RabbitMQ
-  message <- list(folder = outdir, workflowid = workflow_id)
+  message <- list(folder = outdir, workflowid = workflow_id_str)
   res <- PEcAn.remote::rabbitmq_post_message(workflowList$host$rabbitmq$uri, "pecan", message, "rabbitmq")
   
   if(res$routed){
-    return(list(workflow_id = as.character(workflow_id), status = "Submitted successfully"))
+    return(list(workflow_id = workflow_id_str, status = "Submitted successfully"))
   }
   else{
     return(list(status = "Error", message = "Could not submit to RabbitMQ"))

--- a/apps/api/R/submit.workflow.R
+++ b/apps/api/R/submit.workflow.R
@@ -35,12 +35,17 @@ submit.workflow.json <- function(workflowJsonString, userDetails){
 #* @return ID & status of the submitted workflow
 #* @author Tezan Sahu
 submit.workflow.list <- function(workflowList, userDetails) {
-  # Fix details about the database
-  workflowList$database <- list(bety = .bety_params)
 
-  # HACK: We are not read for the Postgres driver yet. Way too many places rely
-  # on implicit string conversion, which doesn't work well for bit64 integers
-  workflowList$database$bety$driver <- "PostgreSQL"
+  # Set database details
+  workflowList$database <- list(
+    bety = PEcAn.DB::get_postgres_envvars(
+      host = "localhost",
+      dbname = "bety",
+      user = "bety",
+      password = "bety",
+      driver = "PostgreSQL"
+    )
+  )
 
   if (!is.null(workflowList$model$id) &&
         (is.null(workflowList$model$type) || is.null(workflowList$model$revision))) {

--- a/apps/api/R/submit.workflow.R
+++ b/apps/api/R/submit.workflow.R
@@ -32,9 +32,10 @@ submit.workflow.json <- function(workflowJsonString, userDetails){
 #* Submit a workflow (converted to list)
 #* @param workflowList Workflow parameters expressed as a list
 #* @param userDetails List containing userid & username
+#* @param dbcon Database connection object. Default is global database pool.
 #* @return ID & status of the submitted workflow
 #* @author Tezan Sahu
-submit.workflow.list <- function(workflowList, userDetails) {
+submit.workflow.list <- function(workflowList, userDetails, dbcon = global_db_pool) {
 
   # Set database details
   workflowList$database <- list(
@@ -124,9 +125,10 @@ submit.workflow.list <- function(workflowList, userDetails) {
 
 #* Insert the workflow into workflows table to obtain the workflow_id
 #* @param workflowList List containing the workflow details
+#* @param dbcon Database connection object. Default is global database pool.
 #* @return ID of the submitted workflow
 #* @author Tezan Sahu
-insert.workflow <- function(workflowList){
+insert.workflow <- function(workflowList, dbcon = global_db_pool){
   
   model_id <- workflowList$model$id
   if(is.null(model_id)){
@@ -188,8 +190,9 @@ insert.workflow <- function(workflowList){
 
 #* Insert the workflow into attributes table
 #* @param workflowList List containing the workflow details
+#* @param dbcon Database connection object. Default is global database pool.
 #* @author Tezan Sahu
-insert.attribute <- function(workflowList){
+insert.attribute <- function(workflowList, dbcon = global_db_pool){
 
   # Create an array of PFTs
   pfts <- c()

--- a/apps/api/R/workflows.R
+++ b/apps/api/R/workflows.R
@@ -5,11 +5,13 @@ source("submit.workflow.R")
 #' @param model_id Model id (character)
 #' @param site_id Site id (character)
 #' @param offset
-#' @param limit 
+#' @param limit Max number of workflows to retrieve (default = 50)
+#' @param dbcon Database connection object. Default is global database pool.
 #' @return List of workflows (using a particular model & site, if specified)
 #' @author Tezan Sahu
 #* @get /
-getWorkflows <- function(req, model_id=NULL, site_id=NULL, offset=0, limit=50, res){
+getWorkflows <- function(req, model_id=NULL, site_id=NULL, offset=0, limit=50, res,
+                         dbcon = global_db_pool){
   if (! limit %in% c(10, 20, 50, 100, 500)) {
     res$status <- 400
     return(list(error = "Invalid value for parameter"))
@@ -108,10 +110,11 @@ submitWorkflow <- function(req, res){
 
 #' Get the of the workflow specified by the id
 #' @param id Workflow id (character)
+#' @param dbcon Database connection object. Default is global database pool.
 #' @return Details of requested workflow
 #' @author Tezan Sahu
 #* @get /<id>
-getWorkflowDetails <- function(id, req, res){
+getWorkflowDetails <- function(id, req, res, dbcon = global_db_pool){
   Workflow <- tbl(dbcon, "workflows") %>%
     select(id, model_id, site_id, folder, hostname, user_id)
   
@@ -161,10 +164,11 @@ getWorkflowDetails <- function(id, req, res){
 
 #' Get the of the workflow specified by the id
 #' @param id Workflow id (character)
+#' @param dbcon Database connection object. Default is global database pool.
 #' @return Details of requested workflow
 #' @author Tezan Sahu
 #* @get /<id>/status
-getWorkflowStatus <- function(req, id, res){
+getWorkflowStatus <- function(req, id, res, dbcon = global_db_pool){
   Workflow <- tbl(dbcon, "workflows") %>%
     select(id, user_id) %>%
     filter(id == !!id)
@@ -194,11 +198,12 @@ getWorkflowStatus <- function(req, id, res){
 
 #' Get a specified file of the workflow specified by the id
 #' @param id Workflow id (character)
+#' @param dbcon Database connection object. Default is global database pool.
 #' @return Details of requested workflow
 #' @author Tezan Sahu
 #* @serializer contentType list(type="application/octet-stream")
 #* @get /<id>/file/<filename>
-getWorkflowFile <- function(req, id, filename, res){
+getWorkflowFile <- function(req, id, filename, res, dbcon = global_db_pool){
   Workflow <- tbl(dbcon, "workflows") %>%
     select(id, user_id) %>%
     filter(id == !!id)

--- a/apps/api/R/workflows.R
+++ b/apps/api/R/workflows.R
@@ -15,8 +15,6 @@ getWorkflows <- function(req, model_id=NULL, site_id=NULL, offset=0, limit=50, r
     return(list(error = "Invalid value for parameter"))
   }
   
-  dbcon <- PEcAn.DB::betyConnect()
-  
   Workflow <- tbl(dbcon, "workflows") %>%
     select(-created_at, -updated_at, -params, -advanced_edit, -notes)
   
@@ -32,8 +30,6 @@ getWorkflows <- function(req, model_id=NULL, site_id=NULL, offset=0, limit=50, r
   
   qry_res <- Workflow %>% collect()
 
-  PEcAn.DB::db.close(dbcon)
-  
   if (nrow(qry_res) == 0 || as.numeric(offset) >= nrow(qry_res)) {
     res$status <- 404
     return(list(error="Workflows not found"))
@@ -116,8 +112,6 @@ submitWorkflow <- function(req, res){
 #' @author Tezan Sahu
 #* @get /<id>
 getWorkflowDetails <- function(id, req, res){
-  dbcon <- PEcAn.DB::betyConnect()
-  
   Workflow <- tbl(dbcon, "workflows") %>%
     select(id, model_id, site_id, folder, hostname, user_id)
   
@@ -127,8 +121,6 @@ getWorkflowDetails <- function(id, req, res){
     filter(id == !!id)
   
   qry_res <- Workflow %>% collect()
-  
-  PEcAn.DB::db.close(dbcon)
   
   if (nrow(qry_res) == 0) {
     res$status <- 404
@@ -173,16 +165,12 @@ getWorkflowDetails <- function(id, req, res){
 #' @author Tezan Sahu
 #* @get /<id>/status
 getWorkflowStatus <- function(req, id, res){
-  dbcon <- PEcAn.DB::betyConnect()
-  
   Workflow <- tbl(dbcon, "workflows") %>%
     select(id, user_id) %>%
     filter(id == !!id)
 
   
   qry_res <- Workflow %>% collect()
-  
-  PEcAn.DB::db.close(dbcon)
   
   if (nrow(qry_res) == 0) {
     res$status <- 404
@@ -211,15 +199,11 @@ getWorkflowStatus <- function(req, id, res){
 #* @serializer contentType list(type="application/octet-stream")
 #* @get /<id>/file/<filename>
 getWorkflowFile <- function(req, id, filename, res){
-  dbcon <- PEcAn.DB::betyConnect()
-  
   Workflow <- tbl(dbcon, "workflows") %>%
     select(id, user_id) %>%
     filter(id == !!id)
   
   qry_res <- Workflow %>% collect()
-  
-  PEcAn.DB::db.close(dbcon)
   
   if (nrow(qry_res) == 0) {
     res$status <- 404

--- a/base/utils/R/convert.input.R
+++ b/base/utils/R/convert.input.R
@@ -270,8 +270,11 @@ convert.input <-
                                                       hostname = host$name, 
                                                       exact.dates = TRUE,
                                                       pattern = pattern
-      ) %>%
-        dplyr::filter(id==input.args$dbfile.id)
+      )
+      if ("id" %in% colnames(existing.dbfile)) {
+        existing.dbfile <- existing.dbfile %>%
+          dplyr::filter(id==input.args$dbfile.id)
+      }
     }else{
       existing.dbfile <- PEcAn.DB::dbfile.input.check(siteid = site.id,
                                                       mimetype = mimetype, 


### PR DESCRIPTION
Resolving some issues I discovered while trying to get the test suite up and running.

- Use the [`pool` package](https://github.com/rstudio/pool) to manage database connections in the API. This prevents "too many connections" errors, which can arise from heavy API use (e.g., when submitting dozens of test runs). Create this connection pool once, when the API is launched, and use it everywhere (rather than re-opening new connections everywhere).
- Add the `availableModels` API entrypoint for querying the models available on a given machine.
- Use explicit string formatting of `workflow_id`, to avoid implicit coercion issues with `bit64`
- Minor bugfix in `base/utils`: If `dbfile.input.check` returned a blank `data.frame` (as it does if files aren't found), then the subsequent `filter` statement would error because the `id` column was absent.