### PR TITLE
API: Only pass model ID to PEcAn

### DIFF
--- a/apps/api/R/submit.workflow.R
+++ b/apps/api/R/submit.workflow.R
@@ -35,7 +35,7 @@ submit.workflow.json <- function(workflowJsonString, userDetails){
 #* @param dbcon Database connection object. Default is global database pool.
 #* @return ID & status of the submitted workflow
 #* @author Tezan Sahu
-submit.workflow.list <- function(workflowList, userDetails, dbcon = global_db_pool, res) {
+submit.workflow.list <- function(workflowList, userDetails, dbcon = global_db_pool) {
 
   # Set database details
   workflowList$database <- list(
@@ -49,8 +49,8 @@ submit.workflow.list <- function(workflowList, userDetails, dbcon = global_db_po
   )
 
   if (is.null(workflowList$model$id)) {
-    res$status <- 400
-    return(list(error = "Must provide model ID."))
+    return(list(status = "Error",
+                error = "Must provide model ID."))
   }
 
   # Get model revision and type for the RabbitMQ queue
@@ -61,17 +61,15 @@ submit.workflow.list <- function(workflowList, userDetails, dbcon = global_db_po
     dplyr::collect()
 
   if (nrow(model_info) < 1) {
-    res$status <- 404  # Not found
     msg <- paste0("No models found with ID ", format(workflowList$model$id, scientific = FALSE))
-    return(list(error = msg))
+    return(list(status = "Error", error = msg))
   } else if (nrow(model_info) > 1) {
-    res$status <- 400
     msg <- paste0(
       "Found multiple (", nrow(model_info), ") matching models for id ",
       format(workflowList$model$id, scientific = FALSE),
       ". This shouldn't happen! Check your database for errors."
     )
-    return(list(error = msg))
+    return(list(status = "Error", error = msg))
   }
 
   model_type <- model_info$name

--- a/apps/api/R/submit.workflow.R
+++ b/apps/api/R/submit.workflow.R
@@ -48,15 +48,8 @@ submit.workflow.list <- function(workflowList, userDetails, dbcon = global_db_po
     )
   )
 
-  if (!is.null(workflowList$model$id) &&
-        (is.null(workflowList$model$type) || is.null(workflowList$model$revision))) {
-    res <- dplyr::tbl(dbcon, "models") %>%
-      select(id, model_name, revision) %>%
-      filter(id == !!workflowList$model$id) %>%
-      collect()
-
-    workflowList$model$type <- res$model_name
-    workflowList$model$revision <- res$revision
+  if (is.null(workflowList$model$id)) {
+    stop("Must provide model ID.")
   }
 
   # Fix RabbitMQ details


### PR DESCRIPTION
Currently, the API incorrectly sets the `model$type` as the `models.model_name`, though these actually have different meanings in PEcAn (though, for many models, they are coincidentally the same value). This would result in a bug when trying to run `ED2.2`, whose name is `ED2.2` but whose _type_ is `ED2`. The resulting error would be something like `No PFT "temperate.Late_Hardwood" for model type "ED2.2"`.

This PR makes it so that only the model ID is passed to PEcAn, which is already unambiguous and, moreover, is how the `rpecanapi::submit.workflow` function already works anyway (i.e., no user-facing changes). It should be the user's responsibility (for now) to manually figure out exactly which model + revision they want to run and the associated ID.

However, given the model ID, we _do_ need to correctly identify the model type and revision to determine the model's RabbitMQ queue. So now, we determine that from the model ID in the API and set it (but never pass this information on to PEcAn). Ideally, PEcAn should probably do this internally (i.e., it shouldn't be the API's responsibility to write this XML field correctly?), but I'm going to punt on that fix because it could be a bit more involved.