### PR TITLE
API: Fix missing `dbcon --> global_db_pool`

### DIFF
--- a/apps/api/R/general.R
+++ b/apps/api/R/general.R
@@ -10,7 +10,7 @@ ping <- function(req){
 #* Function to get the status & basic information about the Database Host
 #* @return Details about the database host
 #* @author Tezan Sahu
-status <- function() {
+status <- function(dbcon = global_db_pool) {
   
   ## helper function to obtain environment variables
   get_env_var = function (item, default = "unknown") {


### PR DESCRIPTION
In all the other places in the API, there is a `dbcon = global_db_pool` function argument. But I forgot to add it to the `status` entrypoint.