### PR TITLE
Allow setting stop_on_error via settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@ This is a major change:
 - PEcAn.JULES: Removed dependency on `ncdf4.helpers` package, which has been removed from CRAN (#2511).
 - data.remote: Arguments to the function `call_MODIS()` have been changed (issue #2519). 
 - Changed precipitaion downscale in `PEcAn.data.atmosphere::download.NOAA_GEFS_downscale`. Precipitation was being downscaled via a spline which was causing fake rain events. Instead the 6 hr precipitation flux values from GEFS are preserved with 0's filling in the hours between. 
--Changed `dbfile.input.insert` to work with inputs (i.e soils) that don't have start and end dates associated with them 
+- Changed `dbfile.input.insert` to work with inputs (i.e soils) that don't have start and end dates associated with them 
+- Default behavior for `stop_on_error` is now `TRUE` for non-ensemble runs; i.e., workflows that run only one model simulation (or omit the `ensemble` XML group altogether) will fail if the model run fails. For ensemble runs, the old behavior is preserved; i.e., workflows will continue even if one of the model runs failed. This behavior can also be manually controlled by setting the new `run -> stop_on_error` XML tag to `TRUE` or `FALSE`.
 
 ### Added
 

--- a/book_source/03_topical_pages/03_pecan_xml.Rmd
+++ b/book_source/03_topical_pages/03_pecan_xml.Rmd
@@ -380,6 +380,7 @@ This section provides detailed configuration for the model run, including the si
     </inputs>
     <start.date>2004/01/01</start.date>
     <end.date>2004/12/31</end.date>
+    <stop_on_error>TRUE</stop_on_error>
   </run>
 ```
 
@@ -456,6 +457,8 @@ PEcAn tries to detect and throw informative errors when dates are out of bounds 
 The following tags are optional run settings that apply to any model: 
 
 * `jobtemplate`: the template used when creating a `job.sh` file, which is used to launch the actual model. Each model has its own default template  in the `inst` folder of the corresponding R package (for instance, here is the one for [ED2](https://github.com/PecanProject/pecan/blob/master/models/ed/inst/template.job)). The following variables can be used: `@SITE_LAT@`, `@SITE_LON@`, `@SITE_MET@`, `@START_DATE@`, `@END_DATE@`, `@OUTDIR@`, `@RUNDIR@` which all come variables in the `pecan.xml` file. The following two command can be used to copy and clean the results from a scratch folder (specified as scratch in the run section below, for example local disk vs network disk) : `@SCRATCH_COPY@`, `@SCRATCH_CLEAR@`.
+
+* `stop_on_error`: (logical) Whether the workflow should immediately terminate if _any_ of the model runs fail. If unset, this defaults to `TRUE` unless you are running an ensemble simulation (and ensemble size is greater than 1).
 
 Some models also have model-specific tags, which are described in the [PEcAn Models](#pecan-models) section.
 

--- a/web/workflow.R
+++ b/web/workflow.R
@@ -116,7 +116,18 @@ if ((length(which(commandArgs() == "--advanced")) != 0)
 # Start ecosystem model runs
 if (PEcAn.utils::status.check("MODEL") == 0) {
   PEcAn.utils::status.start("MODEL")
-  PEcAn.remote::runModule.start.model.runs(settings, stop.on.error = FALSE)
+  stop_on_error <- as.logical(settings[[c("run", "stop_on_error")]])
+  if (is.null(stop_on_error)) {
+    # If we're doing an ensemble run, don't stop. If only a single run, we
+    # should be stopping.
+    if (is.null(settings[["ensemble"]]) ||
+          as.numeric(settings[[c("ensemble", "size")]]) == 1) {
+      stop_on_error <- FALSE
+    } else {
+      stop_on_error <- TRUE
+    }
+  }
+  PEcAn.remote::runModule.start.model.runs(settings, stop.on.error = stop_on_error)
   PEcAn.utils::status.end()
 }
 


### PR DESCRIPTION
New XML tag `run / stop_on_error` controls whether the workflow will terminate if _any_ of the model runs fail. If unset, the _new behavior_ is that the workflow _will_ terminate (`stop_on_error = TRUE`) if you are doing only a single model run, but _will not_ terminate (`stop_on_error = FALSE`) if you are doing an ensemble simulation.