### PR TITLE
Fix meta-analysis update-auto when some columns are NA

### DIFF
--- a/base/db/R/get.trait.data.pft.R
+++ b/base/db/R/get.trait.data.pft.R
@@ -141,10 +141,10 @@ get.trait.data.pft <- function(pft, modeltype, dbfiles, dbcon, trait.names,
           existing_membership <- utils::read.csv(
             need_paths[["pft_membership"]],
             # Columns are: id, genus, species, scientificname
-            # Need this so NA values are
+            # Need this so NA values are formatted consistently
             colClasses = c("double", "character", "character", "character"),
             stringsAsFactors = FALSE,
-            na.strings = ""
+            na.strings = c("", "NA")
           )
           diff_membership <- symmetric_setdiff(
             existing_membership,


### PR DESCRIPTION
Old meta-analysis PFT membership files sometimes stored NA's as literal "NA" strings, which were not being read in as NA's. This caused the difference checking code to (incorrectly) pick up a difference between in PFT membership and caused the trait meta analysis to always run.

For example, this is from one of my recent workflows (before this change):

```
2020-11-11 18:42:04 DEBUG  [FUN] : 
   Checking if PFT membership has changed. 
2020-11-11 18:42:04 ERROR  [FUN] : 
 PFT membership has changed. 
 Difference is:
      source   id     genus species scientificname
1  existing 1390     Tilia      NA          Tilia
2  existing   17      Acer      NA           Acer
3  existing   46  Aesculus      NA       Aesculus
4  existing  634   Halesia      NA        Halesia
5  existing  450 Diospyros      NA      Diospyros
6  existing 1038  Platanus      NA       Platanus
7   current 1390     Tilia    <NA>          Tilia
8   current   17      Acer    <NA>           Acer
9   current   46  Aesculus    <NA>       Aesculus
10  current  634   Halesia    <NA>        Halesia
11  current  450 Diospyros    <NA>      Diospyros
12  current 1038  Platanus    <NA>       Platanus 
```

The first set of `NA`s are literal `"NA"` strings, while the second set are the correct `NA_character_` class.

Here, I fixed this by adding "NA" to the list of strings converted to NA's when reading old PFT membership. Now, if nothing changes, we don't re-run the meta-analysis!