### PR TITLE
WORKFLOW: Bugfix empty stop.on.error

### DIFF
--- a/web/workflow.R
+++ b/web/workflow.R
@@ -117,7 +117,7 @@ if ((length(which(commandArgs() == "--advanced")) != 0)
 if (PEcAn.utils::status.check("MODEL") == 0) {
   PEcAn.utils::status.start("MODEL")
   stop_on_error <- as.logical(settings[[c("run", "stop_on_error")]])
-  if (is.null(stop_on_error)) {
+  if (length(stop_on_error) == 0) {
     # If we're doing an ensemble run, don't stop. If only a single run, we
     # should be stopping.
     if (is.null(settings[["ensemble"]]) ||


### PR DESCRIPTION
When `stop.on.error` is not set, trying to retrieve it returns `NULL. As it turns out, `as.logical(NULL)` produces a length-0 logical vector, not `NULL` (so `is.null(as.logical(NULL))` is `FALSE`), and so my entire automatic setting of this was being skipped! This would lead to downstream errors when the resulting `stop.on.error = logical(0)` interacts with, e.g. ,`if (stop.on.error)`.