### PR TITLE
WORKFLOW: Fix swapped stop.on.error TRUE/FALSE

### DIFF
--- a/web/workflow.R
+++ b/web/workflow.R
@@ -122,9 +122,9 @@ if (PEcAn.utils::status.check("MODEL") == 0) {
     # should be stopping.
     if (is.null(settings[["ensemble"]]) ||
           as.numeric(settings[[c("ensemble", "size")]]) == 1) {
-      stop_on_error <- FALSE
-    } else {
       stop_on_error <- TRUE
+    } else {
+      stop_on_error <- FALSE
     }
   }
   PEcAn.remote::runModule.start.model.runs(settings, stop.on.error = stop_on_error)


### PR DESCRIPTION
If no ensemble, `stop.on.error` should be `TRUE`! If ensemble, should be `FALSE`! I accidentally got this backwards...