### PR TITLE
MET: Cache raw CRUNCEP files

### DIFF
--- a/modules/data.atmosphere/R/download.CRUNCEP_Global.R
+++ b/modules/data.atmosphere/R/download.CRUNCEP_Global.R
@@ -201,9 +201,20 @@ download.CRUNCEP <- function(outfolder, start_date, end_date, lat.in, lon.in,
           "time_end={year}-12-31T21:00:00Z&",
           "accept=netcdf"
         )
-        tmp_file <- tempfile()
-        utils::download.file(ncss_query, tmp_file)
-        dap <- ncdf4::nc_open(tmp_file)
+        # Cache raw CRUNCEP files so that later workflows don't have to download
+        # them (even if they do have to do some reprocessing).
+        raw_file <- file.path(
+          outfolder,
+          glue::glue("cruncep-raw-{year}-{lat.in}-{lon.in}-{current_var}.nc")
+        )
+        if (overwrite || !file.exists(raw_file)) {
+          utils::download.file(ncss_query, raw_file)
+        } else {
+          PEcAn.logger::logger.debug(glue::glue(
+            "Skipping file because it already exists: {raw_file}"
+          ))
+        }
+        dap <- ncdf4::nc_open(raw_file)
       }
 
       # confirm that timestamps match


### PR DESCRIPTION
When using the NetCDF subset method (`ncss`), we would previously download raw yearly CRUNCEP NetCDF files as temporary files, which would just be deleted at some point. Taking inspiration from `download.MERRA`, I figured it might make more sense to actually store these raw files in a meaningful way, so that future workflows could reuse them. Since these files were already complete years (regardless of what the input time step was), this seems like a useful speed gain with the only minor downside being somewhat increased disk usage. These files are silently overwritten if `overwrite = TRUE`.