### PR TITLE
Fix summarize.result so it generates statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ This is a major change:
 - Changed docker-compose.yml to use user & group IDs of the operating system user (#2572)  
 - gSSURGO file download now added as inputs into BETY through extract_soil_gssurgo (#2666)
 - ensure Tleaf converted to K for temperature corrections in PEcAn.photosynthesis::fitA (#2726)
-- fix bug in summarize.result to output stat, which is needed to turn on RE in the meta-analysis (#2752)
+- fix bug in summarize.result to output stat, which is needed to turn on RE in the meta-analysis (#2753)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This is a major change:
 - Changed docker-compose.yml to use user & group IDs of the operating system user (#2572)  
 - gSSURGO file download now added as inputs into BETY through extract_soil_gssurgo (#2666)
 - ensure Tleaf converted to K for temperature corrections in PEcAn.photosynthesis::fitA (#2726)
+- fix bug in summarize.result to output stat, which is needed to turn on RE in the meta-analysis (#2752)
 
 ### Changed
 

--- a/base/utils/R/utils.R
+++ b/base/utils/R/utils.R
@@ -210,11 +210,11 @@ summarize.result <- function(result) {
     dplyr::group_by(citation_id, site_id, trt_id,
                     control, greenhouse, date, time,
                     cultivar_id, specie_id) %>%
-    dplyr::summarize(
-      n = length(n),
-      mean = mean(mean),
+    dplyr::summarize( # stat must be computed first, before n and mean
       statname = dplyr::if_else(length(n) == 1, "none", "SE"),
-      stat = stats::sd(mean) / sqrt(length(n))
+      stat = stats::sd(mean) / sqrt(length(n)),
+      n = length(n),
+      mean = mean(mean)
     ) %>%
     dplyr::ungroup()
   ans2 <- result %>%

--- a/base/utils/tests/testthat/test.utils.R
+++ b/base/utils/tests/testthat/test.utils.R
@@ -9,9 +9,9 @@
 context("Other utilities")
 
 test.stats <- data.frame(Y=rep(1,5),
-                           stat=rep(1,5),
-                           n=rep(4,5),
-                           statname=c('SD', 'MSE', 'LSD', 'HSD', 'MSD'))
+                         stat=rep(1,5),
+                         n=rep(4,5),
+                         statname=c('SD', 'MSE', 'LSD', 'HSD', 'MSD'))
 
 test_that("transformstats works",{
   expect_equal(signif(transformstats(test.stats)$stat, 5),
@@ -20,7 +20,7 @@ test_that("transformstats works",{
   expect_equal(test.stats$Y, transformstats(test.stats)$Y)
   expect_equal(test.stats$n, transformstats(test.stats)$n)          
   expect_false(any(as.character(test.stats$statname) ==
-                   as.character(transformstats(test.stats)$statname)))
+                     as.character(transformstats(test.stats)$statname)))
 })
 
 
@@ -33,7 +33,7 @@ test_that('arrhenius scaling works', {
 
 
 test_that("vecpaste works",{
-
+  
   ## vecpaste()
   expect_that(vecpaste(c('a','b')),
               equals("'a','b'"))
@@ -69,12 +69,29 @@ test_that("summarize.result works appropriately", {
                            specie_id = 1,
                            n = 1,
                            mean = sqrt(1:10),
-                           stat = 'none',
-                           statname = 'none'
-                           )
+                           stat = NA,
+                           statname = NA
+  )
+  # check that individual means produced for distinct sites
+  expect_that(summarize.result(testresult)$mean, equals(testresult$mean)) 
+  
+  # check that four means are produced for a single site
   testresult2 <- transform(testresult, site_id= 1) 
-  expect_that(summarize.result(testresult)$mean, equals(testresult$mean))
-  expect_that(nrow(summarize.result(testresult2)), equals(4))
+  expect_that(nrow(summarize.result(testresult2)), equals(4))  
+  
+  # check that if stat == NA, SE will be computed
+  testresult3 <- summarize.result(testresult2)
+  expect_true(all(!is.na(testresult3$stat)))
+  expect_equal(testresult3$n, c(3L, 2L, 2L, 3L))
+  expect_equal(round(testresult3$stat, 3), c(0.359, 0.177, 0.293, 0.206))
+  expect_equal(round(testresult3$mean, 3), c(1.656, 2.823, 1.707, 2.813))
+  
+  # check that site groups correctly for length(site) > 1
+  testresult4 <- rbind.data.frame(testresult2, transform(testresult2, site_id= 2))
+  testresult5 <- summarize.result(testresult4)
+  expect_true(all(!is.na(testresult5$stat)))
+  expect_equal(nrow(testresult5), 8)
+  
 })
 
 


### PR DESCRIPTION
## Description

Prior to this change, the `summarize.result` function did not summarize SE due to an ordering issue. n and mean were moved to below statname and stat.

previously, the `summarize.result` function included this:

```r
dplyr::summarize(
      n = length(n),	
      mean = mean(mean),	
      stat = stats::sd(mean) / sqrt(length(n))
```

Apparently, the author had expected `sd(mean)` and `length(n)` to use the values in the original data frame, but the summarize function first computed new summary values of mean and n, and since these were reduced to 1 value per group, didn't compute a statistic. 

We also created additional tests were created to ensure the new function works correctly.

## Motivation and Context

As a result, random effects were not being included in some meta-analysis models where these within group statistics were not estimated.

The fix was to calculate the stat before calculating new values of n and mean.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [x] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
