### PR TITLE
Fix get.trait.data.pft so forceupdate set to true stays true

### DIFF
--- a/base/db/R/get.trait.data.pft.R
+++ b/base/db/R/get.trait.data.pft.R
@@ -77,9 +77,7 @@ get.trait.data.pft <- function(pft, modeltype, dbfiles, dbcon, trait.names,
   traits <- names(trait.data.check)
   
   # Set forceupdate FALSE if it's a string (backwards compatible with 'AUTO' flag used in the past)
-  if (!is.logical(forceupdate)) {
-    forceupdate <- FALSE
-  }
+  forceupdate <- isTRUE(as.logical(forceupdate))
   
   # check to see if we need to update
   if (!forceupdate) {


### PR DESCRIPTION
## Description
Should be able to set `forceupdate` in meta-analysis to `TRUE` to update trait data, but this wasn't working because it was read in as a string and changed in `get.trait.data.pft` to `FALSE`. This should fix that, and came from @bcow [original suggestions](https://github.com/PecanProject/pecan/issues/2422) about how to fix this. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
