### PR TITLE
WIP Fix Docker reproducibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,9 +105,6 @@ jobs:
     - name: install new dependencies
       run: Rscript scripts/generate_dependencies.R && Rscript docker/depends/pecan.depends.R
 
-    - name: Manually update rlang and testthat (HACK)
-      run: Rscript -e 'remotes::install_github("r-lib/testthat@v3.0.1")'
-
     # initialize database
     - name: db setup
       uses: docker://pecan/db:ci
@@ -154,9 +151,6 @@ jobs:
       run: apt-get update && apt-get install -y postgresql-client qpdf
     - name: install new dependencies
       run: Rscript scripts/generate_dependencies.R && Rscript docker/depends/pecan.depends.R
-
-    - name: Manually install latest testthat (HACK)
-      run: Rscript -e 'remotes::install_github("r-lib/testthat@v3.0.1")'
 
     # run PEcAn checks
     - name: check

--- a/.github/workflows/styler-actions.yml
+++ b/.github/workflows/styler-actions.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: r-lib/actions/setup-r@master
       - name: Install styler
         run: |
-          Rscript -e 'install.packages("styler", repos = "cloud.r-project.org")'
+          Rscript -e 'install.packages("styler")'
       - name: run styler
         shell: bash
         env:

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,6 @@ $(subst .doc/models/template,,$(MODELS_D)): .install/models/template
 
 include Makefile.depends
 
-#SETROPTIONS = "options(Ncpus = ${NCPUS}, repos = 'https://cran.rstudio.com')"
 SETROPTIONS = "options(Ncpus = ${NCPUS})"
 
 clean:

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -18,9 +18,9 @@ EXPOSE 8000
 RUN   apt-get update \
   &&  apt-get install libsodium-dev -y \
   &&  rm -rf /var/lib/apt/lists/* \
-  &&  Rscript -e "devtools::install_version('promises', '1.1.0', repos = 'http://cran.rstudio.com')" \
-  &&  Rscript -e "devtools::install_version('webutils', '1.1', repos = 'http://cran.rstudio.com')" \
-  &&  Rscript -e "install.packages('pool', repos = 'http://cran.rstudio.com')" \
+  &&  Rscript -e "devtools::install_version('promises', '1.1.0')" \
+  &&  Rscript -e "devtools::install_version('webutils', '1.1')" \
+  &&  Rscript -e "install.packages('pool')" \
   &&  Rscript -e "devtools::install_github('rstudio/swagger')" \
   &&  Rscript -e "devtools::install_github('rstudio/plumber')"
 

--- a/book_source/03_topical_pages/93_installation/03_install_OS/01_Installing-PEcAn-Ubuntu.Rmd
+++ b/book_source/03_topical_pages/93_installation/03_install_OS/01_Installing-PEcAn-Ubuntu.Rmd
@@ -32,7 +32,7 @@ apt-get -y install apache2 libapache2-mod-php5 php5
 apt-get -y install texinfo texlive-latex-base texlive-latex-extra texlive-fonts-recommended
 
 # install devtools
-echo 'install.packages("devtools", repos="http://cran.rstudio.com/")' | R --vanilla
+echo 'install.packages("devtools")' | R --vanilla
 
 # done as root
 exit

--- a/book_source/03_topical_pages/93_installation/03_install_OS/02_Installing-PEcAn-CentOS.Rmd
+++ b/book_source/03_topical_pages/93_installation/03_install_OS/02_Installing-PEcAn-CentOS.Rmd
@@ -37,7 +37,7 @@ firewall-cmd --reload
 #apt-get -y install texinfo texlive-latex-base texlive-latex-extra texlive-fonts-recommended
 
 # install devtools
-echo 'install.packages("devtools", repos="http://cran.rstudio.com/")' | R --vanilla
+echo 'install.packages("devtools")' | R --vanilla
 
 # done as root
 exit

--- a/book_source/03_topical_pages/94_docker/06_troubleshooting.Rmd
+++ b/book_source/03_topical_pages/94_docker/06_troubleshooting.Rmd
@@ -7,20 +7,20 @@
 ```
 Installing package into ‘/usr/local/lib/R/site-library’
 (as ‘lib’ is unspecified)
-Warning: unable to access index for repository https://mran.microsoft.com/snapshot/2018-09-01/src/contrib:
- cannot open URL 'https://mran.microsoft.com/snapshot/2018-09-01/src/contrib/PACKAGES'
+Warning: unable to access index for repository <URL>
+ cannot open URL '<URL>'
 Warning message:
 package ‘<PACKAGE>’ is not available (for R version 3.5.1)
 ```
 
-**CAUSE**: This can sometimes happen if there are problems with Microsoft's CRAN snapshots, which are the default repository for the `rocker/tidyverse` containers.
+**CAUSE**: This can sometimes happen if there are problems with the RStudio Package manager, which is the default repository for the `rocker/tidyverse` containers.
 See GitHub issues [rocker-org/rocker-versioned#102](https://github.com/rocker-org/rocker-versioned/issues/102) and [#58](https://github.com/rocker-org/rocker-versioned/issues/58).
 
-**SOLUTION**: Add the following line to the `depends` and/or `base` Dockerfiles _before_ (i.e. above) any commands that install R packages (e.g. `Rscript -e "install.packages(...)"`):
+**WORKAROUND**: Add the following line to the `depends` and/or `base` Dockerfiles _before_ (i.e. above) any commands that install R packages (e.g. `Rscript -e "install.packages(...)"`):
 
 ```
 RUN echo "options(repos = c(CRAN = 'https://cran.rstudio.org'))" >> /usr/local/lib/R/etc/Rprofile.site
 ```
 
-This will set the default repository to the more reliable (albeit, more up-to-date; beware of breaking package changes!) RStudio CRAN mirror.
+This will set the default repository to the more reliable (**albeit, more up-to-date; beware of breaking package changes!**) RStudio CRAN mirror.
 Then, build the image as usual.

--- a/book_source/03_topical_pages/95_remote_execution.Rmd
+++ b/book_source/03_topical_pages/95_remote_execution.Rmd
@@ -308,8 +308,7 @@ will fall back on the older versions install site-library
 
 ```
 install.packages(c('udunits2', 'lubridate'), 
-   configure.args=c(udunits2='--with-udunits2-lib=/project/earth/packages/udunits-2.1.24/lib --with-udunits2-include=/project/earth/packages/udunits-2.1.24/include'),
-   repos='http://cran.us.r-project.org')
+   configure.args=c(udunits2='--with-udunits2-lib=/project/earth/packages/udunits-2.1.24/lib --with-udunits2-include=/project/earth/packages/udunits-2.1.24/include'))
 ```
 
 Finally to install support for both ED and SIPNET:

--- a/docker/depends/Dockerfile
+++ b/docker/depends/Dockerfile
@@ -39,8 +39,8 @@ RUN apt-get update \
 # INSTALL DEPENDENCIES
 # ----------------------------------------------------------------------
 COPY pecan.depends.R /
-RUN  Rscript -e "install.packages(c('devtools'), repos = 'http://cran.rstudio.com')" \
-  && Rscript -e "devtools::install_version('roxygen2', '7.0.2', repos = 'http://cran.rstudio.com')" \
+RUN  Rscript -e "install.packages(c('devtools'))" \
+  && Rscript -e "devtools::install_version('roxygen2', '7.0.2')" \
   && R_LIBS_USER='/usr/local/lib/R/site-library' Rscript /pecan.depends.R \
   && rm -rf /tmp/*
 

--- a/scripts/install_pecan.sh
+++ b/scripts/install_pecan.sh
@@ -357,21 +357,21 @@ if [ -z "${R_LIBS_USER}" ]; then
       ;;
   esac
 fi
-echo 'if(!"devtools" %in% installed.packages()) install.packages("devtools", repos="http://cran.rstudio.com/")' | R --vanilla
-echo 'if(!"udunits2" %in% installed.packages()) install.packages("udunits2", configure.args=c(udunits2="--with-udunits2-include=/usr/include/udunits2"), repo="http://cran.rstudio.com")'  | R --vanilla
+echo 'if(!"devtools" %in% installed.packages()) install.packages("devtools")' | R --vanilla
+echo 'if(!"udunits2" %in% installed.packages()) install.packages("udunits2", configure.args=c(udunits2="--with-udunits2-include=/usr/include/udunits2"))'  | R --vanilla
 
 # packages for BrownDog shiny app
-echo 'if(!"leaflet" %in% installed.packages()) install.packages("leaflet", repos="http://cran.rstudio.com/")' | R --vanilla
-echo 'if(!"RJSONIO" %in% installed.packages()) install.packages("RJSONIO", repos="http://cran.rstudio.com/")' | R --vanilla
+echo 'if(!"leaflet" %in% installed.packages()) install.packages("leaflet")' | R --vanilla
+echo 'if(!"RJSONIO" %in% installed.packages()) install.packages("RJSONIO")' | R --vanilla
 
 # packages for other shiny apps
-echo 'if(!"DT" %in% installed.packages()) install.packages("DT", repos="http://cran.rstudio.com/")' | R --vanilla
+echo 'if(!"DT" %in% installed.packages()) install.packages("DT")' | R --vanilla
 
-#echo 'update.packages(repos="http://cran.rstudio.com/", ask=FALSE)' | sudo R --vanilla
-echo 'x <- rownames(old.packages(repos="http://cran.rstudio.com/")); update.packages(repos="http://cran.rstudio.com/", ask=FALSE, oldPkgs=x[!x %in% "rgl"])' | sudo R --vanilla
+#echo 'update.packages(ask=FALSE)' | sudo R --vanilla
+echo 'x <- rownames(old.packages(); update.packages(ask=FALSE, oldPkgs=x[!x %in% "rgl"])' | sudo R --vanilla
 
-#echo 'update.packages(repos="http://cran.rstudio.com/", ask=FALSE)' | R --vanilla
-echo 'x <- rownames(old.packages(repos="http://cran.rstudio.com/")); update.packages(repos="http://cran.rstudio.com/", ask=FALSE, oldPkgs=x[!x %in% "rgl"])' | R --vanilla
+#echo 'update.packages(ask=FALSE)' | R --vanilla
+echo 'x <- rownames(old.packages()); update.packages(ask=FALSE, oldPkgs=x[!x %in% "rgl"])' | R --vanilla
 
 echo "######################################################################"
 echo "ED"
@@ -479,7 +479,7 @@ echo "######################################################################"
 echo "PECAN"
 echo "######################################################################"
 
-echo 'if(!"rgl" %in% installed.packages()) install.packages("rgl", repos="http://cran.rstudio.com/")' | R --vanilla
+echo 'if(!"rgl" %in% installed.packages()) install.packages("rgl")' | R --vanilla
 
 if [ ! -e ${HOME}/pecan ]; then
   cd
@@ -622,12 +622,12 @@ echo "######################################################################"
 echo "SHINY SERVER"
 echo "######################################################################"
 if [ "${SHINY_SERVER}" != "" -a $( uname -m ) == "x86_64" ]; then
-  sudo su - -c "R -e \"install.packages(c('rmarkdown', 'shiny'), repos='https://cran.rstudio.com/')\""
+  sudo su - -c "R -e \"install.packages(c('rmarkdown', 'shiny'))\""
 
   R -e "install.packages(c('https://www.bioconductor.org/packages/release/bioc/src/contrib/BiocGenerics_0.28.0.tar.gz', 'http://www.bioconductor.org/packages/release/bioc/src/contrib/graph_1.60.0.tar.gz'), repos=NULL)"
   R -e "devtools::install_github('duncantl/CodeDepends')"
   #R -e "devtools::install_github('OakleyJ/SHELF')"
-  R -e "install.packages(c('shinythemes', 'shinytoastr', 'plotly'), repos='https://cran.rstudio.com/')"
+  R -e "install.packages(c('shinythemes', 'shinytoastr', 'plotly'))"
 
   cd 
 
@@ -731,8 +731,8 @@ echo "######################################################################"
 echo "PalEON"
 echo "######################################################################"
 if [ "$SETUP_PALEON" != "" ]; then
-  echo 'if(!"neotoma" %in% installed.packages()) install.packages("neotoma", repos="http://cran.rstudio.com/")' | R --vanilla
-  echo 'if(!"R2jags" %in% installed.packages()) install.packages("R2jags", repos="http://cran.rstudio.com/")' | R --vanilla
+  echo 'if(!"neotoma" %in% installed.packages()) install.packages("neotoma")' | R --vanilla
+  echo 'if(!"R2jags" %in% installed.packages()) install.packages("R2jags")' | R --vanilla
 
   if [ ! -e ${HOME}/Camp2016 ]; then
     cd

--- a/shiny/workflowPlot/helper.R
+++ b/shiny/workflowPlot/helper.R
@@ -2,7 +2,7 @@
 checkAndDownload<-function(packageNames) {
   for(packageName in packageNames) {
     if(!isInstalled(packageName)) {
-      install.packages(packageName,repos="http://lib.stat.cmu.edu/R/CRAN") 
+      install.packages(packageName)
     } 
     library(packageName,character.only=TRUE,quietly=TRUE,verbose=FALSE)
   }


### PR DESCRIPTION
**NOTE: Hold off on pulling this until I've removed the WIP marker. I want to see if GH Actions pass under this configuration.**

- Do not set `repos = ...` in install.packages calls. We should not be overwriting the user- or system-specific setting in `.Rprofile`. In particular, this can produce insidious bugs when interacting with Docker containers that are configured to use specific CRAN snapshots. We should defer to the Docker R image configuration to handle this, unless strictly necessary.
- Undo manual installing rlang and testthat in GH actions . If we defer to the correct Docker images with the correct fixed RStudio package manager snapshots, this should not be necessary

