### PR TITLE
WIP HACK: Fix GH actions coda and mvtnorm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,11 @@ jobs:
     # HACK: Temporary fix for GH actions issue that coda and mvtnorm installed via R4.0.3
     - name: Install coda and mvtnorm from source
       run: |
-        Rscript -e 'remotes::install_github("cran/coda")' -e 'remotes::install_github("cran/mvtnorm")' -e 'remotes::install_github("cran/XML")'
+        Rscript \
+          -e 'remotes::install_github("cran/coda")' \
+          -e 'remotes::install_github("cran/mvtnorm")' \
+          -e 'remotes::install_github("cran/XML")' \
+          -e 'remotes::install_github("cran/rjags")'
 
     # run PEcAn checks
     - name: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,11 @@ jobs:
     - name: install new dependencies
       run: Rscript scripts/generate_dependencies.R && Rscript docker/depends/pecan.depends.R
 
+    # HACK: Temporary fix for GH actions issue that coda and mvtnorm installed via R4.0.3
+    - name: Install coda and mvtnorm from source
+      run: |
+        Rscript -e 'remotes::install_github("cran/coda")' -e 'remotes::install_github("cran/mvtnorm")'
+
     # run PEcAn checks
     - name: check
       run: make -j1 check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,14 +155,16 @@ jobs:
     - name: install new dependencies
       run: Rscript scripts/generate_dependencies.R && Rscript docker/depends/pecan.depends.R
 
-    # HACK: Temporary fix for GH actions issue that coda and mvtnorm installed via R4.0.3
-    - name: Install coda and mvtnorm from source
+    # HACK: Temporary fix for GH actions issue that some packages are installed via R4.0.3
+    - name: Re-install problematic packages from source
       run: |
         Rscript \
           -e 'remotes::install_github("cran/coda")' \
           -e 'remotes::install_github("cran/mvtnorm")' \
           -e 'remotes::install_github("cran/XML")' \
-          -e 'remotes::install_github("cran/rjags")'
+          -e 'remotes::install_github("cran/rjags")' \
+          -e 'remotes::install_github("cran/ggmap")' \
+          -e 'remotes::install_github("cran/gridExtra")'
 
     # run PEcAn checks
     - name: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
     # HACK: Temporary fix for GH actions issue that coda and mvtnorm installed via R4.0.3
     - name: Install coda and mvtnorm from source
       run: |
-        Rscript -e 'remotes::install_github("cran/coda")' -e 'remotes::install_github("cran/mvtnorm")'
+        Rscript -e 'remotes::install_github("cran/coda")' -e 'remotes::install_github("cran/mvtnorm")' -e 'remotes::install_github("cran/XML")'
 
     # run PEcAn checks
     - name: check


### PR DESCRIPTION
Current builds are failing the `check` CI test for R4.0.2 because of the following:

```
  ── Newly failing
  
  ✖ checking whether package ‘PEcAn.allometry’ can be installed ... WARNING
  
  R check of modules/allometry reports the following new problems. Please fix these and resubmit:
  checking whether package ‘PEcAn.allometry’ can be installed ... WARNING
  Found the following significant warnings:
    Warning: package ‘coda’ was built under R version 4.0.3
    Warning: package ‘mvtnorm’ was built under R version 4.0.3
  See ‘/tmp/RtmpYbnRSL/PEcAn.allometry.Rcheck/00install.out’ for details.
  make: *** [Makefile:139: .check/modules/allometry] Error 1
```

As best I can tell, this is a bug in the R Package Manager, not something broken on our end. This PR implements a hack where we reinstall `coda` and `mvtnorm` from source to ensure R version consistency. Not great, but hopefully will fix the issue for now.