### PR TITLE
HACK: Install some packages from source by hand

### DIFF
--- a/docker/depends/Dockerfile
+++ b/docker/depends/Dockerfile
@@ -42,5 +42,14 @@ COPY pecan.depends.R /
 RUN  Rscript -e "install.packages(c('devtools'))" \
   && Rscript -e "devtools::install_version('roxygen2', '7.0.2')" \
   && R_LIBS_USER='/usr/local/lib/R/site-library' Rscript /pecan.depends.R \
+# These 6 packages are not cached correctly for some reason, so we need to
+# install them from source by hand.
+  && Rscript \
+    -e 'remotes::install_github("cran/coda")' \
+    -e 'remotes::install_github("cran/mvtnorm")' \
+    -e 'remotes::install_github("cran/XML")' \
+    -e 'remotes::install_github("cran/rjags")' \
+    -e 'remotes::install_github("cran/ggmap")' \
+    -e 'remotes::install_github("cran/gridExtra")' \
   && rm -rf /tmp/*
 


### PR DESCRIPTION
They are not cached properly by the RStudio Package Manager. For whatever reason, the default versions of these packages are compiled under R v4.0.3, even for R version 4.0.2. So we have to re-compile them from source by hand. This is an imperfect fix, but should (temporarily) stop our 4.0.2 builds from breaking.

The alternative is #2777 , which implements this only via GH Actions.

Another alternative is to advance to 4.0.3 -- now that R 4.0.4 is out, we can treat that as the latest and use 4.0.3 as the default for CI (though we can still check builds against 4.0.2 if we want).

NOTE: This will _not_ resolve current build errors until it is merged (because the base Docker image won't be pushed yet). However, once it is merged, subsequent builds should start succeeding again.