### PR TITLE
Bump default R version to 4.0.3

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest  
 
     container: 
-      image: pecan/depends:R4.0.2
+      image: pecan/depends:R4.0.3
 
     steps:
     # checkout source code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
       fail-fast: false
       matrix:
         R:
-          - "4.0.2"
           - "4.0.3"
+          - "4.0.4"
 
     env:
       NCPUS: 2
@@ -76,8 +76,8 @@ jobs:
       fail-fast: false
       matrix:
         R:
-          - "4.0.2"
           - "4.0.3"
+          - "4.0.4"
 
     services:
       postgres:
@@ -129,8 +129,8 @@ jobs:
       fail-fast: false
       matrix:
         R:
-          - "4.0.2"
           - "4.0.3"
+          - "4.0.4"
 
     env:
       NCPUS: 2
@@ -175,8 +175,8 @@ jobs:
       fail-fast: false
       matrix:
         R:
-          - "4.0.2"
           - "4.0.3"
+          - "4.0.4"
 
     services:
       postgres:

--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   # official supported version of R
-  SUPPORTED: 4.0.2
+  SUPPORTED: 4.0.3
   DOCKERHUB_ORG: pecan
 
 jobs:
@@ -24,8 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         R:
-          - "4.0.2"
           - "4.0.3"
+          - "4.0.4"
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 
 ## [Unreleased]
 
-### Due to dependencies, PEcAn is now using R 4.0.2 for Docker images.
+### Due to dependencies, PEcAn is now using R 4.0.3 for Docker images.
 
 This is a major change:
 


### PR DESCRIPTION
Our 4.0.3 builds and checks are already passing, and now that R 4.0.4 is released, 4.0.3 packages are frozen to Feb 17, 2021. Meanwhile, our 4.0.2 builds are failing for no fault of our own (looks like an error with the R Package Manager).

NOTE: I think this will fail the 4.0.4 checks (not required) until it's merged because we haven't build the containers yet. I already changed the branch protection rules to use the 4.0.3 builds and checks instead of 4.0.2.