### PR TITLE
Handle exact.dates = FALSE in dbfile.input.check

### DIFF
--- a/base/db/R/dbfiles.R
+++ b/base/db/R/dbfiles.R
@@ -285,6 +285,15 @@ dbfile.input.check <- function(siteid, startdate = NULL, enddate = NULL, mimetyp
         con = con
       )
     }
+  } else { # not exact dates
+    inputs <- db.query(
+        query = paste0(
+          "SELECT * FROM inputs WHERE site_id=", siteid,
+          " AND format_id=", formatid,
+          parent
+        ),
+        con = con
+    )
   }
 
   if (is.null(inputs) | length(inputs$id) == 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
I added an else block under for the if (exact.dates). I kept the end_date logic added in 692b65aa588d2352bb3dfb2f88a235e32295bc1e but brought back the missing code from the earlier version d93f1b395279119cd0849c0bc34c121f7bf2edda.
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When trying to get CF met data processed I found the workflow to crash in dbfile.input.check, because no query is run whenever the exact.dates argument is false. It seems that the code to handle this case had gone missing in a recent commit. Assuming that this was accidental, I restored the missing code from an earlier version. 

<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
