### PR TITLE
set port

### DIFF
--- a/docker/web/config.docker.php
+++ b/docker/web/config.docker.php
@@ -3,6 +3,7 @@
 # Information to connect to the BETY database
 $db_bety_type="pgsql";
 $db_bety_hostname=getenv('PGHOST', true) ?: "postgres";
+$db_bety_port=getenv('PGPORT', true) ?: 5432;
 $db_bety_username=getenv('BETYUSER', true) ?: "bety";
 $db_bety_password=getenv('BETYPASSWORD', true) ?: "bety";
 $db_bety_database=getenv('BETYDATABASE', true) ?: "bety";


### PR DESCRIPTION
This will fix the docker image for the web frontend for PEcAn to specify the port that is needed to connect to pecan.

This is needed to fix  issue related to https://github.com/PecanProject/pecan/commit/de5ec33247e55f866e1479ea0191491af127a838

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [X] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
