### PR TITLE
Support devtools >= 2.4.0 in check_with_errors.R

### DIFF
--- a/scripts/check_with_errors.R
+++ b/scripts/check_with_errors.R
@@ -32,6 +32,14 @@ if (!runtests) {
     args <- c("--timings")
 }
 
+# devtools 2.4.0 changed values accepted by document argument:
+# < 2.4.0: TRUE = yes, FALSE = no, NA = yes if a Roxygen package
+# >= 2.4.0: TRUE = yes, FALSE = no,
+#   NULL = if installed Roxygen is same version as package's RoxygenNote
+if ((packageVersion("devtools") >= "2.4.0") && is.na(redocument)) {
+    redocument <- NULL
+}
+
 chk <- devtools::check(pkg, args = args, quiet = TRUE,
     error_on = die_level, document = redocument)
 


### PR DESCRIPTION
Apparently devtools 2.4.0 changed the needed input for its `document` argument without saying so in the release notes 😒

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
