### PR TITLE
Logger spelling fix

### DIFF
--- a/base/logger/DESCRIPTION
+++ b/base/logger/DESCRIPTION
@@ -11,15 +11,16 @@ Authors@R: c(person("Rob", "Kooper", role = c("aut", "cre"),
              person("Chris", "Black", role = c("ctb")),
              person("University of Illinois, NCSA", role = c("cph")))
 Description: Convenience functions for logging outputs from 'PEcAn',
-   the Predictive Ecosystem Analyzer (LeBauer et al. 2017;
-   doi:10.1890/12-0137.1). Enables the user to set what level of messages are
+   the Predictive Ecosystem Analyzer (LeBauer et al. 2017)
+   <doi:10.1890/12-0137.1>. Enables the user to set what level of messages are
    printed, as well as whether these messages are written to the console, 
    a file, or both. It also allows control over whether severe errors should
-   stop execution of the PEcAn workflow; this allows strictness when deugging
+   stop execution of the 'PEcAn' workflow; this allows strictness when debugging
    and lenience when running large batches of simulations that should not be
-   terminated by errors in individual models. PEcAn.logger is loosely based on
+   terminated by errors in individual models. It is loosely based on
    the 'log4j' package.
 BugReports: https://github.com/PecanProject/pecan/issues
+URL: https://pecanproject.github.io/
 Imports: utils
 Suggests: testthat
 License: BSD_3_clause + file LICENSE

--- a/base/logger/DESCRIPTION
+++ b/base/logger/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: PEcAn.logger
-Title: Logger Functions for PEcAn
+Title: Logger Functions for 'PEcAn'
 Version: 1.8.0
 Date: 2021-07-27
 Authors@R: c(person("Rob", "Kooper", role = c("aut", "cre"),


### PR DESCRIPTION
Found by checking PEcAn.logger against the R-hub check service: `Rscript -e 'rhub::check_for_cran("PEcAn.logger_1.8.0.tar.gz", email = "chris@ckblack.org")'`

(use your own email address; rhub will give you instructions on how to verify it before you submit the package) 

r-hub results: Before this patch ([R-devel Fedora](https://builder.r-hub.io/status/PEcAn.logger_1.8.0.tar.gz-5448fb4274fa440596dc4faee348eb5b), [R-release Fedora](https://builder.r-hub.io/status/PEcAn.logger_1.8.0.tar.gz-f261c02966024604b3fb69cc82161289), [R-devel Windows](https://builder.r-hub.io/status/PEcAn.logger_1.8.0.tar.gz-d58a4cf8451740799bb4bfd6cf6018e7)); After this patch ([R-devel Fedora](https://builder.r-hub.io/status/PEcAn.logger_1.8.0.tar.gz-c4bd584c907248d4b78bc04daff699ee), [R-release Fedora](https://builder.r-hub.io/status/PEcAn.logger_1.8.0.tar.gz-6ae62749268941e59391d82042d06f1c), [R-devel Windows](https://builder.r-hub.io/status/PEcAn.logger_1.8.0.tar.gz-7547acd8b0874177aebead5c57ddeb2c)). 

@robkooper Note that 'LeBauer', 'et', 'al', and sometimes 'workflow' are still reported as "possibly mis-spelled" and should be called out as false positives in the CRAN submission form.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
