### PR TITLE
convert last uses of deprecated PEcAn.utils::logger* to PEcAn.logger::loger*

### DIFF
--- a/base/utils/R/mcmc.list2init.R
+++ b/base/utils/R/mcmc.list2init.R
@@ -66,7 +66,7 @@ mcmc.list2init <- function(dat) {
         }
         
       } else {
-        PEcAn.utils::logger.severe("dimension not supported",dim,uname[v])
+        PEcAn.logger::logger.severe("dimension not supported",dim,uname[v])
       }
       
     }  ## end else VECTOR or MATRIX

--- a/modules/assim.sequential/R/get_ensemble_weights.R
+++ b/modules/assim.sequential/R/get_ensemble_weights.R
@@ -49,7 +49,7 @@ get_ensemble_weights <- function(settings, time_do){
                                                                                                     time_do[tt] &
                                                                                                     weight_file$climate_model %in% climate_names, 'weights'])) * nens
       
-      if(sum(weight_list[[tt]]) != nens) PEcAn.utils::logger.warn(paste('Time',tt,'does not equal the number of ensemble members',nens))
+      if(sum(weight_list[[tt]]) != nens) PEcAn.logger::logger.warn(paste('Time',tt,'does not equal the number of ensemble members',nens))
       
       #TO DO: will need to have some way of dealing with sampling too if there are more ensemble members than weights or vice versa
       

--- a/modules/data.land/R/InventoryGrowthFusion.R
+++ b/modules/data.land/R/InventoryGrowthFusion.R
@@ -29,7 +29,7 @@ InventoryGrowthFusion <- function(data, cov.data=NULL, time_data = NULL, n.iter=
   }
   max.chunks <- ceiling(n.iter/n.chunk)
   if(max.chunks < k_restart){
-    PEcAn.utils::logger.warn("MCMC already complete",max.chunks,k_restart)
+    PEcAn.logger::logger.warn("MCMC already complete",max.chunks,k_restart)
     return(NULL)
   }
   avail.chunks <- k_restart:ceiling(n.iter/n.chunk)

--- a/scripts/EFI_workflow.R
+++ b/scripts/EFI_workflow.R
@@ -113,7 +113,7 @@ if(length(input_check$id) > 0){
   
   settings$run$inputs$met$id = index_id
   settings$run$inputs$met$path = clim_check
-}else{PEcAn.utils::logger.error("No met file found")}
+}else{PEcAn.logger::logger.error("No met file found")}
 #settings <- PEcAn.workflow::do_conversions(settings, T, T, T)
 
 if(is_empty(settings$run$inputs$met$path) & length(clim_check)>0){


### PR DESCRIPTION

## Description
The logger functions in PEcAn.utils have been deprecated for several years and will be removed entirely in #2830. 

These are the only remaining uses of them I could find in the codebase, but if you're reading this please check all your local scripts and update them now!


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
