### PR TITLE
skip dependency check when on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,9 @@ $(ALL_PKGS_I) $(ALL_PKGS_C) $(ALL_PKGS_T) $(ALL_PKGS_D): | .install/devtools .in
 
 .SECONDEXPANSION:
 .doc/%: $$(call files_in_dir, %) | $$(@D)
+ifeq ($(CI),) # skipped on CI because we start the run by bulk-installing all deps
 	+ $(call depends_R_pkg, $(subst .doc/,,$@))
+endif
 	$(call doc_R_pkg, $(subst .doc/,,$@))
 	echo `date` > $@
 


### PR DESCRIPTION
Not needed because when on CI all known dependencies are listed in `docker/depends/pecan.depends.R` and we install them in bulk before invoking make

Question for @robkooper:  On checking, it looks like install-dependencies steps of the `test`, `check`, and `sipnet` jobs is 

```
Rscript scripts/generate_dependencies.R && Rscript docker/depends/pecan.depends.R
``` 

But in the `build` job it's just

```
Rscript scripts/generate_dependencies.R
```

Should that change, or does build not need depends?