### PR TITLE
Add tests for rescaling_stateVars

### DIFF
--- a/modules/assim.sequential/R/Helper.functions.R
+++ b/modules/assim.sequential/R/Helper.functions.R
@@ -124,7 +124,9 @@ rescaling_stateVars <- function(settings, X, multiply=TRUE) {
       purrr::discard( ~ .x %in% c("dim", "dimnames"))
     
     if (length(attr.X) > 0) {
-      attr(Y, attr.X) <- attr(X, attr.X)
+      for (att in attr.X) {
+        attr(Y, att) <- attr(X, att)
+      }
     }
     
   }, silent = TRUE)

--- a/modules/assim.sequential/R/Helper.functions.R
+++ b/modules/assim.sequential/R/Helper.functions.R
@@ -112,10 +112,13 @@ rescaling_stateVars <- function(settings, X, multiply=TRUE) {
       }else{
         X[, .x]
       }
-    }) %>%
-    as.matrix() %>%
-    `colnames<-`(colnames(X))
-  
+    })
+
+  if (is.matrix(X)) {
+    Y <- as.matrix(Y)
+    colnames(Y) <- colnames(X)
+  }
+
   try({
     # I'm trying to give the new transform variable the attributes of the old one
     # X for example has `site` attribute

--- a/modules/assim.sequential/tests/testthat/test_rescaling.R
+++ b/modules/assim.sequential/tests/testthat/test_rescaling.R
@@ -1,0 +1,75 @@
+
+settings <- list(
+	state.data.assimilation = list(
+		state.variables = list(
+			variable = list(variable.name = "a", scaling_factor = 1),
+			variable = list(variable.name = "b", scaling_factor = 2),
+			variable = list(variable.name = "c", scaling_factor = 3),
+			variable = list(variable.name = "z", scaling_factor = 0))))
+
+mkdata <- function(...) {
+	as.matrix(data.frame(...))
+}
+
+test_that("returns input where no scaling specified", {
+	expect_identical(
+		rescaling_stateVars(list(), 1L),
+		1L)
+
+	unscalable <- mkdata(d = 1, e = 1)
+	expect_identical(
+		rescaling_stateVars(settings, unscalable),
+		unscalable)
+
+	partly_scaleable <- mkdata(c = 10, d = 10)
+	expect_equal(
+		rescaling_stateVars(settings, partly_scaleable),
+		partly_scaleable * c(3, 1))
+})
+
+test_that("multiplies or divides as requested", {
+	expect_equal(
+		rescaling_stateVars(
+			settings,
+			mkdata(a = 1:3, b = 1:3, c = 1:3)),
+		mkdata(a = (1:3) * 1, b = (1:3) * 2, c = (1:3) * 3))
+	expect_equal(
+		rescaling_stateVars(
+			settings,
+			mkdata(a = 1:3, b = 1:3, c = 1:3),
+			multiply = FALSE),
+		mkdata(a = (1:3) / 1, b = (1:3) / 2, c = (1:3) / 3))
+})
+
+test_that("handles zeroes in data", {
+	expect_equal(
+		rescaling_stateVars(settings, mkdata(c = 0)),
+		mkdata(c = 0))
+	expect_equal(
+		rescaling_stateVars(settings, mkdata(c = 0), multiply = FALSE),
+		mkdata(c = 0))
+})
+
+test_that("handles zeroes in scalars", {
+	expect_equal(
+		rescaling_stateVars(settings, mkdata(z = 10)),
+		mkdata(z = 0))
+	expect_equal(
+		rescaling_stateVars(settings, mkdata(z = 10), multiply = FALSE),
+		mkdata(z = Inf))
+})
+
+test_that("retains attributes", {
+	x_attrs <- mkdata(b = 1:3)
+	attr(x_attrs, "site") <- "foo"
+
+	expect_identical(
+		attr(rescaling_stateVars(settings, x_attrs), "site"),
+		"foo")
+})
+
+test_that("accepts data frames", {
+	expect_equal(
+		rescaling_stateVars(settings, data.frame(b = 2:4)),
+		data.frame(b = (2:4) * 2))
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
A few unit tests for the helper function that rescales state variables. 

As is traditional, writing the tests also leads to bug fixes: 
* When the input had more than one attribute set, none of the attributes were being copied to the output. Fixed by looping over all of them.
* Inputs that were dataframes lead to corrupted output, because their `class` and `names` attributes got copied over onto the matrix output. Fixed by only coercing the result to matrix if the input was also a matrix, and otherwise returning dataframe. Note that the function is only documented to accept and return matrices, but quiet dataframe support seemed better than data corruption.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
"Once again, Chris, why are you spending your time writing tests for the simplest function in the package?" 

Well, because my real motivation is to prevent a future build problem: 

* The allometry and assim.sequential packages currently contain no unit tests.
* This is fine in our current CI builds because they currently use devtools 2.3.2, in which `devtools::test` simply reports that no tests were found and moves on to the next package.
* But devtools >= 2.4 stops with an error when no tests are found, so the CI builds will start failing for these packages the next time we bump the R version we test against.
* Therefore I'm setting out to make sure every package contains *some* tests, but I'm gonna start with the functions that are easiest to test 😉  I highly encourage the owners of these packages to follow up with PRs that test the functions actually central to each package.


## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
