### PR TITLE
Install new packages at start of /document

### DIFF
--- a/.github/workflows/styler-actions.yml
+++ b/.github/workflows/styler-actions.yml
@@ -51,6 +51,10 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: update dependency lists
         run: Rscript scripts/generate_dependencies.R
+      - name: install any new dependencies
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+        run: Rscript docker/depends/pecan.depends.R
       - id: file_changes
         uses: trilom/file-changes-action@v1.2.4
       - name : make


### PR DESCRIPTION
Fix missed in #2864: You'd think we'd need to either install at the beginning /or/ during Make, but 🤷‍♂️ 