### PR TITLE
make Rmarkdown code chunks use same number of ticks at start and end

### DIFF
--- a/book_source/03_topical_pages/01_advanced_vm.Rmd
+++ b/book_source/03_topical_pages/01_advanced_vm.Rmd
@@ -90,9 +90,9 @@ Login to [Amazon Web Services (AWS)](http://console.aws.amazon.com/) and select 
 +	Click “Add Rule”, leave the pull down on “Custom TCP Rule”, and then change the Port Range from 0 to 8787. Set “Source” to Anywhere. This rule allows you to access RStudio Server on PEcAn.
 +	Click “Review and Launch”  . You will then see this pop-up:
   
-  ```{r, echo=FALSE,fig.align='center'}
+```{r, echo = FALSE, fig.align = 'center'}
 knitr::include_graphics(rep("figures/pic2.jpg"))
-```    
+```
 
 Select the default drive volume type and click Next
 

--- a/documentation/tutorials/StateAssimilation/TreeRingSDA.Rmd
+++ b/documentation/tutorials/StateAssimilation/TreeRingSDA.Rmd
@@ -96,21 +96,21 @@ Perform a site-level SIPNET run using the following settings
   </state.data.assimilation>
 ```
 
-* Delete the ```<pfts>`` block from the settings
+* Delete the `<pfts>` block from the settings
 
-* In the PEcAn History, go to your PDA run and open ```pecan.pda[UNIQUEID].xml``` (the one PEcAn saved for you AFTER you finished the PDA)
+* In the PEcAn History, go to your PDA run and open `pecan.pda[UNIQUEID].xml` (the one PEcAn saved for you AFTER you finished the PDA)
 
-* Cut-and-paste the PDA ```<pfts>``` block into the SDA settings file
+* Cut-and-paste the PDA `<pfts>` block into the SDA settings file
 
-* Save the file as ```pecan.SDA.xml```
+* Save the file as `pecan.SDA.xml`
 
 #### Loading data
 
 * If you have not done so already, clone (new) or pull (update) the PalEON Camp2016 repository
  + Open a shell under Tools > Shell
- + ```cd`` to go to your home directory
- + To clone: ```git clone git@github.com:PalEON-Project/Camp2016.git```
- + To pull: ```cd Camp2016; git pull https://github.com/PalEON-Project/Camp2016.git master```
+ + `cd` to go to your home directory
+ + To clone: `git clone git@github.com:PalEON-Project/Camp2016.git`
+ + To pull: `cd Camp2016; git pull https://github.com/PalEON-Project/Camp2016.git master`
 
 * Open the tree-ring data assimilation workflow under Home > pecan > scripts > workflow.treering.R
 
@@ -158,7 +158,7 @@ $$\tau_{r} \sim Gamma(a_r,r_r)$$
 
 This model is encapsulated in the PEcAn function:
 
-``````{r echo= TRUE, eval=FALSE}
+```{r echo = TRUE, eval = FALSE}
 InventoryGrowthFusion(combined,n,iter)
 ```
 


### PR DESCRIPTION
Fixes #2872 

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of .zenodo.json
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
