### PR TITLE
throw Make error if wrong Roxygen2 used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,10 @@ test_R_pkg = ./scripts/time.sh "test ${1}" Rscript \
 	-e "stop_on_failure = TRUE," \
 	-e "stop_on_warning = FALSE)" # TODO: Raise bar to stop_on_warning = TRUE when we can
 
-doc_R_pkg = ./scripts/time.sh "document ${1}" Rscript -e "devtools::document('"$(strip $(1))"')"
+doc_R_pkg = ./scripts/time.sh "document ${1}" Rscript \
+	-e "roxver <- packageVersion('roxygen2')" \
+	-e "if (roxver != '7.0.2') stop('Roxygen2 version is ', roxver, ', but PEcAn package documentation must be built with exactly version 7.0.2')" \
+	-e "devtools::document('"$(strip $(1))"')"
 
 depends = .doc/$(1) .install/$(1) .check/$(1) .test/$(1)
 


### PR DESCRIPTION
## Description
When invoking `make document`, check that Roxygen version is exactly 7.0.2 and stop immediatelywith a clear error message, rather than let Roxygen update every package in a way that's hard to roll back as it does currently.

## Motivation and Context

The fact that we make everyone use the same version of Roxygen is buried somewhere in the documentation, but hasn't been a clear part of the onboarding routine (sorry, @helge22a and @DongchenZ!). It's definitely worsened by the fact that we've let the supported version of Roxygen get so old, but I submit that we'll still need this check even after updating to use the version of Roxygen that's current as I write this.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of .zenodo.json
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
