### PR TITLE
fix docker.sh to use R 4.1

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -11,7 +11,7 @@ cd $(dirname $0)
 # Can set the following variables
 DEBUG=${DEBUG:-""}
 DEPEND=${DEPEND:-""}
-R_VERSION=${R_VERSION:-"4.0.2"}
+R_VERSION=${R_VERSION:-"4.1"}
 
 # --------------------------------------------------------------------------------
 # PECAN BUILD SECTION

--- a/docker/depends/Dockerfile
+++ b/docker/depends/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update \
 # ----------------------------------------------------------------------
 COPY pecan.depends.R /
 RUN  Rscript -e "install.packages(c('devtools'))" \
-  && Rscript -e "devtools::install_version('roxygen2', '7.1.2')" \
+  && Rscript -e "devtools::install_version('roxygen2', '7.1.2', repos = 'cran.r-project.org')" \
   && R_LIBS_USER='/usr/local/lib/R/site-library' Rscript /pecan.depends.R \
   && rm -rf /tmp/*
 


### PR DESCRIPTION
Noticed that we still use docker 4.0.2 to build, now using 4.1

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of .zenodo.json
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
