### PR TITLE
Less eager dependency check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,11 +62,15 @@ drop_parents = $(filter-out $(patsubst %/,%,$(dir $1)), $1)
 # Generates a list of regular files at any depth inside its argument
 files_in_dir = $(call drop_parents, $(call recurse_dir, $1))
 
-# HACK: assigning to `deps` is an ugly workaround for circular dependencies in utils pkg.
+# HACK: NA vs TRUE switch on dependencies argument is an ugly workaround for
+# circular dependencies in utils pkg.
 # When these are fixed, can go back to simple `dependencies = TRUE`
-depends_R_pkg = ./scripts/time.sh "depends ${1}" Rscript -e ${SETROPTIONS} \
-	-e "deps <- if (grepl('(base/utils|modules/benchmark)', '$(1)')) { c('Depends', 'Imports', 'LinkingTo') } else { TRUE }" \
-	-e "devtools::install_deps('$(strip $(1))', dependencies = deps, upgrade=FALSE)"
+depends_R_pkg = ./scripts/time.sh "depends ${1}" \
+	./scripts/confirm_deps.R ${1} \
+	$(if $(or \
+			$(findstring base/utils,$(1)), \
+			$(findstring modules/benchmark,$(1))) \
+		,NA,TRUE)
 install_R_pkg = ./scripts/time.sh "install ${1}" Rscript \
 	-e ${SETROPTIONS} \
 	-e "devtools::install('$(strip $(1))', upgrade=FALSE)"
@@ -146,9 +150,7 @@ $(ALL_PKGS_I) $(ALL_PKGS_C) $(ALL_PKGS_T) $(ALL_PKGS_D): | .install/devtools .in
 
 .SECONDEXPANSION:
 .doc/%: $$(call files_in_dir, %) | $$(@D)
-ifeq ($(CI),) # skipped on CI because we start the run by bulk-installing all deps
 	+ $(call depends_R_pkg, $(subst .doc/,,$@))
-endif
 	$(call doc_R_pkg, $(subst .doc/,,$@))
 	echo `date` > $@
 

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -18,6 +18,7 @@ ARG PECAN_GIT_DATE="unknown"
 # copy folders
 COPY Makefile Makefile.depends /pecan/
 COPY scripts/time.sh /pecan/scripts/time.sh
+COPY scripts/confirm_deps.R /pecan/scripts/confirm_deps.R
 COPY base     /pecan/base/
 COPY modules  /pecan/modules/
 COPY models   /pecan/models/

--- a/scripts/confirm_deps.R
+++ b/scripts/confirm_deps.R
@@ -1,0 +1,109 @@
+#!/usr/bin/env Rscript
+
+# Usage as a script:
+# ./confirm_deps path/to/package [dependencies]
+# Usage as a function: source in and use as documented below
+
+
+
+#' Check whether a local package's dependencies are already satisfied
+#'
+#' This is a wrapper around `remotes::install_deps` that checks first, before
+#' consulting any remote repositories,  whether the package versions already
+#' installed are sufficient to meet all declared dependencies.
+#' If they are, it returns nothing. If any dependencies are missing or need
+#' upgrading, it either installs them by calling `remotes::install_deps`
+#' (if `install = TRUE`) or returns a dataframe of dependency versions
+#' (if `install = FALSE`).
+#'
+#' Motivation: Because `install_deps` always eagerly checks for new versions of
+#' all dependencies, including those in non-CRAN remotes, using it to check
+#' dependencies for a large number of packages can exceed GitHub's limit on 
+#' unauthenticated API queries.
+#' Setting a personal access token increases the rate allowance, but it still seemed silly to check
+#' every time for new versions when the real question was "Do I already have the
+#' dependencies in place to install this package right now?"
+#'
+#' Note that if any packages do need installation, the call to
+#' `install_deps` will as usual check and update all dependencies, not just the
+#' ones that were unsatisfied. Control this behavior by passing an `upgrade`
+#' argument in `...`.
+#'
+#' @inheritParams remotes::install_deps
+#' @param install Install dependencies if they are missing, or just report them?
+#' @return If `install = FALSE`, a data frame of available and needed package
+#'   versions. If `install = TRUE`, the output from `install_deps`.
+confirm_deps <- function(
+		pkg,
+		install = TRUE,
+		dependencies = NA,
+		...) {
+
+	if(all(is.na(dependencies)) || all(dependencies == "hard")) {
+		dependencies <- c("Depends", "Imports", "LinkingTo")
+	} else if (isTRUE(dependencies) || all(dependencies == "soft")) {
+		dependencies <- c("Depends", "Imports", "LinkingTo", "Suggests")
+	} else if (isFALSE(dependencies)) {
+		return() # for compatibility with remotes::install_deps
+	}
+
+	deps <- desc::desc_get_deps(pkg)
+	deps <- deps[deps$type %in% dependencies,]
+	
+	pkgs <- as.data.frame(installed.packages())[, c("Package", "Version")]
+	colnames(pkgs) <- c("package", "installed_version")
+	colnames(deps)[colnames(deps) == "version"] <- "needed_version"
+	deps <- merge(deps, pkgs, all.x = TRUE)
+
+	# Check for incompatible versions
+	# Surprised I can't find a base function that does this in one shot...
+	# Regex note: `*` in pattern is a literal asterisk,
+	#	to match the "*" returned by desc_get_deps when no version is specified
+	deps$later_ok <- grepl("[>*]", deps$needed_version) #
+	deps$earlier_ok <- grepl("[<*]", deps$needed_version)
+	deps$equal_ok <- grepl("[=*]", deps$needed_version)
+	deps$needed_version <- gsub("[^[:digit:].-]", "", deps$needed_version)
+	deps$compare <- mapply(
+		FUN = compareVersion,
+		deps$installed_version,
+		deps$needed_version,
+		SIMPLIFY = TRUE)
+	deps$needs_upgrade <- (
+		is.na(deps$installed_version)
+		| (!deps$equal_ok) & (deps$compare == 0)
+		| (!deps$later_ok) & (deps$compare == 1)
+		| (!deps$earlier_ok) & (deps$compare == -1)
+	)
+
+	if (any(deps$needs_upgrade) && install) {
+		return(
+			remotes::install_deps(
+				pkg = pkg,
+				dependencies = dependencies,
+				...)
+		)
+	}
+
+	if (!install) {
+		cols <- c(
+			"package",
+			"needed_version",
+			"installed_version",
+			"needs_upgrade")
+		return(deps[, cols])
+	}
+}
+
+
+
+
+
+
+args <- commandArgs(trailingOnly = TRUE)
+pkg <- args[[1]]
+if (length(args) > 1) {
+	dep <- eval(parse(text = args[[2]]))
+} else {
+	dep <- NA
+}
+confirm_deps(pkg = pkg, dependencies = dep, install = TRUE, upgrade = FALSE)

--- a/scripts/confirm_deps.R
+++ b/scripts/confirm_deps.R
@@ -18,7 +18,7 @@
 #'
 #' Motivation: Because `install_deps` always eagerly checks for new versions of
 #' all dependencies, including those in non-CRAN remotes, using it to check
-#' dependencies for a large number of packages can exceed GitHub's limit on 
+#' dependencies for a large number of packages can exceed GitHub's limit on
 #' unauthenticated API queries.
 #' Setting a personal access token increases the rate allowance, but it still seemed silly to check
 #' every time for new versions when the real question was "Do I already have the
@@ -33,65 +33,66 @@
 #' @param install Install dependencies if they are missing, or just report them?
 #' @return If `install = FALSE`, a data frame of available and needed package
 #'   versions. If `install = TRUE`, the output from `install_deps`.
-confirm_deps <- function(
-		pkg,
-		install = TRUE,
-		dependencies = NA,
-		...) {
+confirm_deps <- function(pkg,
+                         install = TRUE,
+                         dependencies = NA,
+                         ...) {
+  if (all(is.na(dependencies)) || all(dependencies == "hard")) {
+    dependencies <- c("Depends", "Imports", "LinkingTo")
+  } else if (isTRUE(dependencies) || all(dependencies == "soft")) {
+    dependencies <- c("Depends", "Imports", "LinkingTo", "Suggests")
+  } else if (isFALSE(dependencies)) {
+    return() # for compatibility with remotes::install_deps
+  }
 
-	if(all(is.na(dependencies)) || all(dependencies == "hard")) {
-		dependencies <- c("Depends", "Imports", "LinkingTo")
-	} else if (isTRUE(dependencies) || all(dependencies == "soft")) {
-		dependencies <- c("Depends", "Imports", "LinkingTo", "Suggests")
-	} else if (isFALSE(dependencies)) {
-		return() # for compatibility with remotes::install_deps
-	}
+  deps <- desc::desc_get_deps(pkg)
+  deps <- deps[deps$type %in% dependencies, ]
 
-	deps <- desc::desc_get_deps(pkg)
-	deps <- deps[deps$type %in% dependencies,]
-	
-	pkgs <- as.data.frame(installed.packages())[, c("Package", "Version")]
-	colnames(pkgs) <- c("package", "installed_version")
-	colnames(deps)[colnames(deps) == "version"] <- "needed_version"
-	deps <- merge(deps, pkgs, all.x = TRUE)
+  pkgs <- as.data.frame(installed.packages())[, c("Package", "Version")]
+  colnames(pkgs) <- c("package", "installed_version")
+  colnames(deps)[colnames(deps) == "version"] <- "needed_version"
+  deps <- merge(deps, pkgs, all.x = TRUE)
 
-	# Check for incompatible versions
-	# Surprised I can't find a base function that does this in one shot...
-	# Regex note: `*` in pattern is a literal asterisk,
-	#	to match the "*" returned by desc_get_deps when no version is specified
-	deps$later_ok <- grepl("[>*]", deps$needed_version) #
-	deps$earlier_ok <- grepl("[<*]", deps$needed_version)
-	deps$equal_ok <- grepl("[=*]", deps$needed_version)
-	deps$needed_version <- gsub("[^[:digit:].-]", "", deps$needed_version)
-	deps$compare <- mapply(
-		FUN = compareVersion,
-		deps$installed_version,
-		deps$needed_version,
-		SIMPLIFY = TRUE)
-	deps$needs_upgrade <- (
-		is.na(deps$installed_version)
-		| (!deps$equal_ok) & (deps$compare == 0)
-		| (!deps$later_ok) & (deps$compare == 1)
-		| (!deps$earlier_ok) & (deps$compare == -1)
-	)
+  # Check for incompatible versions
+  # Surprised I can't find a base function that does this in one shot...
+  # Regex note: `*` in pattern is a literal asterisk,
+  # to match the "*" returned by desc_get_deps when no version is specified
+  deps$later_ok <- grepl("[>*]", deps$needed_version) #
+  deps$earlier_ok <- grepl("[<*]", deps$needed_version)
+  deps$equal_ok <- grepl("[=*]", deps$needed_version)
+  deps$needed_version <- gsub("[^[:digit:].-]", "", deps$needed_version)
+  deps$compare <- mapply(
+    FUN = compareVersion,
+    deps$installed_version,
+    deps$needed_version,
+    SIMPLIFY = TRUE
+  )
+  deps$needs_upgrade <- (
+    is.na(deps$installed_version) |
+      (!deps$equal_ok) & (deps$compare == 0) |
+      (!deps$later_ok) & (deps$compare == 1) |
+      (!deps$earlier_ok) & (deps$compare == -1)
+  )
 
-	if (any(deps$needs_upgrade) && install) {
-		return(
-			remotes::install_deps(
-				pkg = pkg,
-				dependencies = dependencies,
-				...)
-		)
-	}
+  if (any(deps$needs_upgrade) && install) {
+    return(
+      remotes::install_deps(
+        pkg = pkg,
+        dependencies = dependencies,
+        ...
+      )
+    )
+  }
 
-	if (!install) {
-		cols <- c(
-			"package",
-			"needed_version",
-			"installed_version",
-			"needs_upgrade")
-		return(deps[, cols])
-	}
+  if (!install) {
+    cols <- c(
+      "package",
+      "needed_version",
+      "installed_version",
+      "needs_upgrade"
+    )
+    return(deps[, cols])
+  }
 }
 
 
@@ -102,8 +103,8 @@ confirm_deps <- function(
 args <- commandArgs(trailingOnly = TRUE)
 pkg <- args[[1]]
 if (length(args) > 1) {
-	dep <- eval(parse(text = args[[2]]))
+  dep <- eval(parse(text = args[[2]]))
 } else {
-	dep <- NA
+  dep <- NA
 }
 confirm_deps(pkg = pkg, dependencies = dep, install = TRUE, upgrade = FALSE)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Replaces the Makefile check for package dependencies, previously provided by a call to `devtools::install_deps` that always checked for updates, with a new check that checks locally first and exits if all dependencies are already satisfied, _even if newer versions of them are available_. This is a change in behavior, but I argue it's what we want: If your installed version of (say) `stringi` still works, running `make document` shouldn't waste your time looking for a new version of it.

Note that if any dependencies *are* missing for a given package, we still resolve them by calling `install_deps` with `upgrade = FALSE`, which will still _send queries_ to learn about updates to all dependencies (not just the ones that are missing) but will only  _install_ the missing ones. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The primary motivation is that during CI builds, running `install_deps` on every package was generating enough GitHub API queries to routinely use up GitHub's rate limit of 60 unauthenticated requests per hour. Providing a personal access token helped, but was a hassle to pass in to all the places that run Make. 

This PR takes the approach that it's fine if _a few_ packages find missing dependencies and install them during the build -- this allows easier testing of PRs that add new dependencies which aren't yet installed on the Docker images -- but that we needn't spam CRAN and GitHub repeatedly checking for new versions of packages that are already installed and working.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of .zenodo.json
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
