### PR TITLE
skip icos/merra download on CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 
 - Using R4.0 and R4.1 tags to build PEcAn. Default is now 4.1
 - Database connections consistently use `DBI::dbConnect` instead of the deprecated `dplyr::src_postgres` (#2881). This change should be invisible to most users, but it involved converting a lot of internal variables from `bety$con` to `con`. If you see errors involving these symbols it means we missed a place, so please report them as bugs.
+- Skipped ICOS and MERRA download tests when running in github actions
 
 ### Removed
 

--- a/modules/data.atmosphere/tests/testthat/test.download.ICOS.R
+++ b/modules/data.atmosphere/tests/testthat/test.download.ICOS.R
@@ -5,6 +5,8 @@ setup(dir.create(outfolder, showWarnings = FALSE, recursive = TRUE))
 teardown(unlink(outfolder, recursive = TRUE))
 
 test_that("ICOS Drought 2018 download works", {
+  skip_on_ci()
+
   start_date <- "2016-01-01"
   end_date <- "2017-01-01"
   sitename <- "FI-Sii"
@@ -15,6 +17,8 @@ test_that("ICOS Drought 2018 download works", {
 })
 
 test_that("ICOS ETC download works", {
+  skip_on_ci()
+
   start_date <- "2019-01-01"
   end_date <- "2020-01-01"
   sitename <- "FI-Sii"

--- a/modules/data.atmosphere/tests/testthat/test.download.MERRA.R
+++ b/modules/data.atmosphere/tests/testthat/test.download.MERRA.R
@@ -5,6 +5,8 @@ setup(dir.create(outdir, showWarnings = FALSE, recursive = TRUE))
 teardown(unlink(outdir, recursive = TRUE))
 
 test_that("MERRA download works", {
+  skip_on_ci()
+  
   start_date <- "2009-06-01"
   end_date <- "2009-06-04"
   dat <- download.MERRA(outdir, start_date, end_date,


### PR DESCRIPTION
This will skip icos and merra downloads in testing. This should speed things up and prevent failures if the service is down.
## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [X] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of .zenodo.json
- [X] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
