### PR TITLE
ignore udunits warning to unstick CI

### DIFF
--- a/base/all/tests/Rcheck_reference.log
+++ b/base/all/tests/Rcheck_reference.log
@@ -8,6 +8,16 @@
 * this is package ‘PEcAn.all’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
+* checking package dependencies ... WARNING
+Depends: includes the non-default packages:
+  ‘PEcAn.DB’ ‘PEcAn.settings’ ‘PEcAn.MA’ ‘PEcAn.logger’ ‘PEcAn.utils’
+  ‘PEcAn.uncertainty’ ‘PEcAn.data.atmosphere’ ‘PEcAn.data.land’
+  ‘PEcAn.data.remote’ ‘PEcAn.assim.batch’ ‘PEcAn.emulator’
+  ‘PEcAn.priors’ ‘PEcAn.benchmark’ ‘PEcAn.remote’ ‘PEcAn.workflow’
+Adding so many packages to the search path is excessive and importing
+selectively is preferable.
+
+Requires (indirectly) orphaned package: ‘udunits2’
 * checking package dependencies ... NOTE
 Depends: includes the non-default packages:
   ‘PEcAn.DB’ ‘PEcAn.settings’ ‘PEcAn.MA’ ‘PEcAn.logger’ ‘PEcAn.utils’

--- a/base/db/tests/Rcheck_reference.log
+++ b/base/db/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.DB’ version ‘1.7.1’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/base/db/tests/testthat/test.symmetric-setdiff.R
+++ b/base/db/tests/testthat/test.symmetric-setdiff.R
@@ -18,7 +18,7 @@ test_that("Symmetric setdiff works", {
 test_that("Unequal dfs compare unequal", {
   expect_error(
     symmetric_setdiff(data.frame(a = 1L), data.frame(b = 1L)),
-    "Cols in x but not y")
+    "Cols in `?x`? but not `?y")
   d <- symmetric_setdiff(data.frame(a = 1:3L), data.frame(a = 1:4L))
   expect_length(d$a, 1L)
   expect_equal(d$a, 4L)

--- a/base/settings/tests/Rcheck_reference.log
+++ b/base/settings/tests/Rcheck_reference.log
@@ -7,7 +7,8 @@
 * this is package ‘PEcAn.settings’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires (indirectly) orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/base/utils/tests/Rcheck_reference.log
+++ b/base/utils/tests/Rcheck_reference.log
@@ -8,8 +8,12 @@
 * this is package ‘PEcAn.utils’ version ‘1.7.1’
 * package encoding: UTF-8
 * checking package namespace information ... OK
+* checking package dependencies ... WARNING
+Requires orphaned package: ‘udunits2’
+
+Package suggested but not available for checking: ‘PEcAn.DB’
 * checking package dependencies ... NOTE
-Package suggested but not available for checking: 'PEcAn.DB'
+Package suggested but not available for checking: ‘PEcAn.DB’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/base/visualization/tests/Rcheck_reference.log
+++ b/base/visualization/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.visualization’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires (indirectly) orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/models/basgra/tests/Rcheck_reference.log
+++ b/models/basgra/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.BASGRA’ version ‘1.7.1’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/models/biocro/tests/Rcheck_reference.log
+++ b/models/biocro/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.BIOCRO’ version ‘1.7.2’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/models/clm45/tests/Rcheck_reference.log
+++ b/models/clm45/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.CLM45’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/models/dalec/tests/Rcheck_reference.log
+++ b/models/dalec/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.DALEC’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/models/dvmdostem/tests/Rcheck_reference.log
+++ b/models/dvmdostem/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.dvmdostem’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires (indirectly) orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/models/ed/tests/Rcheck_reference.log
+++ b/models/ed/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.ED2’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/models/fates/tests/Rcheck_reference.log
+++ b/models/fates/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.FATES’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires (indirectly) orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/models/jules/tests/Rcheck_reference.log
+++ b/models/jules/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.JULES’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires (indirectly) orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/models/linkages/tests/Rcheck_reference.log
+++ b/models/linkages/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.LINKAGES’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/models/lpjguess/tests/Rcheck_reference.log
+++ b/models/lpjguess/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.LPJGUESS’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires (indirectly) orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/models/maat/tests/Rcheck_reference.log
+++ b/models/maat/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.MAAT’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/models/maespa/tests/Rcheck_reference.log
+++ b/models/maespa/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.MAESPA’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/models/preles/tests/Rcheck_reference.log
+++ b/models/preles/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.PRELES’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/models/sibcasa/tests/Rcheck_reference.log
+++ b/models/sibcasa/tests/Rcheck_reference.log
@@ -1,11 +1,11 @@
-* using log directory ‘/tmp/Rtmpy5gmHK/PEcAn.GDAY.Rcheck’
-* using R version 3.5.2 (2018-12-20)
-* using platform: x86_64-pc-linux-gnu (64-bit)
+* using log directory ‘/private/var/folders/qr/mbw8xxpd45jdv_46b27914280000gn/T/RtmpqsmgS1/PEcAn.SIBCASA.Rcheck’
+* using R version 4.1.1 Patched (2021-09-19 r80937)
+* using platform: x86_64-apple-darwin17.0 (64-bit)
 * using session charset: UTF-8
-* using options ‘--no-tests --no-manual --as-cran’
-* checking for file ‘PEcAn.GDAY/DESCRIPTION’ ... OK
+* using options ‘--no-manual --as-cran’
+* checking for file ‘PEcAn.SIBCASA/DESCRIPTION’ ... OK
 * checking extension type ... Package
-* this is package ‘PEcAn.GDAY’ version ‘1.7.0’
+* this is package ‘PEcAn.SIBCASA’ version ‘0.0.1’
 * package encoding: UTF-8
 * checking package namespace information ... OK
 * checking package dependencies ... WARNING
@@ -17,13 +17,11 @@ Requires (indirectly) orphaned package: ‘udunits2’
 * checking for portable file names ... OK
 * checking for sufficient/correct file permissions ... OK
 * checking serialization versions ... OK
-* checking whether package ‘PEcAn.GDAY’ can be installed ... OK
+* checking whether package ‘PEcAn.SIBCASA’ can be installed ... OK
 * checking installed package size ... OK
 * checking package directory ... OK
-* checking DESCRIPTION meta-information ... NOTE
-Authors@R field gives no person with name and roles.
-Authors@R field gives no person with maintainer role, valid email
-address and non-empty name.
+* checking for future file timestamps ... OK
+* checking DESCRIPTION meta-information ... OK
 * checking top-level files ... OK
 * checking for left-over files ... OK
 * checking index information ... OK
@@ -35,45 +33,36 @@ address and non-empty name.
 * checking whether the package can be unloaded cleanly ... OK
 * checking whether the namespace can be loaded with stated dependencies ... OK
 * checking whether the namespace can be unloaded cleanly ... OK
-* checking loading without being on the library search path ... OK
-* checking dependencies in R code ... NOTE
-Package in Depends field not imported from: ‘PEcAn.utils’
-  These packages need to be imported from (in the NAMESPACE file)
-  for when this namespace is loaded but not attached.
+* checking dependencies in R code ... OK
 * checking S3 generic/method consistency ... OK
 * checking replacement functions ... OK
 * checking foreign function calls ... OK
-* checking R code for possible problems ... NOTE
-model2netcdf.GDAY: no visible global function definition for ‘read.csv’
-Undefined global functions or variables:
-  read.csv
-Consider adding
-  importFrom("utils", "read.csv")
-to your NAMESPACE file.
+* checking R code for possible problems ... OK
 * checking Rd files ... OK
 * checking Rd metadata ... OK
 * checking Rd line widths ... OK
 * checking Rd cross-references ... OK
 * checking for missing documentation entries ... OK
 * checking for code/documentation mismatches ... OK
-* checking Rd \usage sections ... WARNING
-Undocumented arguments in documentation object 'met2model.GDAY'
-  ‘...’
-
-Undocumented arguments in documentation object 'write.config.GDAY'
-  ‘trait.values’
-Documented arguments not in \usage in documentation object 'write.config.GDAY':
-  ‘trait.samples’
-
-Functions with \usage entries need to have the appropriate \alias
-entries, and all their arguments documented.
-The \usage entries must correspond to syntactically valid R code.
-See chapter ‘Writing R documentation files’ in the ‘Writing R
-Extensions’ manual.
+* checking Rd \usage sections ... OK
 * checking Rd contents ... OK
 * checking for unstated dependencies in examples ... OK
+* checking contents of ‘data’ directory ... OK
+* checking data for non-ASCII characters ... OK
+* checking LazyData ... OK
+* checking data for ASCII and uncompressed saves ... OK
 * checking examples ... NONE
 * checking for unstated dependencies in ‘tests’ ... OK
-* checking tests ... SKIPPED
+* checking tests ...
+  Running ‘testthat.R’
+ OK
+* checking for non-standard things in the check directory ... OK
+* checking for detritus in the temp directory ... OK
 * DONE
-Status: 1 WARNING, 3 NOTEs
+
+Status: 1 WARNING
+See
+  ‘/private/var/folders/qr/mbw8xxpd45jdv_46b27914280000gn/T/RtmpqsmgS1/PEcAn.SIBCASA.Rcheck/00check.log’
+for details.
+
+

--- a/models/sipnet/tests/Rcheck_reference.log
+++ b/models/sipnet/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.SIPNET’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/models/stics/tests/Rcheck_reference.log
+++ b/models/stics/tests/Rcheck_reference.log
@@ -1,15 +1,15 @@
-* using log directory ‘/tmp/RtmpiqxPPg/PEcAn.workflow.Rcheck’
-* using R version 3.5.2 (2018-12-20)
-* using platform: x86_64-pc-linux-gnu (64-bit)
+* using log directory ‘/private/var/folders/qr/mbw8xxpd45jdv_46b27914280000gn/T/RtmpZSkJmu/PEcAn.STICS.Rcheck’
+* using R version 4.1.1 Patched (2021-09-19 r80937)
+* using platform: x86_64-apple-darwin17.0 (64-bit)
 * using session charset: UTF-8
 * using options ‘--no-manual --as-cran’
-* checking for file ‘PEcAn.workflow/DESCRIPTION’ ... OK
+* checking for file ‘PEcAn.STICS/DESCRIPTION’ ... OK
 * checking extension type ... Package
-* this is package ‘PEcAn.workflow’ version ‘1.7.0’
+* this is package ‘PEcAn.STICS’ version ‘1.7.2’
 * package encoding: UTF-8
 * checking package namespace information ... OK
 * checking package dependencies ... WARNING
-Requires (indirectly) orphaned package: ‘udunits2’
+Requires orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK
@@ -17,13 +17,11 @@ Requires (indirectly) orphaned package: ‘udunits2’
 * checking for portable file names ... OK
 * checking for sufficient/correct file permissions ... OK
 * checking serialization versions ... OK
-* checking whether package ‘PEcAn.workflow’ can be installed ... OK
+* checking whether package ‘PEcAn.STICS’ can be installed ... OK
 * checking installed package size ... OK
 * checking package directory ... OK
-* checking DESCRIPTION meta-information ... NOTE
-Authors@R field gives no person with name and roles.
-Authors@R field gives no person with maintainer role, valid email
-address and non-empty name.
+* checking for future file timestamps ... OK
+* checking DESCRIPTION meta-information ... OK
 * checking top-level files ... OK
 * checking for left-over files ... OK
 * checking index information ... OK
@@ -35,19 +33,11 @@ address and non-empty name.
 * checking whether the package can be unloaded cleanly ... OK
 * checking whether the namespace can be loaded with stated dependencies ... OK
 * checking whether the namespace can be unloaded cleanly ... OK
-* checking loading without being on the library search path ... OK
 * checking dependencies in R code ... OK
 * checking S3 generic/method consistency ... OK
 * checking replacement functions ... OK
 * checking foreign function calls ... OK
-* checking R code for possible problems ... NOTE
-run.write.configs: no visible binding for global variable
-  ‘trait.samples’
-run.write.configs: no visible binding for global variable ‘sa.samples’
-run.write.configs: no visible binding for global variable
-  ‘ensemble.samples’
-Undefined global functions or variables:
-  ensemble.samples sa.samples trait.samples
+* checking R code for possible problems ... OK
 * checking Rd files ... OK
 * checking Rd metadata ... OK
 * checking Rd line widths ... OK
@@ -60,6 +50,15 @@ Undefined global functions or variables:
 * checking examples ... NONE
 * checking for unstated dependencies in ‘tests’ ... OK
 * checking tests ...
+  Running ‘testthat.R’
  OK
+* checking for non-standard things in the check directory ... OK
+* checking for detritus in the temp directory ... OK
 * DONE
-Status: 2 NOTEs
+
+Status: 1 WARNING
+See
+  ‘/private/var/folders/qr/mbw8xxpd45jdv_46b27914280000gn/T/RtmpZSkJmu/PEcAn.STICS.Rcheck/00check.log’
+for details.
+
+

--- a/models/template/tests/Rcheck_reference.log
+++ b/models/template/tests/Rcheck_reference.log
@@ -1,11 +1,11 @@
-* using log directory ‘/tmp/Rtmpy5gmHK/PEcAn.GDAY.Rcheck’
-* using R version 3.5.2 (2018-12-20)
-* using platform: x86_64-pc-linux-gnu (64-bit)
+* using log directory ‘/private/var/folders/qr/mbw8xxpd45jdv_46b27914280000gn/T/RtmpR7hui5/PEcAn.ModelName.Rcheck’
+* using R version 4.1.1 Patched (2021-09-19 r80937)
+* using platform: x86_64-apple-darwin17.0 (64-bit)
 * using session charset: UTF-8
-* using options ‘--no-tests --no-manual --as-cran’
-* checking for file ‘PEcAn.GDAY/DESCRIPTION’ ... OK
+* using options ‘--no-manual --as-cran’
+* checking for file ‘PEcAn.ModelName/DESCRIPTION’ ... OK
 * checking extension type ... Package
-* this is package ‘PEcAn.GDAY’ version ‘1.7.0’
+* this is package ‘PEcAn.ModelName’ version ‘1.7.2’
 * package encoding: UTF-8
 * checking package namespace information ... OK
 * checking package dependencies ... WARNING
@@ -17,13 +17,11 @@ Requires (indirectly) orphaned package: ‘udunits2’
 * checking for portable file names ... OK
 * checking for sufficient/correct file permissions ... OK
 * checking serialization versions ... OK
-* checking whether package ‘PEcAn.GDAY’ can be installed ... OK
+* checking whether package ‘PEcAn.ModelName’ can be installed ... OK
 * checking installed package size ... OK
 * checking package directory ... OK
-* checking DESCRIPTION meta-information ... NOTE
-Authors@R field gives no person with name and roles.
-Authors@R field gives no person with maintainer role, valid email
-address and non-empty name.
+* checking for future file timestamps ... OK
+* checking DESCRIPTION meta-information ... OK
 * checking top-level files ... OK
 * checking for left-over files ... OK
 * checking index information ... OK
@@ -35,45 +33,32 @@ address and non-empty name.
 * checking whether the package can be unloaded cleanly ... OK
 * checking whether the namespace can be loaded with stated dependencies ... OK
 * checking whether the namespace can be unloaded cleanly ... OK
-* checking loading without being on the library search path ... OK
-* checking dependencies in R code ... NOTE
-Package in Depends field not imported from: ‘PEcAn.utils’
-  These packages need to be imported from (in the NAMESPACE file)
-  for when this namespace is loaded but not attached.
+* checking dependencies in R code ... OK
 * checking S3 generic/method consistency ... OK
 * checking replacement functions ... OK
 * checking foreign function calls ... OK
-* checking R code for possible problems ... NOTE
-model2netcdf.GDAY: no visible global function definition for ‘read.csv’
-Undefined global functions or variables:
-  read.csv
-Consider adding
-  importFrom("utils", "read.csv")
-to your NAMESPACE file.
+* checking R code for possible problems ... OK
 * checking Rd files ... OK
 * checking Rd metadata ... OK
 * checking Rd line widths ... OK
 * checking Rd cross-references ... OK
 * checking for missing documentation entries ... OK
 * checking for code/documentation mismatches ... OK
-* checking Rd \usage sections ... WARNING
-Undocumented arguments in documentation object 'met2model.GDAY'
-  ‘...’
-
-Undocumented arguments in documentation object 'write.config.GDAY'
-  ‘trait.values’
-Documented arguments not in \usage in documentation object 'write.config.GDAY':
-  ‘trait.samples’
-
-Functions with \usage entries need to have the appropriate \alias
-entries, and all their arguments documented.
-The \usage entries must correspond to syntactically valid R code.
-See chapter ‘Writing R documentation files’ in the ‘Writing R
-Extensions’ manual.
+* checking Rd \usage sections ... OK
 * checking Rd contents ... OK
 * checking for unstated dependencies in examples ... OK
 * checking examples ... NONE
 * checking for unstated dependencies in ‘tests’ ... OK
-* checking tests ... SKIPPED
+* checking tests ...
+  Running ‘testthat.R’
+ OK
+* checking for non-standard things in the check directory ... OK
+* checking for detritus in the temp directory ... OK
 * DONE
-Status: 1 WARNING, 3 NOTEs
+
+Status: 1 WARNING
+See
+  ‘/private/var/folders/qr/mbw8xxpd45jdv_46b27914280000gn/T/RtmpR7hui5/PEcAn.ModelName.Rcheck/00check.log’
+for details.
+
+

--- a/modules/assim.batch/tests/Rcheck_reference.log
+++ b/modules/assim.batch/tests/Rcheck_reference.log
@@ -8,6 +8,13 @@
 * this is package ‘PEcAn.assim.batch’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
+* checking package dependencies ... WARNING
+Requires orphaned package: ‘udunits2’
+
+Imports includes 28 non-default packages.
+Importing from so many packages makes the package vulnerable to any of
+them becoming unavailable.  Move as many as possible to Suggests and
+use conditionally.
 * checking package dependencies ... NOTE
 Imports includes 28 non-default packages.
 Importing from so many packages makes the package vulnerable to any of

--- a/modules/assim.sequential/tests/Rcheck_reference.log
+++ b/modules/assim.sequential/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.assim.sequential’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires (indirectly) orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/modules/benchmark/tests/Rcheck_reference.log
+++ b/modules/benchmark/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.benchmark’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/modules/data.atmosphere/tests/Rcheck_reference.log
+++ b/modules/data.atmosphere/tests/Rcheck_reference.log
@@ -8,6 +8,13 @@
 * this is package ‘PEcAn.data.atmosphere’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
+* checking package dependencies ... WARNING
+Requires orphaned package: ‘udunits2’
+
+Imports includes 37 non-default packages.
+Importing from so many packages makes the package vulnerable to any of
+them becoming unavailable.  Move as many as possible to Suggests and
+use conditionally.
 * checking package dependencies ... NOTE
 Imports includes 37 non-default packages.
 Importing from so many packages makes the package vulnerable to any of

--- a/modules/data.hydrology/tests/Rcheck_reference.log
+++ b/modules/data.hydrology/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.data.hydrology’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires (indirectly) orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/modules/data.land/tests/Rcheck_reference.log
+++ b/modules/data.land/tests/Rcheck_reference.log
@@ -8,6 +8,13 @@
 * this is package ‘PEcAn.data.land’ version ‘1.7.1’
 * package encoding: UTF-8
 * checking package namespace information ... OK
+* checking package dependencies ... WARNING
+Requires orphaned package: ‘udunits2’
+
+Imports includes 31 non-default packages.
+Importing from so many packages makes the package vulnerable to any of
+them becoming unavailable.  Move as many as possible to Suggests and
+use conditionally.
 * checking package dependencies ... NOTE
 Imports includes 31 non-default packages.
 Importing from so many packages makes the package vulnerable to any of

--- a/modules/data.remote/tests/Rcheck_reference.log
+++ b/modules/data.remote/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.data.remote’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires (indirectly) orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/modules/meta.analysis/tests/Rcheck_reference.log
+++ b/modules/meta.analysis/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.MA’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires (indirectly) orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/modules/priors/tests/Rcheck_reference.log
+++ b/modules/priors/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.priors’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires (indirectly) orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/modules/rtm/tests/Rcheck_reference.log
+++ b/modules/rtm/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAnRTM’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires (indirectly) orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK

--- a/modules/uncertainty/tests/Rcheck_reference.log
+++ b/modules/uncertainty/tests/Rcheck_reference.log
@@ -8,7 +8,8 @@
 * this is package ‘PEcAn.uncertainty’ version ‘1.7.0’
 * package encoding: UTF-8
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... WARNING
+Requires orphaned package: ‘udunits2’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK


### PR DESCRIPTION
* {udunits} is orphaned but we hope it will be back soon -- ignore the warning for now
* This included re-adding `Rcheck_reference.log` to three packages we previously had down to zero ignored messages (stics, sibcasa, template) 😿 
* needed to allow for backticks in a dplyr error message when testing symmetric_setdiff


<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of .zenodo.json
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
