### PR TITLE
Update README: Fixed link to API docs in swagger

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -2,7 +2,7 @@
 
 This folder contains the code & tests for PEcAn's RESTful API server. The API allows users to remotely interact with the PEcAn servers and leverage the functionalities provided by the PEcAn Project. It has been designed to follow common RESTful API conventions. Most operations are performed using the HTTP methods: `GET` (retrieve) & `POST` (create).
 
-#### For the most up-to-date documentation, you can visit the [PEcAn API Documentation](http://pecan-dev.ncsa.illinois.edu/swagger/).
+#### For the most up-to-date documentation, you can visit the [PEcAn API Documentation](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/PecanProject/pecan/develop/apps/api/pecanapi-spec.yml).
 
 ## Starting the PEcAn server:
 


### PR DESCRIPTION
## Description
Updated a not working link in the README.md for the API docs.

## Motivation and Context
Previous link doesn't work, this one does.

## Review Time Estimate
- [X] When possible

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of .zenodo.json
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.