### PR TITLE
remove dependency on  binaryLogic (+ add NEWS)

### DIFF
--- a/docker/depends/pecan.depends.R
+++ b/docker/depends/pecan.depends.R
@@ -24,7 +24,6 @@ wanted <- c(
 'abind',
 'amerifluxr',
 'BayesianTools',
-'binaryLogic',
 'BioCro',
 'bit64',
 'BrownDog',

--- a/modules/data.remote/DESCRIPTION
+++ b/modules/data.remote/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PEcAn.data.remote
 Type: Package
 Title: PEcAn functions used for extracting remote sensing data
-Version: 1.7.2
+Version: 1.7.2.9000
 Date: 2021-10-04
 Authors@R: c(person("Mike", "Dietze", role = c("aut"),
                      email = "dietze@bu.edu"),
@@ -27,7 +27,6 @@ Imports:
     PEcAn.logger,
     PEcAn.remote,
     stringr (>= 1.1.0),
-    binaryLogic,
     doParallel,
     parallel,
     foreach

--- a/modules/data.remote/NEWS.md
+++ b/modules/data.remote/NEWS.md
@@ -1,0 +1,10 @@
+# PEcAn.data.remote 1.7.2.9000
+
+## Internal changes
+
+* `call_MODIS` now checks QC flags using base R functions, and therefore no longer depends on the `binaryLogic` package.
+
+# PEcAn.data.remote 1.7.1
+
+* All changes in 1.7.1 and earlier were recorded in a single file for all of the PEcAn packages; please see 
+https://github.com/PecanProject/pecan/blob/v1.7.1/CHANGELOG.md for details.

--- a/modules/data.remote/R/call_MODIS.R
+++ b/modules/data.remote/R/call_MODIS.R
@@ -217,31 +217,36 @@ call_MODIS <- function(var, product,
     if (run_parallel) 
     {
       qc <- foreach::foreach(i=seq_along(site_info$site_id), .combine = rbind) %dopar% 
-        MODISTools::mt_subset(lat = site_coords$lat[i],lon = site_coords$lon[i],
+        MODISTools::mt_subset(lat = site_coords$lat[i],
+                              lon = site_coords$lon[i],
                               product = product,
                               band = qc_band,
                               start = dates[1],
                               end = dates[length(dates)],
                               km_ab = size, km_lr = size,
                               progress = progress)
-      } else {
-        qc <- MODISTools::mt_subset(lat = site_coords$lat[i],lon = site_coords$lon[i],
-                                    product = product,
-                                    band = qc_band,
-                                    start = dates[1],
-                                    end = dates[length(dates)],
-                                    km_ab = size, km_lr = size,
-                                    progress = progress)
-        
-      }
-    
+    } else {
+      qc <- MODISTools::mt_subset(lat = site_coords$lat[i],
+                                  lon = site_coords$lon[i],
+                                  product = product,
+                                  band = qc_band,
+                                  start = dates[1],
+                                  end = dates[length(dates)],
+                                  km_ab = size, km_lr = size,
+                                  progress = progress)
+
+    }
+
     output$qc <- as.character(qc$value)
     
     #convert QC values and keep only okay values
     for (i in seq_len(nrow(output)))
     {
-      convert <- paste(binaryLogic::as.binary(as.integer(output$qc[i]), n = 8), collapse = "")
-      output$qc[i] <- substr(convert, nchar(convert) - 2, nchar(convert))
+      # QC flags are stored as an 8-bit mask
+      # we only care about the 3 least-significant bits
+      qc_flags <- intToBits(as.integer(output$qc[i])) # NB big-endian (ones place first)
+      qc_flags <- as.integer(rev(head(qc_flags, 3))) # now ones place last
+      output$qc[i] <- paste(qc_flags, collapse = "")
     }
     good <- which(output$qc %in% c("000", "001"))
     if (length(good) > 0)

--- a/modules/data.remote/R/call_MODIS.R
+++ b/modules/data.remote/R/call_MODIS.R
@@ -245,7 +245,7 @@ call_MODIS <- function(var, product,
       # QC flags are stored as an 8-bit mask
       # we only care about the 3 least-significant bits
       qc_flags <- intToBits(as.integer(output$qc[i])) # NB big-endian (ones place first)
-      qc_flags <- as.integer(rev(head(qc_flags, 3))) # now ones place last
+      qc_flags <- as.integer(rev(utils::head(qc_flags, 3))) # now ones place last
       output$qc[i] <- paste(qc_flags, collapse = "")
     }
     good <- which(output$qc %in% c("000", "001"))


### PR DESCRIPTION
## Motivation

The `binaryLogic` package has been removed from CRAN and appears abandoned on GitHub, so depending on it seems risky. Fortunately we were only using it for one call inside `PEcAn.data.remote::call_MODIS` and that call was relatively easy to replace with base functions.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of .zenodo.json
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
