### PR TITLE
add cmake to depends image

### DIFF
--- a/docker/depends/Dockerfile
+++ b/docker/depends/Dockerfile
@@ -21,6 +21,7 @@ RUN if [ "$(lsb_release -s -c)" = "stretch" ]; then \
 # ----------------------------------------------------------------------
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
+       cmake \
        curl \
        jags \
        time \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Needed when installing `nloptr` from source, as happens on the Rdevel image. The images for other R versions install binary packages from Rstudio Package Manager and therefore don't strictly need this, but I vote we install cmake everywhere rather than fuss around installing different apt packages on different tags.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of .zenodo.json
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
