### PR TITLE
avoid string->factor when running `confirm_deps` in R < 4.0

### DIFF
--- a/scripts/confirm_deps.R
+++ b/scripts/confirm_deps.R
@@ -48,7 +48,7 @@ confirm_deps <- function(pkg,
   deps <- desc::desc_get_deps(pkg)
   deps <- deps[deps$type %in% dependencies, ]
 
-  pkgs <- as.data.frame(installed.packages())[, c("Package", "Version")]
+  pkgs <- as.data.frame(installed.packages(), stringsAsFactors = FALSE)[, c("Package", "Version")]
   colnames(pkgs) <- c("package", "installed_version")
   colnames(deps)[colnames(deps) == "version"] <- "needed_version"
   deps <- merge(deps, pkgs, all.x = TRUE)


### PR DESCRIPTION
Makes `scripts/confirm.deps.R` work as expected with R 3.6.3. 

Note that R 4.0 is the oldest version we still include in the PEcAn CI tests, so it is *very likely* that we have other components that no longer support R 3.6 -- I only fixed this one because it was simpler than adding an interpretable error message.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
