### PR TITLE
would mount pecan folder in wrong user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ We are slowly change the license from NCSA opensource to BSD-3 to help with publ
 - Fix broken build caused by BioCro updates #2925
 - rstudio was not working behind traefik.
 - plots now work in docker containers
+- when specifying diferent rstudio user, dev setup would mount pecan folder in wrong path.
 
 ### Changed
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,8 +22,14 @@ services:
   rstudio:
     volumes:
       - 'pecan_home:/pecan/'
-      - 'pecan_home:/home/carya/pecan/'
+      - 'pecan_home:/home/${PECAN_RSTUDIO_USER:-carya}/pecan/'
       - 'pecan_lib:/usr/local/lib/R/site-library/'
+    # add route to api for help when debugging plumber application. Same can
+    # be used for other apps.
+    #labels:
+    #  - "traefik.http.routers.rstudio-api.rule=Host(`api.pecan.localhost`)"
+    #  - "traefik.http.routers.rstudio-api.service=rstudio-api"
+    #  - "traefik.http.services.rstudio-api.loadbalancer.server.port=8000"
 
   # use following as template for other models
   # this can be used if you are changng the code for a model in PEcAN


### PR DESCRIPTION
would always mount pecan folder in /home/carya/pecan, no matter what PECAN_RSTUDIO_USER was set to.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
