### PR TITLE
do not count "R" as a package that needs installing. Fixes #2993

### DIFF
--- a/scripts/generate_dependencies.R
+++ b/scripts/generate_dependencies.R
@@ -46,6 +46,8 @@ d <- purrr::walk(
     # load DESCRIPTION file
     d <- desc::desc(file = x)
     deps <- d$get_deps()[["package"]]
+    # ignore R version requirements (e.g. "Depends: R (>= 3.2.0)")
+    deps <- deps[deps != "R"]
 
     # PEcAn dependencies
     y <- deps[grepl("^PEcAn.", deps)]


### PR DESCRIPTION
Updates `generate_dependencies.R` to avoid adding a(nonexistant) "R" package to the list of needed packages when a package contains an R version support declaration of the form "Depends: R (>= x.y)"