### PR TITLE
remove leftover link to udunits2 package

### DIFF
--- a/base/utils/R/datasets.R
+++ b/base/utils/R/datasets.R
@@ -4,7 +4,7 @@
 #' A lookup table giving standard names, units and descriptions for variables in PEcAn input/output files.
 #' Originally based on the \href{https://nacp.ornl.gov/MsTMIP_variables.shtml}{MsTMIP} standards,
 #' with additions to accomodate a wider range of model inputs and outputs.
-#' The standard_vars table replaces both \code{mstmip_vars} and \code{mstmip_local},
+#' The standard_vars table replaces both `mstmip_vars` and `mstmip_local`,
 #' both of which are now deprecated.
 #'
 #' @name standard_vars
@@ -15,7 +15,7 @@
 #'  \item{Variable.Name}{Short name suitable for programming with}
 #'  \item{standard_name}{Name used in the NetCDF \href{http://cfconventions.org/standard-names.html}{CF metadata conventions} }
 #'  \item{Units}{Standard units for this variable. Do not call variables by these names if they are in different units.
-#'    See \code{\link[udunits2]{ud.convert}} for conversions to and from non-standard units}
+#'    See `ud_convert` for conversions to and from non-standard units}
 #'  \item{Long.Name}{Human-readable variable name, suitable for e.g. axis labels}
 #'  \item{Category}{What kind of variable is it? (Carbon pool, N flux, dimension, input driver, etc)}
 #'  \item{var_type}{Storage type (character, integer, etc)}

--- a/base/utils/man/standard_vars.Rd
+++ b/base/utils/man/standard_vars.Rd
@@ -10,7 +10,7 @@ data frame, all columns character
 \item{Variable.Name}{Short name suitable for programming with}
 \item{standard_name}{Name used in the NetCDF \href{http://cfconventions.org/standard-names.html}{CF metadata conventions} }
 \item{Units}{Standard units for this variable. Do not call variables by these names if they are in different units.
-See \code{\link[udunits2]{ud.convert}} for conversions to and from non-standard units}
+See \code{ud_convert} for conversions to and from non-standard units}
 \item{Long.Name}{Human-readable variable name, suitable for e.g. axis labels}
 \item{Category}{What kind of variable is it? (Carbon pool, N flux, dimension, input driver, etc)}
 \item{var_type}{Storage type (character, integer, etc)}


### PR DESCRIPTION
R checks for utils now complain if run on a system that doesn't have `udunits2` installed. Fixed by rewording to point to new wrapper instead.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
