### PR TITLE
Remove orphaned and troublesome query and logger message from ensemble.R

### DIFF
--- a/modules/uncertainty/R/ensemble.R
+++ b/modules/uncertainty/R/ensemble.R
@@ -303,22 +303,6 @@ write.ensemble.configs <- function(defaults, ensemble.samples, settings, model,
         if (is.null(samples[[r_tag]]) & r_tag!="parameters") samples[[r_tag]]$samples <<- rep(settings$run$inputs[[tolower(r_tag)]]$path[1], settings$ensemble$size)
       })
     
-
-    # Let's find the PFT based on site location, if it was found I will subset the ensemble.samples otherwise we're not affecting anything    
-    if(!is.null(con)){
-      Pft_Site_df <- dplyr::tbl(con, "sites_cultivars")%>%
-        dplyr::filter(.data$site_id == !!settings$run$site$id) %>%
-        dplyr::inner_join(dplyr::tbl(con, "cultivars_pfts"), by = "cultivar_id") %>%
-        dplyr::inner_join(dplyr::tbl(con, "pfts"), by = c("pft_id" = "id")) %>%
-        dplyr::collect() 
-      
-      site_pfts_names <- Pft_Site_df$name %>% unlist() %>% as.character()
-      
-      PEcAn.logger::logger.info(paste("The most suitable pfts for your site are the followings:",site_pfts_names))
-      #-- if there is enough info to connect the site to pft
-      #if ( nrow(Pft_Site_df) > 0 & all(site_pfts_names %in% names(ensemble.samples)) ) ensemble.samples <- ensemble.samples [Pft_Site$name %>% unlist() %>% as.character()]
-    }
-
     # Reading the site.pft specific tags from xml
     site.pfts.vec <- settings$run$site$site.pft %>% unlist %>% as.character
     


### PR DESCRIPTION
Removing code implemented in PR https://github.com/PecanProject/pecan/pull/2126. The queried the DB and used the information to return some information. 

It was implemented as a quick workaround for a specific project to link pfts with specific sites. But at this point it has no effect other than to send a message via logger, or create an error if nothing is returned (perhaps because R has changed how it handles missing data). In [todays meeting](https://docs.google.com/document/d/1DUQyKEwGYTumr6ttFJA8vcwZXqgUTTxn4rjeVdomQtU/edit#bookmark=id.ucevo0tnkm6b) we decided to remove the code and punt the implementation of pft-site relationships to the next time it is needed 