### PR TITLE
removed udunits2::ud.is.parseable usages from PEcAn

### DIFF
--- a/base/db/R/insert.format.vars.R
+++ b/base/db/R/insert.format.vars.R
@@ -126,8 +126,7 @@ insert.format.vars <- function(con, format_name, mimetype_id, notes = NULL, head
       u1 <- formats_variables[1,"unit"]
       u2 <- dplyr::tbl(con, "variables") %>% dplyr::select(.data$id, units) %>% dplyr::filter(.data$id %in% !!formats_variables[[1, "variable_id"]]) %>% dplyr::pull(.data$units)
 
-      u1_recognized <- tryCatch(units::as_units(u1), error = function(e) FALSE)
-      if(!u1_recognized){
+      if(!PEcAn.utils::unit_is_parseable(u1)){
         PEcAn.logger::logger.error(
           "Units '", u1,  "' not parseable.",
           "Please provide a unit that is parseable by the udunits library."

--- a/modules/data.atmosphere/R/met2CF.csv.R
+++ b/modules/data.atmosphere/R/met2CF.csv.R
@@ -656,7 +656,7 @@ met.conv <- function(x, orig, bety, CF) {
   if (nchar(orig) == 0) {
     orig <- bety  ## if units not provided, default is that they were the same units as bety
   }
-  if (units::install_unit(orig)) {
+  if (PEcAn.utils::unit_is_parseable(orig)) {
     if (units::ud_are_convertible(orig, bety)) {
       return(PEcAn.utils::ud_convert(PEcAn.utils::ud_convert(x, orig, bety), bety, CF))
     } else {


### PR DESCRIPTION
Replacing udunits2::ud.is.parseable with PEcAn.utils::unit_is_parseable