### PR TITLE
assume nothing about characters after "PEcAn" in package name

### DIFF
--- a/scripts/generate_dependencies.R
+++ b/scripts/generate_dependencies.R
@@ -50,14 +50,14 @@ d <- purrr::walk(
     deps <- deps[deps != "R"]
 
     # PEcAn dependencies
-    y <- deps[grepl("^PEcAn.", deps)]
+    y <- deps[grepl("^PEcAn", deps)]
     p <- d$get_field("Package")
     pecan[[p]] <<- f
     depends[[f]] <<- y
 
     # Dockerfile dependencies
     z <- y["package"]
-    z <- deps[!grepl("^PEcAn.", deps)]
+    z <- deps[!grepl("^PEcAn", deps)]
     docker <<- unique(c(docker, z))
 
     # Dockerfile remote dependencies


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description

Updates the matching rule for treating a dependency as a PEcAn package, from "starts with `PEcAn` followed by at least one other character" to simply "starts with `PEcAn`"

## Motivation and Context

`generate_dependencies.R` identifies dependencies between PEcAn packages by parsing DESCRIPTION files and looking for dependencies matching `"^PEcAn."`. The dot is treated as a wildcard, so this works as intended, but is confusing to read since it will be matching a literal dot in most but not all packages. Removing the dot makes it clearer that we don't care that characters come after the prefix.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
