### PR TITLE
find fqdn across platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ convert data for a single PFT fixed (#1329, #2974, #2981)
 - Added an updated ED2IN template file, `models/ed/inst/ED2IN.r2.2.0.github`, to reflect new variables in the development version of ED2
 - `PEcAn.data.land::gSSURGO.Query` has been updated to work again after changes to the gSSURGO API.
 - `PEcAn.settings::read.settings()` now prints a warning when falling back on default `"pecan.xml"` if the named `inputfile` doesn't exist.
+- fqdn() can access hostname on Windows (#3044 fixed by #3058)
 
 ### Changed
 

--- a/base/remote/R/fqdn.R
+++ b/base/remote/R/fqdn.R
@@ -19,5 +19,10 @@
 ##' @examples
 ##' fqdn()
 fqdn <- function() {
-  as.character(Sys.info()["nodename"])
+  if (Sys.getenv("FQDN") == "") {
+    fqdn <- as.character(Sys.info()["nodename"])
+  } else {
+    fqdn <- Sys.getenv("FQDN")
+  }
+  return(fqdn)
 } # fqdn

--- a/base/remote/R/fqdn.R
+++ b/base/remote/R/fqdn.R
@@ -19,12 +19,5 @@
 ##' @examples
 ##' fqdn()
 fqdn <- function() {
-  fqdn <- Sys.getenv("FQDN")
-  if (fqdn == "") {
-    fqdn <- system2("hostname", "-f", stdout = TRUE)
-  } 
-  if (fqdn == "") {
-    fqdn <- as.character(Sys.info()["nodename"])
-  }
-  return(fqdn)
+  as.character(Sys.info()["nodename"])
 } # fqdn

--- a/base/remote/R/fqdn.R
+++ b/base/remote/R/fqdn.R
@@ -19,9 +19,12 @@
 ##' @examples
 ##' fqdn()
 fqdn <- function() {
-  if (Sys.getenv("FQDN") != "") {
-    Sys.getenv("FQDN")
-  } else {
-    system2("hostname", "-f", stdout = TRUE)
+  fqdn <- Sys.getenv("FQDN")
+  if (fqdn == "") {
+    fqdn <- system2("hostname", "-f", stdout = TRUE)
+  } 
+  if (fqdn == "") {
+    fqdn <- as.character(Sys.info()["nodename"])
   }
+  return(fqdn)
 } # fqdn


### PR DESCRIPTION
## Description

Add `as.character(Sys.info()["nodename"])`  if no env variable FQDN and `hostname -f`  return empty strings.

## Motivation and Context

hostname doesn't work on Windows. Fixes #3044

**Perhaps a simpler option** 

replace function with `fqdn <- function() as.character(Sys.info()["nodename"])`

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] My name is in the list of CITATION.cff
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
