### PR TITLE
Allow `model2netcdf.ED2()` to process partial output from failed runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ see if you need to change any of these:
 - Initial LDNDC model coupling
 - `PEcAn.settings::read.settings()` now strips comments so HTML style comments (e.g. `<!-- a comment -->`) are now allowed in pecan.xml files
 - `PEcAn.logger::setLevel()` now invisibly returns the previously set logger level
+- Added optional `process_partial` argument to `model2netcdf.ED2()` to allow it to process existing output from failed runs.
 
 We are slowly change the license from NCSA opensource to BSD-3 to help with publishing PEcAn to CRAN.
 

--- a/models/ed/DESCRIPTION
+++ b/models/ed/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PEcAn.ED2
 Type: Package
 Title: PEcAn Package for Integration of ED2 Model
-Version: 1.7.2
+Version: 1.7.2.9000
 Date: 2021-10-04
 Authors@R: c(person("Mike", "Dietze", role = c("aut", "cre"),
                      email = "dietze@bu.edu"),
@@ -66,4 +66,3 @@ Encoding: UTF-8
 RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 Config/testthat/edition: 2
-

--- a/models/ed/NEWS.md
+++ b/models/ed/NEWS.md
@@ -1,0 +1,7 @@
+# PEcAn.ED2 (development version)
+
+* Added optional `process_partial` argument to `model2netcdf.ED2()` to allow it to process existing output from failed runs.
+
+# PEcAn.ED2 1.7.2
+
+* Added a `NEWS.md` file to track changes to the package. Prior to this point, PEcAn.ED2 development was tracked in the main PEcAn NEWS file.

--- a/models/ed/R/model2netcdf.ED2.R
+++ b/models/ed/R/model2netcdf.ED2.R
@@ -20,6 +20,9 @@
 ##' @param end_date End time of the simulation
 ##' @param pfts a named vector of PFT numbers where the names are PFT names
 ##' @param settings pecan settings object
+##' @param process_partial should failed runs be processed? Defaults to `FALSE`.
+##'   `TRUE` will generate .nc files for runs that have generated some, but not
+##'   all, of the expected outputs
 ##'
 ##' @details if \code{settings} is provided, then values for missing arguments
 ##'   `sitelat`, `sitelon`, `start_date`, `end_date`, and `pfts` will be taken
@@ -37,7 +40,8 @@ model2netcdf.ED2 <- function(outdir,
                              start_date,
                              end_date,
                              pfts,
-                             settings = NULL) {
+                             settings = NULL,
+                             process_partial = FALSE) {
   if(!is.null(settings)) {
     if(!inherits(settings, "Settings")) {
       PEcAn.logger::logger.error("`settings` should be a PEcAn 'Settings' object")
@@ -94,24 +98,26 @@ model2netcdf.ED2 <- function(outdir,
   # for now I'm going with this, do failed runs also provide information
   # on parameters? 
   year_check <- unique(unlist(ylist))
-  if (max(year_check) < end_year) {
-    PEcAn.logger::logger.warn("Run failed with some outputs.")
+  if (max(year_check) < end_year) { #if run failed early
+    PEcAn.logger::logger.warn("Run ended earlier than expected.  Check logfile.txt")
+    
+    #figure out if this is an ensemble
     run_id <- basename(outdir)
     workflow_dir <- dirname(dirname(outdir))
     rundir <- file.path(workflow_dir, "run", run_id) 
     readme <- file.path(rundir, "README.txt")
     runtype <- readLines(readme, n = 1)
-    if (grepl("ensemble", runtype)) {
+    is_ensemble <- grepl("ensemble", runtype)
+    if (is_ensemble & !process_partial) {
       PEcAn.logger::logger.info("This is an ensemble run. ",
                                 "Not processing anything.")
       return(NULL)
-      } else {
-        PEcAn.logger::logger.info("This is not an ensemble run. ",
-                                  "Processing existing outputs.")
-        end_year <- max(year_check)
-      }
+    } else {
+      PEcAn.logger::logger.info("Processing existing outputs.")
+      end_year <- max(year_check)
     }
-
+  }
+  
   # ----- start loop over years
   for (y in start_year:end_year) {
 

--- a/models/ed/R/model2netcdf.ED2.R
+++ b/models/ed/R/model2netcdf.ED2.R
@@ -1516,7 +1516,7 @@ read_S_files <- function(sfile, outdir, pfts, pecan_names = NULL, settings = NUL
 extract_pfts <- function(pfts) {
   
   get_pft_num <- function(x) {
-    pftmapping <- pftmapping #get rid of no visible binding warning
+    pftmapping <- PEcAn.ED2::pftmapping
     pft_number <- x[["ed2_pft_number"]]
     pft_name <- x[["name"]]
     if(!is.null(pft_number)) {

--- a/models/ed/R/veg2model.ED2.R
+++ b/models/ed/R/veg2model.ED2.R
@@ -150,7 +150,7 @@ veg2model.ED2 <- function(outfolder, veg_info, start_date, new_site, source, ens
   
   
   # Convert PFT names to ED2 Numbers
-  data(pftmapping, package = "PEcAn.ED2")
+  pftmapping <- PEcAn.ED2::pftmapping
   css$pft.number <- NA
   for (p in seq_along(css$pft)) {
     css$pft.number[p] <- pftmapping$ED[pftmapping$PEcAn == as.character(css$pft[p])]

--- a/models/ed/R/write.configs.ed.R
+++ b/models/ed/R/write.configs.ed.R
@@ -458,7 +458,7 @@ write.config.xml.ED2 <- function(settings, trait.values, defaults = settings$con
   }
 
   edtraits <- names(edhistory)
-  data(pftmapping, package = 'PEcAn.ED2', envir = environment())
+  pftmapping <- PEcAn.ED2::pftmapping
   
   ## Get ED2 specific model settings and put into output config xml file
   xml <- PEcAn.settings::listToXml(settings$model$config.header, "config")

--- a/models/ed/man/model2netcdf.ED2.Rd
+++ b/models/ed/man/model2netcdf.ED2.Rd
@@ -11,7 +11,8 @@ model2netcdf.ED2(
   start_date,
   end_date,
   pfts,
-  settings = NULL
+  settings = NULL,
+  process_partial = FALSE
 )
 }
 \arguments{
@@ -28,6 +29,10 @@ model2netcdf.ED2(
 \item{pfts}{a named vector of PFT numbers where the names are PFT names}
 
 \item{settings}{pecan settings object}
+
+\item{process_partial}{should failed runs be processed? Defaults to \code{FALSE}.
+\code{TRUE} will generate .nc files for runs that have generated some, but not
+all, of the expected outputs}
 }
 \description{
 Modified from code to convert ED2's HDF5 output into the NACP

--- a/modules/data.atmosphere/man/cos_solar_zenith_angle.Rd
+++ b/modules/data.atmosphere/man/cos_solar_zenith_angle.Rd
@@ -21,7 +21,7 @@ cos_solar_zenith_angle(doy, lat, lon, dt, hr)
 `numeric(1)` of cosine of solar zenith angle
 }
 \description{
-For explanations of formulae, see http://www.itacanet.org/the-sun-as-a-source-of-energy/part-3-calculating-solar-angles/
+For explanations of formulae, see https://web.archive.org/web/20180307133425/http://www.itacanet.org/the-sun-as-a-source-of-energy/part-3-calculating-solar-angles/
 }
 \author{
 Alexey Shiklomanov


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Adds an argument `process_partial` (default FALSE) to `model2netcdf.ED2()` that allows it to work even on partial runs that have been interrupted and not produced as many .h5 files as expected based on the dates in settings.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Although ensembles of different lengths might screw up downstream analysis, sometimes you want to extract data from failed runs to inspect it.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] My name is in the list of CITATION.cff
- [x] I have updated the CHANGELOG.md.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
