### PR TITLE
Bump testthat and vdiffr versions

### DIFF
--- a/base/qaqc/DESCRIPTION
+++ b/base/qaqc/DESCRIPTION
@@ -34,8 +34,8 @@ X-Comment-Remotes:
     When building on a system that finds these versions on CRAN,
     OK to remove these Remotes lines and this comment.
 Remotes:
-    github::r-lib/testthat@v3.0.4,
-    github::r-lib/vdiffr@v1.0.2
+    github::r-lib/testthat@v3.1.6,
+    github::r-lib/vdiffr@v1.0.4
 License: BSD_3_clause + file LICENSE
 Copyright: Authors
 LazyLoad: yes

--- a/docker/depends/pecan.depends.R
+++ b/docker/depends/pecan.depends.R
@@ -13,8 +13,8 @@ remotes::install_github(c(
 'chuhousen/amerifluxr',
 'ebimodeling/biocro@0.951',
 'MikkoPeltoniemi/Rpreles',
-'r-lib/testthat@v3.0.4',
-'r-lib/vdiffr@v1.0.2',
+'r-lib/testthat@v3.1.6',
+'r-lib/vdiffr@v1.0.4',
 'ropensci/geonames',
 'ropensci/nneo'
 ), lib = rlib)


### PR DESCRIPTION
Background: We install pinned versions of `testthat` and `vdiffr` from GitHub rather than CRAN, because on our R 4.0 images, "CRAN" is an RSPM snapshot from 2020 and contains testthat 3.0.2 (we need at least 3.0.4 for vdiffr support).

Problem: Our weekly tests on R-devel are [failing](https://github.com/PecanProject/pecan/actions/runs/4040621324/jobs/6946430240) because of some incompatibility between testthat 3.0.4 and devtools 2.4.5.

Solution: Bump the pinned version of testthat to 3.1.6, the current latest CRAN release. 

