### PR TITLE
install rmarkdown from github

### DIFF
--- a/base/db/DESCRIPTION
+++ b/base/db/DESCRIPTION
@@ -70,9 +70,17 @@ Suggests:
     RPostgres,
     RSQLite,
     rcrossref,
-    rmarkdown,
+    rmarkdown (>= 2.19),
     testthat (>= 2.0.0),
     tidyverse
+X-Comment-Remotes:
+    Installing markdown from GitHub because as of 2023-02-05, this is the
+    easiest way to get version >= 2.19 onto Docker images that use older
+    Rstudio Package Manager snapshots.
+    When building on a system that finds a new enough version on CRAN,
+    OK to remove the Remotes line and this comment.
+Remotes:
+    github::rstudio/rmarkdown@v2.20
 License: BSD_3_clause + file LICENSE
 VignetteBuilder: knitr
 Copyright: Authors

--- a/docker/depends/pecan.depends.R
+++ b/docker/depends/pecan.depends.R
@@ -16,7 +16,8 @@ remotes::install_github(c(
 'r-lib/testthat@v3.1.6',
 'r-lib/vdiffr@v1.0.4',
 'ropensci/geonames',
-'ropensci/nneo'
+'ropensci/nneo',
+'rstudio/rmarkdown@v2.20'
 ), lib = rlib)
 
 # install all packages (depends, imports, suggests)


### PR DESCRIPTION
Version bump is needed to avoid "xfun::isFALSE is deprecated" warnings; installing from Github is just the easiest way to bump it on Docker images that use fixed-date RSPM snapsnots as their CRAN.

Note also that this only specifies the rmarkdown version for PEcAn.DB (where the `xfun::isFALSE` warnings were appearing during vignette build), but it has the effect of bumping the rmarkdown version for all PEcAn packages that use it.

(I'm not sure I like this pattern as a long-term solution, but at the moment it feels like the cleanest balance of keeping most dependency versions stable while incrementing the ones we need to.)

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
