### PR TITLE
Update get.analysis.filenames.r

### DIFF
--- a/modules/uncertainty/R/get.analysis.filenames.r
+++ b/modules/uncertainty/R/get.analysis.filenames.r
@@ -111,7 +111,7 @@ sensitivity.filename <- function(settings,
                     " among ", sapply(settings$pfts, function(x) x$name), " USING")
         ind <- ind[1]
       }
-      if (is.null(settings$pfts[[ind]]$outdir) | is.na(settings$pfts[[ind]]$outdir)) {
+      if (is.null(settings$pfts[[ind]]$outdir) || is.na(settings$pfts[[ind]]$outdir)) {
         ## no outdir
         settings$pfts[[ind]]$outdir <- file.path(settings$outdir, "pfts", pft)
       }


### PR DESCRIPTION
Discovered today that in some contexts this will throw an error because if outdir is NULL then is.na returns numeric(0) not FALSE.