### PR TITLE
Added condition for link response in `download.Fluxnet2015`

### DIFF
--- a/modules/data.atmosphere/R/download.Fluxnet2015.R
+++ b/modules/data.atmosphere/R/download.Fluxnet2015.R
@@ -36,7 +36,10 @@ download.Fluxnet2015 <- function(sitename, outfolder, start_date, end_date,
   result <- httr::POST(url, body = json_query, encode = "json", httr::add_headers(`Content-Type` = "application/json"))
   link <- httr::content(result)
   ftplink <- NULL
-  if (length(link$dataURLsList) > 0) {
+
+  if(is.null(link) || is.atomic(link)) {
+    PEcAn.logger::logger.severe("Could not get information about", site, ".", "Is this an Fluxnet2015 site?")
+  } else if (length(link$dataURLsList) > 0) {
     ftplink <- link$dataURLsList[[1]]$URL
   }
   


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
This adds an additional condition when checking for `dataURLsList` in `link` object. 
Made this improvement as it does not check conditions when the `link` is `NULL` or when the return value is `atomic`.

Work done : 
I ran the API code separately and ended up in the result as below in the `link` variable :

      [1] "This endpoint is no longer available. Please contact ameriflux-support@lbl.gov for assistance."

which is `atomic` and thus the condition seemed necessary.

`sitename` set to : `Niwot Ridge Forest/LTER NWT1`

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [X] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
