### PR TITLE
Bugfix for `model2netcdf.ED2()`—missing PFTs cause incorrect dimensions

### DIFF
--- a/models/ed/NEWS.md
+++ b/models/ed/NEWS.md
@@ -9,6 +9,7 @@
 * Fixed a bug in `read_E_files()` affecting `model2netcdf.ED2()` that resulted in incorrect calculations (#3126)
 * DDBH (change in DBH over time) is no longer extracted and summarized from monthly -E- files by `model2netcdf.ED2()`.  We are not sure it makes sense to summarize this variable across cohorts of different sizes.
 * The `yr` and `yfiles` arguments of `read_E_files()` are no longer used and the simulation date is extracted from the names of the .h5 files output by ED2.
+* Fixed a bug where dimensions of output .nc file would be incorrect if a PFT was missing from ED2 output for less than a full year
 
 
 # PEcAn.ED2 1.7.2.9000

--- a/models/ed/R/model2netcdf.ED2.R
+++ b/models/ed/R/model2netcdf.ED2.R
@@ -1081,11 +1081,13 @@ read_E_files <- function(yr, yfiles, h5_files, outdir, start_date, end_date,
   # dimensions don't get screwed up later.  Other code in model2netcdf.ED2
   # assumes the dimensions are constant for the entire year.
   
-  expected <- expand_grid(
+  expected <- tidyr::expand_grid(
     date = unique(out$date),
     PFT = unique(out$PFT)
   )
-  out <- full_join(out, expected) %>% arrange(date)
+  out <- 
+    dplyr::full_join(out, expected, by = c("date", "PFT")) %>%
+    dplyr::arrange(.data$date)
   
   # Rename variables to PEcAn standard and convert to list
   n_pft <- length(unique(out$PFT))

--- a/models/ed/R/model2netcdf.ED2.R
+++ b/models/ed/R/model2netcdf.ED2.R
@@ -1050,6 +1050,7 @@ read_E_files <- function(yr, yfiles, h5_files, outdir, start_date, end_date,
     purrr::map(file.path(outdir, h5_files[yr == yfiles]), extract_E_file) %>% 
     dplyr::bind_rows() 
   
+  
   # Unit conversions
   out <- raw %>% 
     dplyr::mutate(
@@ -1069,12 +1070,22 @@ read_E_files <- function(yr, yfiles, h5_files, outdir, start_date, end_date,
     dplyr::summarize(
       dplyr::across(
         dplyr::any_of(c("BSEEDS_CO", "AGB_CO", "MMEAN_NPPDAILY_CO", "MMEAN_TRANSP_CO", "NPLANT")),
-        function(.x) sum(.x * .data$AREA)
+        function(.x) sum(.x * .data$AREA, na.rm = TRUE)
       ),
       #(or a mean when it makes sense)
-      DBH_mean = mean(.data$DBH),
+      DBH_mean = mean(.data$DBH, na.rm = TRUE),
       .groups = "drop"
     )
+  # Make sure every PFT is found in every date.  This is not necessarily the
+  # case in ED2 output, but we need to fill in some dummy values so the
+  # dimensions don't get screwed up later.  Other code in model2netcdf.ED2
+  # assumes the dimensions are constant for the entire year.
+  
+  expected <- expand_grid(
+    date = unique(out$date),
+    PFT = unique(out$PFT)
+  )
+  out <- full_join(out, expected) %>% arrange(date)
   
   # Rename variables to PEcAn standard and convert to list
   n_pft <- length(unique(out$PFT))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

Fixes a bug in `model2netcdf.ED2()` where `put_E_values()` would fail because the dimensions were wrong when a PFT was missing from ED2 output .h5 files. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

 I was previously making the assumption that all PFTs would show up in all outputs, but apparently they can "disappear" for a few months and then come back.  This may be an ED2 bug, but for now, I figured it would be best to write `NA`s for temporarily missing PFTs so that the dimensions get figured out correctly and .nc files get created.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] My name is in the list of CITATION.cff
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
