### PR TITLE
Add optional `pfts` argument to `run.sensitivity.analysis()` (fix/workaround for #3154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@ see if you need to change any of these:
 - Added litter_mass_content_of_water to model2netcdf.SIPNET
 - Added all SIPNET state variables to read_restart and write_restart
 - Added Observation preparation functions into the SDA workflow, which supports AGB, LAI, Soil Carbon, and Soil moisture.
-We are slowly change the license from NCSA opensource to BSD-3 to help with publishing PEcAn to CRAN.
+- We are slowly change the license from NCSA opensource to BSD-3 to help with publishing PEcAn to CRAN.
+- Added an optional `pfts` argument to `PEcAn.uncertainty::run.sensitivity.analysis()` so that sensitivity analysis and variance decomposition can be run on a subset of PFTs defined in `settings` if desired (#3155).
 
 ### Fixed
 

--- a/modules/uncertainty/DESCRIPTION
+++ b/modules/uncertainty/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PEcAn.uncertainty
 Type: Package
 Title: PEcAn Functions Used for Propagating and Partitioning Uncertainties in Ecological Forecasts and Reanalysis
-Version: 1.7.2
+Version: 1.7.2.9000
 Date: 2021-10-04
 Authors@R: c(person("Mike", "Dietze", role = c("aut"),
                      email = "dietze@bu.edu"),

--- a/modules/uncertainty/NEWS.md
+++ b/modules/uncertainty/NEWS.md
@@ -1,0 +1,7 @@
+# PEcAn.uncertainty (development version)
+
+- Added an optional `pfts` argument to `run.sensitivity.analysis()` so that sensitivity analysis and variance decomposition can be run on a subset of PFTs defined in `settings` if desired (#3155).
+
+# PEcAn.uncertainty 1.7.2
+
+* Added a `NEWS.md` file to track changes to the package.

--- a/modules/uncertainty/R/run.sensitivity.analysis.R
+++ b/modules/uncertainty/R/run.sensitivity.analysis.R
@@ -8,18 +8,34 @@
 #-------------------------------------------------------------------------------
 #--------------------------------------------------------------------------------------------------#
 ##' run sensitivity.analysis
+##' 
+##' Runs the sensitivity analysis module on a finished run
 ##'
-##' @name run.sensitivity.analysis
-##' @title run sensitivity.analysis
-##' @return nothing, saves \code{sensitivity.results} as sensitivity.results.Rdata,
-##' sensitivity plots as sensitivityanalysis.pdf, and variance decomposition 'popsicle plot'
-##' as variancedecomposition.pdf a side effect (OPTIONAL)
+##' @return nothing, saves \code{sensitivity.results} as
+##'   sensitivity.results.Rdata, sensitivity plots as sensitivityanalysis.pdf,
+##'   and variance decomposition 'popsicle plot' as variancedecomposition.pdf a
+##'   side effect (OPTIONAL)
 ##'
+##' @param settings a PEcAn settings object
 ##' @param plot logical. Option to generate sensitivity analysis and variance
 ##' decomposition plots (plot=TRUE) or to turn these plots off (plot=FALSE).
+##' @param ensemble.id ensemble ID
+##' @param variable which varibable(s) to do sensitivity analysis for. Defaults
+##'   to all specified in `settings`
+##' @param start.year defaults to what is specified in `settings`
+##' @param end.year defaults to what is specified in `settings`
+##' @param ... currently unused
+##' 
 ##'
 ##' @export
 ##' @author David LeBauer, Shawn Serbin, Ryan Kelly
+##' @examples
+##' \dontrun{
+##' library(PEcAn.settings)
+##' library(PEcAn.uncertainty)
+##' settings <- read.settings("path/to/pecan.xml")
+##' run.sensitivity.analysis(settings)
+##' }
 ##'
 run.sensitivity.analysis <- function(settings,plot=TRUE, ensemble.id=NULL, variable=NULL, start.year=NULL, end.year=NULL, ...){
   if ('sensitivity.analysis' %in% names(settings)) {

--- a/modules/uncertainty/R/run.sensitivity.analysis.R
+++ b/modules/uncertainty/R/run.sensitivity.analysis.R
@@ -73,8 +73,16 @@ run.sensitivity.analysis <-
     }
     if(is.null(pfts)) {
       #extract just pft names
-      pfts <- settings %>% purrr::map_chr("name")
-    } 
+      pfts <- purrr::map_chr(settings, "name")
+    } else {
+      # validate pfts argument
+      if(!is.character(pfts)) {
+        PEcAn.logger::logger.severe("Please supply a character vector for `pfts`")
+      }
+      if(!pfts %in% purrr::map_chr(settings, "name")) {
+        PEcAn.logger::logger.severe("`pfts` must be a subset of the PFTs defined in `settings`")
+      }
+    }
 
     variables <- variable
     if(length(variables) >= 1) {

--- a/modules/uncertainty/R/run.sensitivity.analysis.R
+++ b/modules/uncertainty/R/run.sensitivity.analysis.R
@@ -73,13 +73,13 @@ run.sensitivity.analysis <-
     }
     if(is.null(pfts)) {
       #extract just pft names
-      pfts <- purrr::map_chr(settings, "name")
+      pfts <- purrr::map_chr(settings$pfts, "name")
     } else {
       # validate pfts argument
       if(!is.character(pfts)) {
         PEcAn.logger::logger.severe("Please supply a character vector for `pfts`")
       }
-      if(!pfts %in% purrr::map_chr(settings, "name")) {
+      if(!pfts %in% purrr::map_chr(settings$pfts, "name")) {
         PEcAn.logger::logger.severe("`pfts` must be a subset of the PFTs defined in `settings`")
       }
     }

--- a/modules/uncertainty/R/run.sensitivity.analysis.R
+++ b/modules/uncertainty/R/run.sensitivity.analysis.R
@@ -71,6 +71,10 @@ run.sensitivity.analysis <-
     if(is.null(variable)) {
       PEcAn.logger::logger.severe("No variables for sensitivity analysis!")
     }
+    if(is.null(pfts)) {
+      #extract just pft names
+      pfts <- settings %>% purrr::map_chr("name")
+    } 
 
     variables <- variable
     if(length(variables) >= 1) {

--- a/modules/uncertainty/R/run.sensitivity.analysis.R
+++ b/modules/uncertainty/R/run.sensitivity.analysis.R
@@ -67,7 +67,7 @@ run.sensitivity.analysis <- function(settings,plot=TRUE, ensemble.id=NULL, varia
         } else {
           ensemble.id <- NULL
         }
-        if(file.exists(fname)) load(fname)
+        if(file.exists(fname)) load(fname, envir = environment())
         
         # For backwards compatibility, define some variables if not just loaded
         if(!exists("pft.names"))    pft.names <- names(trait.samples)
@@ -82,7 +82,7 @@ run.sensitivity.analysis <- function(settings,plot=TRUE, ensemble.id=NULL, varia
           settings, "sensitivity.output", "Rdata", all.var.yr = FALSE,
           ensemble.id = ensemble.id, variable = variable.fn,
           start.year = start.year, end.year = end.year)
-        load(fname)
+        load(fname, envir = environment())
         
         ### Generate SA output and diagnostic plots
         sensitivity.results <- list()

--- a/modules/uncertainty/R/run.sensitivity.analysis.R
+++ b/modules/uncertainty/R/run.sensitivity.analysis.R
@@ -54,7 +54,7 @@ run.sensitivity.analysis <- function(settings,plot=TRUE, ensemble.id=NULL, varia
         # Have to load samples.Rdata for the traits. But can overwrite the run ids if a sensitivity analysis ensemble id provided. samples.Rdata always has only the most recent ensembles for both ensemble and sensitivity runs.
         fname <- file.path(settings$outdir, 'samples.Rdata')
         if(!file.exists(fname)) PEcAn.logger::logger.severe("No samples.Rdata file found!")
-        load(fname)
+        load(fname, envir = environment())
         
         # Can specify ensemble ids manually. If not, look in settings. If none there, will use the most recent, which was loaded with samples.Rdata
         if(!is.null(ensemble.id)) {

--- a/modules/uncertainty/R/run.sensitivity.analysis.R
+++ b/modules/uncertainty/R/run.sensitivity.analysis.R
@@ -39,7 +39,16 @@
 ##' run.sensitivity.analysis(settings)
 ##' }
 ##'
-run.sensitivity.analysis <- function(settings,plot=TRUE, ensemble.id=NULL, variable=NULL, start.year=NULL, end.year=NULL, pfts = NULL, ...){
+run.sensitivity.analysis <-
+  function(settings,
+           plot = TRUE,
+           ensemble.id = NULL,
+           variable = NULL,
+           start.year = NULL,
+           end.year = NULL,
+           pfts = NULL,
+           ...) {
+    
   if ('sensitivity.analysis' %in% names(settings)) {
     # Set variable and years. Use args first, then settings, then defaults/error
     if(is.null(start.year)) {

--- a/modules/uncertainty/R/run.sensitivity.analysis.R
+++ b/modules/uncertainty/R/run.sensitivity.analysis.R
@@ -24,7 +24,7 @@
 ##'   to all specified in `settings`
 ##' @param start.year defaults to what is specified in `settings`
 ##' @param end.year defaults to what is specified in `settings`
-##' @param pft a vector of PFT names found in `settings` to run sensitivity
+##' @param pfts a vector of PFT names found in `settings` to run sensitivity
 ##'   analysis on
 ##' @param ... currently unused
 ##' 
@@ -39,7 +39,7 @@
 ##' run.sensitivity.analysis(settings)
 ##' }
 ##'
-run.sensitivity.analysis <- function(settings,plot=TRUE, ensemble.id=NULL, variable=NULL, start.year=NULL, end.year=NULL, pft=NULL, ...){
+run.sensitivity.analysis <- function(settings,plot=TRUE, ensemble.id=NULL, variable=NULL, start.year=NULL, end.year=NULL, pfts = NULL, ...){
   if ('sensitivity.analysis' %in% names(settings)) {
     # Set variable and years. Use args first, then settings, then defaults/error
     if(is.null(start.year)) {
@@ -106,7 +106,7 @@ run.sensitivity.analysis <- function(settings,plot=TRUE, ensemble.id=NULL, varia
         sensitivity.results <- list()
         
         for (pft in settings$pfts) {
-          if (pft$name %in% pft) {
+          if (pft$name %in% pfts) {
             traits <- trait.names[[pft$name]]
             quantiles.str <- rownames(sa.samples[[pft$name]])
             quantiles.str <- quantiles.str[which(quantiles.str != '50')]

--- a/modules/uncertainty/man/run.sensitivity.analysis.Rd
+++ b/modules/uncertainty/man/run.sensitivity.analysis.Rd
@@ -15,16 +15,39 @@ run.sensitivity.analysis(
 )
 }
 \arguments{
+\item{settings}{a PEcAn settings object}
+
 \item{plot}{logical. Option to generate sensitivity analysis and variance
 decomposition plots (plot=TRUE) or to turn these plots off (plot=FALSE).}
+
+\item{ensemble.id}{ensemble ID}
+
+\item{variable}{which varibable(s) to do sensitivity analysis for. Defaults
+to all specified in `settings`}
+
+\item{start.year}{defaults to what is specified in `settings`}
+
+\item{end.year}{defaults to what is specified in `settings`}
+
+\item{...}{currently unused}
 }
 \value{
-nothing, saves \code{sensitivity.results} as sensitivity.results.Rdata,
-sensitivity plots as sensitivityanalysis.pdf, and variance decomposition 'popsicle plot'
-as variancedecomposition.pdf a side effect (OPTIONAL)
+nothing, saves \code{sensitivity.results} as
+  sensitivity.results.Rdata, sensitivity plots as sensitivityanalysis.pdf,
+  and variance decomposition 'popsicle plot' as variancedecomposition.pdf a
+  side effect (OPTIONAL)
 }
 \description{
-run sensitivity.analysis
+Runs the sensitivity analysis module on a finished run
+}
+\examples{
+\dontrun{
+library(PEcAn.settings)
+library(PEcAn.uncertainty)
+settings <- read.settings("path/to/pecan.xml")
+run.sensitivity.analysis(settings)
+}
+
 }
 \author{
 David LeBauer, Shawn Serbin, Ryan Kelly

--- a/modules/uncertainty/man/run.sensitivity.analysis.Rd
+++ b/modules/uncertainty/man/run.sensitivity.analysis.Rd
@@ -11,6 +11,7 @@ run.sensitivity.analysis(
   variable = NULL,
   start.year = NULL,
   end.year = NULL,
+  pft = NULL,
   ...
 )
 }
@@ -28,6 +29,9 @@ to all specified in `settings`}
 \item{start.year}{defaults to what is specified in `settings`}
 
 \item{end.year}{defaults to what is specified in `settings`}
+
+\item{pft}{a vector of PFT names found in `settings` to run sensitivity
+analysis on}
 
 \item{...}{currently unused}
 }

--- a/modules/uncertainty/man/run.sensitivity.analysis.Rd
+++ b/modules/uncertainty/man/run.sensitivity.analysis.Rd
@@ -11,7 +11,7 @@ run.sensitivity.analysis(
   variable = NULL,
   start.year = NULL,
   end.year = NULL,
-  pft = NULL,
+  pfts = NULL,
   ...
 )
 }
@@ -30,7 +30,7 @@ to all specified in `settings`}
 
 \item{end.year}{defaults to what is specified in `settings`}
 
-\item{pft}{a vector of PFT names found in `settings` to run sensitivity
+\item{pfts}{a vector of PFT names found in `settings` to run sensitivity
 analysis on}
 
 \item{...}{currently unused}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

Adds a `pfts` argument to `run.sensitivity.analysis()` to allow the user to specify a subset of PFTs in the `settings` object to run sensitivity analysis on. 

Also prevents this function from dumping objects into the global environment (and possibly overwriting things without any warning) by specifying the environment for `load()`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Doing sensitivity analysis with a large number of PFTs generates a large number of runs and to save on compute time, I "manually" removed SA runs for PFTs I'm not interested in.  `run.sensitivity.analysis()` interprets this as an there having been an error in model runs and doesn't generate all the files it is supposed to (in particular, no sensitivity.results.Rdata) (#3154).

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] My name is in the list of CITATION.cff
- [x] I have updated the CHANGELOG.md.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
