### PR TITLE
Allow `ud_convert()` to work with class "difftime" (fix for #3012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ convert data for a single PFT fixed (#1329, #2974, #2981)
 - DDBH (change in DBH over time) is no longer extracted and summarized from monthly -E- files by `PEcAn.ED2::model2netcdf.ED2()`.  We are not sure it makes sense to summarize this variable across cohorts of different sizes.
 - The `yr` and `yfiles` arguments of `PEcAn.ED2::read_E_files()` are no longer used and the simulation date is extracted from the names of the .h5 files output by ED2.
 - Update Dockerfile for sipnet/maespa/template to use pecan/models:tag to build.
+- Fixed a bug in `PEcAn.utils::ud_convert()` where it failed with objects of class "difftime" introduced by refactoring to use the `units` package instead of `udunits` (#3012)
 
 ### Changed
 

--- a/base/utils/NEWS.md
+++ b/base/utils/NEWS.md
@@ -5,3 +5,5 @@
 * Shifted `convert.input` function from `PEcAn.utils` to `PEcAn.DB` with a new name `convert_input`to remove circular dependency.
   (#3026; @nanu1605)
 * Added a stub function `convert.input`. (#3026; @nanu1605)
+* Updated unit conversions throughout PEcAn to use the `units` R package instead of the unmaintained `udunits2`. Note that both `units` and `udunits2` interface with the same underlying compiled code, so the `udunits2` *system library* is still required. (#2989; @nanu1605)
+* Fixed a bug in `ud_convert()` where it failed with objects of class "difftime" introduced by refactoring to use the `units` package instead of `udunits` (#3012)

--- a/base/utils/R/ud_convert.R
+++ b/base/utils/R/ud_convert.R
@@ -15,6 +15,9 @@ ud_convert <- function(x, u1, u2) {
   stopifnot(units::ud_are_convertible(u1, u2))
   if(inherits(x, "difftime")) {
     x1 <- units::as_units(x)
+    if(units::units(x1) != units::units(units::as_units(u1))) {
+      warning("Units of `x` don't match `u1`, using '", units::deparse_unit(x1), "' instead")
+    }
   } else {
     x1 <- units::set_units(x, value = u1, mode = "standard")
   }

--- a/base/utils/R/ud_convert.R
+++ b/base/utils/R/ud_convert.R
@@ -15,7 +15,7 @@ ud_convert <- function(x, u1, u2) {
   stopifnot(units::ud_are_convertible(u1, u2))
   if(inherits(x, "difftime")) {
     x1 <- units::as_units(x)
-    if(units::units(x1) != units::units(units::as_units(u1))) {
+    if(units(x1) != units(units::as_units(u1))) {
       warning("Units of `x` don't match `u1`, using '", units::deparse_unit(x1), "' instead")
     }
   } else {

--- a/base/utils/R/ud_convert.R
+++ b/base/utils/R/ud_convert.R
@@ -11,7 +11,11 @@
 ##' @export
 ud_convert <- function(x, u1, u2) {
   stopifnot(units::ud_are_convertible(u1, u2))
-  x1 <- units::set_units(x, value = u1, mode = "standard")
+  if(inherits("difftime")) {
+    x1 <- units::as_units(x)
+  } else {
+    x1 <- units::set_units(x, value = u1, mode = "standard")
+  }
   x2 <- units::set_units(x1, value = u2, mode = "standard")
   
   units::drop_units(x2)

--- a/base/utils/R/ud_convert.R
+++ b/base/utils/R/ud_convert.R
@@ -3,8 +3,10 @@
 ##' Unit conversion to replace the now-unmaintained `udunits2::ud.convert`
 ##' @author Chris Black
 ##' 
-##' @param x numeric vector
-##' @param u1 string parseable as the units in which `x` is provided
+##' @param x vector of class "numeric" or "difftime"
+##' @param u1 string parseable as the units in which `x` is provided.  If `x` is
+##'   class "difftime", then `u1` is not actually used.  However, it still needs
+##'   to be supplied and needs to be convertible to `u2` for consistency.
 ##' @param u2 string parseable as the units to convert to
 ##' 
 ##' @return numeric vector with values converted to units in `u2`

--- a/base/utils/R/ud_convert.R
+++ b/base/utils/R/ud_convert.R
@@ -11,7 +11,7 @@
 ##' @export
 ud_convert <- function(x, u1, u2) {
   stopifnot(units::ud_are_convertible(u1, u2))
-  if(inherits("difftime")) {
+  if(inherits(x, "difftime")) {
     x1 <- units::as_units(x)
   } else {
     x1 <- units::set_units(x, value = u1, mode = "standard")

--- a/base/utils/man/ud_convert.Rd
+++ b/base/utils/man/ud_convert.Rd
@@ -7,9 +7,11 @@
 ud_convert(x, u1, u2)
 }
 \arguments{
-\item{x}{numeric vector}
+\item{x}{vector of class "numeric" or "difftime"}
 
-\item{u1}{string parseable as the units in which \code{x} is provided}
+\item{u1}{string parseable as the units in which \code{x} is provided.  If \code{x} is
+class "difftime", then \code{u1} is not actually used.  However, it still needs
+to be supplied and needs to be convertible to \code{u2} for consistency.}
 
 \item{u2}{string parseable as the units to convert to}
 }

--- a/base/utils/tests/testthat/test-ud_convert.R
+++ b/base/utils/tests/testthat/test-ud_convert.R
@@ -25,3 +25,14 @@ test_that("output is type numeric and not class \"units\"", {
   testthat::expect_type(x, "double")
 
 })
+
+test_that("ud_convert() handles difftime", {
+  x <- ud_convert(as.difftime("12:00:00"), u1 = "hours", u2 = "days")
+  testthat::expect_is(x, "numeric")
+  testthat::expect_equal(x, 0.5)
+  
+  #u1 doesn't matter, except that it has to be convertible to u2
+  y <- ud_convert(as.difftime("12:00:00"), u1 = "years", u2 = "minutes")
+  testthat::expect_equal(y, 720)
+  expect_error(ud_convert(as.difftime("12:00:00"), u1 = "kilograms", u2 = "minutes"))
+})

--- a/base/utils/tests/testthat/test-ud_convert.R
+++ b/base/utils/tests/testthat/test-ud_convert.R
@@ -28,11 +28,12 @@ test_that("output is type numeric and not class \"units\"", {
 
 test_that("ud_convert() handles difftime", {
   x <- ud_convert(as.difftime("12:00:00"), u1 = "hours", u2 = "days")
-  testthat::expect_is(x, "numeric")
-  testthat::expect_equal(x, 0.5)
-  
-  #u1 doesn't matter, except that it has to be convertible to u2
-  y <- ud_convert(as.difftime("12:00:00"), u1 = "years", u2 = "minutes")
-  testthat::expect_equal(y, 720)
+  expect_is(x, "numeric")
+  expect_equal(x, 0.5)
+})
+
+test_that("ud_convert() warns with wrong input units for difftime", {
+  expect_warning(ud_convert(as.difftime("12:00:00"), u1 = "years", u2 = "minutes"))
+  #should still error if units are not convertible
   expect_error(ud_convert(as.difftime("12:00:00"), u1 = "kilograms", u2 = "minutes"))
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Fixes #3012 .  Checks if argument `x` is difftime, and if it is converts it to a `units` object with `as_units()`.  Units are inferred from the class, so argument `u1` isn't actually used in the conversion in this case.  UI is a little weird here, but seems like this is mostly an internal function so probably better than adding argument defaults and allowing `u1` to be `NULL` or something like that.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] My name is in the list of CITATION.cff
- [x] I have updated the CHANGELOG.md.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
