### PR TITLE
Add resave mode to check_with_errors.R

### DIFF
--- a/scripts/check_with_errors.R
+++ b/scripts/check_with_errors.R
@@ -7,6 +7,8 @@ log_level <- Sys.getenv("LOGLEVEL", unset = NA)
 die_level <- Sys.getenv("DIELEVEL", unset = NA)
 redocument <- as.logical(Sys.getenv("REBUILD_DOCS", unset = NA))
 runtests <- as.logical(Sys.getenv("RUN_TESTS", unset = TRUE))
+resave <- as.logical(Sys.getenv("RESAVE_CHECKS", unset = FALSE))
+if (resave) die_level <- "never"
 
 old_file <- file.path(pkg, "tests", "Rcheck_reference.log")
 if (file.exists(old_file)) {
@@ -71,7 +73,7 @@ if (log_notes && n_notes > 0) {
 # such that it's not yet practical to break the build on every warning.
 # Cleaning this up is a long-term goal, but will take time.
 # Meanwhile, we compare against a cached historic check output to enforce that
-# no *new* warnings are added. As historic warnings are removed, we will update
+# no *new* warnings are added. As historic warnings are removed, we update
 # the cached results to ensure they stay gone.
 #
 # To compare checks, we take a two-level approach:
@@ -83,16 +85,16 @@ if (log_notes && n_notes > 0) {
 ###
 # To update reference files after fixing an old warning:
 # * Run check_with_errors.R to be sure the check is currently passing
-# * Delete the file you want to update
-# * Uncomment this section
-# * run `DIELEVEL=never Rscript scripts/check_with_errors.R path/to/package`
-# * recomment this section
-# * Commit updated file
-# if (!file.exists(old_file)) {
-#     cat("No reference check file found. Saving current results as the new standard\n")
-#     cat(chk$stdout, file = old_file)
-#     quit("no")
-# }
+# * run `RESAVE_CHECKS=true Rscript scripts/check_with_errors.R path/to/package`
+# * Commit updated <pkgname>/tests/Rcheck_reference.log file
+if (resave) {
+    cat("Saving current check results as the new standard\n")
+    if (file.exists(old_file)) {
+        cat("**Overwriting** existing saved check output\n")
+    }
+    cat(chk$stdout, file = old_file)
+    quit("no")
+}
 ###
 
 # everything beyond this point is comparing to old version


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
Adds a new usage variant: To update the cached check results in `[package_dir]/tests/Rcheck_reference.log`, run the check script with env var `RESAVE_CHECKS` set, e.g.:

```
RESAVE_CHECKS=true Rscript scripts/check_with_errors.R base/db
```

After running, review the changes to `Rcheck_reference.log` and commit them if they look good.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Thanks to the whole team in general and @moki1202 in particular, lots of our cached check results are stale in the sense that they contain messages about errors/warnings we have since fixed. We've mostly been updating these by manually editing the saved files, but this is tedious and error-prone. This patch provides a one-shot method to ease the process.

As always, my hope is that we'll use this to remove fixed messages (so that we can eventually remove all `Rcheck_reference.log` files entirely) rather than to ignore newly added messages, but it will do either one as needed.


## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
