### PR TITLE
reverting back lines that read rabbitmq.out

### DIFF
--- a/base/workflow/R/start_model_runs.R
+++ b/base/workflow/R/start_model_runs.R
@@ -292,7 +292,7 @@ start_model_runs <- function(settings, write = TRUE, stop.on.error = TRUE) {
       job_finished <- FALSE
       if (is_rabbitmq) {
         job_finished <- 
-          file.exists(file.path(settings$modeloutdir, run, "rabbitmq.out"))
+          file.exists(file.path(jobids[run], "rabbitmq.out"))
       } else if (is_qsub) {
         job_finished <- PEcAn.remote::qsub_run_finished(
           run = jobids[run],
@@ -304,7 +304,7 @@ start_model_runs <- function(settings, write = TRUE, stop.on.error = TRUE) {
       
         # TODO check output log
         if (is_rabbitmq) {
-          data <- readLines(file.path(settings$modeloutdir, run, "rabbitmq.out"))
+          data <- readLines(file.path(jobids[run], "rabbitmq.out"))
           if (data[-1] == "ERROR") {
             msg <- paste("Run", run, "has an ERROR executing")
             if (stop.on.error) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
On docker, workflow writes rabbitmq.out to rundirs, but [start_model_runs()](https://github.com/PecanProject/pecan/blob/develop/base/workflow/R/start_model_runs.R#L294) try to read it from outdir, workflow hangs, further description here: #3236 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3236 
## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [X] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
