### PR TITLE
Allow manual trigger of depends build

### DIFF
--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - master
+  workflow_dispatch:
 
   # this runs on the develop branch
   schedule:
@@ -27,7 +28,6 @@ jobs:
       fail-fast: false
       matrix:
         R:
-          - "4.0"
           - "4.1"
           - "4.2"
           - "4.3"
@@ -50,7 +50,10 @@ jobs:
       # calculate some variables that are used later
       - name: github branch
         # build Rdevel only on Mondays, others every day (but not twice on Mondays)
-        if: (matrix.R != 'devel' && github.event.schedule == '0 0 * * *') || (matrix.R == 'devel' && github.event.schedule == '30 1 * * 1')
+        if: |
+          github.event_name == 'workflow_dispatch' ||
+          (matrix.R != 'devel' && github.event.schedule == '0 0 * * *') ||
+          (matrix.R == 'devel' && github.event.schedule == '30 1 * * 1')
         run: |
           BRANCH=${GITHUB_REF##*/}
           echo "GITHUB_BRANCH=${BRANCH}" >> $GITHUB_ENV


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

As discussed in Slack -- If I did this right, should let us manually trigger a new build of the Depends image rather than wait for midnight in cases where it's blocking other merges.

Also drops build of the R 4.0 image -- we gave it a good run, but have dropped support for it and will not be going back.
(I think this means we can now start using `|>` in place of `%>%`, if we want to)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
