### PR TITLE
[met downscaling] Fix for non-hour timesteps in cfmet.downscale.daily

### DIFF
--- a/modules/data.atmosphere/R/temporal.downscaling.R
+++ b/modules/data.atmosphere/R/temporal.downscaling.R
@@ -120,7 +120,7 @@ cfmet.downscale.subdaily <- function(subdailymet, output.dt = 1) {
 cfmet.downscale.daily <- function(dailymet, output.dt = 1, lat) {
   
   tint <- 24/output.dt
-  tseq <- 0:(23 * output.dt)/output.dt
+  tseq <- seq(from = 0, to = 23, by = output.dt)
   
   data.table::setkeyv(dailymet, c("year", "doy"))
   


### PR DESCRIPTION
I think this was a flipped multiply/divide -- the now-replaced `0:(23 * output.dt)/output.dt` (which has been there for a looong time!) works when output.dt == 1, but gives too many rows for larger timesteps. 

I assume the original intention was to write `0:(23/output.dt)*output.dt`, but I replaced it with `seq(0, 23, by = output.dt)` -- that behaves identically and is a lot clearer to me.

## Motivation and Context
Noticed while reviewing #3218
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
