### PR TITLE
Remove extra arguments for STICS convert_xml2txt

### DIFF
--- a/models/stics/R/met2model.STICS.R
+++ b/models/stics/R/met2model.STICS.R
@@ -121,7 +121,7 @@ met2model.STICS <- function(in.path, in.prefix, outfolder, start_date, end_date,
       
       if(unlist(strsplit(nc$dim$time$units, " "))[1] %in% c("days", "day")){
         #this should always be the case, but just in case
-        origin_dt <- (as.POSIXct(unlist(strsplit(nc$dim$time$units, " "))[3], "%Y-%m-%d", tz="UTC") + 60*60*24) - dt
+        origin_dt <- as.POSIXct(unlist(strsplit(nc$dim$time$units, " "))[3], "%Y-%m-%d", tz="UTC")
         ydays <- lubridate::yday(origin_dt + sec)
         
       }else{

--- a/models/stics/R/write.config.STICS.R
+++ b/models/stics/R/write.config.STICS.R
@@ -162,7 +162,6 @@ write.config.STICS <- function(defaults, trait.values, settings, run.id) {
   
   # stics and javastics path
   stics_path <- settings$model$binary
-  javastics_path <-  gsub("bin","", dirname(stics_path))
 
   
   # Per STICS development team, there are two types of STICS inputs
@@ -749,7 +748,7 @@ write.config.STICS <- function(defaults, trait.values, settings, run.id) {
     
     # convert xml2txt
     if(names(trait.values)[pft] != "env"){
-      SticsRFiles::convert_xml2txt(file = plant_file, javastics = javastics_path)
+      SticsRFiles::convert_xml2txt(file = plant_file)
       # do I also need to move the file out of the plant folder to main rundir?
     }
     
@@ -1155,7 +1154,7 @@ write.config.STICS <- function(defaults, trait.values, settings, run.id) {
     # skipping, Qmulchdec:
     # maximal amount of decomposable mulch
       
-    SticsRFiles::convert_xml2txt(file = gen_file, javastics = javastics_path)
+    SticsRFiles::convert_xml2txt(file = gen_file)
     
     this_usm <- grep(names(trait.values)[pft], usmdirs)
     sapply(this_usm, function(x){
@@ -1165,7 +1164,7 @@ write.config.STICS <- function(defaults, trait.values, settings, run.id) {
     ### new formulations 
     # DO NOTHING ELSE FOR NOW
     
-    SticsRFiles::convert_xml2txt(file = newf_file, javastics = javastics_path)
+    SticsRFiles::convert_xml2txt(file = newf_file)
     sapply(this_usm, function(x){
       file.copy(file.path(rundir, "tempoparv6.sti"), file.path(usmdirs[x], "tempoparv6.sti"), overwrite = TRUE)
     })
@@ -1246,7 +1245,7 @@ write.config.STICS <- function(defaults, trait.values, settings, run.id) {
       ncdf4::nc_close(ic_nc)
     }
     
-    SticsRFiles::convert_xml2txt(file = ini_file, javastics = javastics_path)
+    SticsRFiles::convert_xml2txt(file = ini_file)
     file.rename(file.path(rundir, "ficini.txt"), file.path(usmdirs[i], "ficini.txt"))
   }
 
@@ -1347,7 +1346,7 @@ write.config.STICS <- function(defaults, trait.values, settings, run.id) {
   # change latitude
   SticsRFiles::set_param_xml(sta_file, "latitude", settings$run$site$lat, overwrite = TRUE)
   
-  SticsRFiles::convert_xml2txt(file = sta_file, javastics = javastics_path)
+  SticsRFiles::convert_xml2txt(file = sta_file)
   file.copy(file.path(rundir, "station.txt"), file.path(usmdirs, "station.txt"))
   
   # another way to change latitute
@@ -1548,8 +1547,7 @@ write.config.STICS <- function(defaults, trait.values, settings, run.id) {
         
         # TODO: more than 1 USM, rbind
         
-        SticsRFiles::convert_xml2txt(file = file.path(usmdirs[usmi], "tmp_tec.xml"), 
-                                     javastics = javastics_path)
+        SticsRFiles::convert_xml2txt(file = file.path(usmdirs[usmi], "tmp_tec.xml"))
         
       
      } # end-loop over usms


### PR DESCRIPTION
Priority: 02 - Normal
Status: Ready

## Description
Updates to SticsRFiles meant using the `javastics` argument of `convert_xml2txt` caused an error in generating input files for STICS. Removed these arguments and the now-unused `javastics_path` variable.
Also changed met2model to use the proper datetime origin.

## Motivation and Context
Required due to SticsRFiles package being updated. Run generation does not work with the latest package versions without these changes.

## Review Time Estimate
- [ ] Immediately
- [ ] Within one week
- [x] When possible

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
