### PR TITLE
Remove copyright notice that references outdated license

### DIFF
--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -1,12 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
-# University of Illinois/NCSA Open Source License
-# which accompanies this distribution, and is available at
-# http://opensource.ncsa.illinois.edu/license.html
-#-------------------------------------------------------------------------------
-
 .utils.logger <- new.env()
 .utils.logger$filename <- NA
 .utils.logger$console <- TRUE

--- a/base/logger/tests/testthat/test.logger.R
+++ b/base/logger/tests/testthat/test.logger.R
@@ -1,11 +1,3 @@
-## -------------------------------------------------------------------------------
-##  Copyright (c) 2012 University of Illinois, NCSA.
-##  All rights reserved. This program and the accompanying materials
-##  are made available under the terms of the 
-##  University of Illinois/NCSA Open Source License
-##  which accompanies this distribution, and is available at
-##  http://opensource.ncsa.illinois.edu/license.html
-##-------------------------------------------------------------------------------
 
 context("Testing Logger Settings")
 


### PR DESCRIPTION
Replaces [robkooper/pecan/#83](https://github.com/robkooper/pecan/pull/83)