### PR TITLE
relicense QAQC and PEcAn.STICS as BSD3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - The following components have changed their licensing. With approval of all their contributors, we now provide them under a BSD 3-clause license rather than the previously used NCSA Open Source license. As a reminder, we intend to relicense the entire system and this list will expand as we gather permission from the relevant copyright owners.
     * Shiny apps `dbsync`, `Data-Ingest`, and `Elicitation`
     * Base packages `PEcAn.all` and `PEcAn.QAQC`
-    * Model packages `PEcAn.LDNDC` and `PEcAn.SIBCASA`
+    * Model packages `PEcAn.LDNDC`, `PEcAn.SIBCASA`, and `PEcAn.STICS`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 ### Changed
 - The following components have changed their licensing. With approval of all their contributors, we now provide them under a BSD 3-clause license rather than the previously used NCSA Open Source license. As a reminder, we intend to relicense the entire system and this list will expand as we gather permission from the relevant copyright owners.
     * Shiny apps `dbsync`, `Data-Ingest`, and `Elicitation`
-    * Base package `PEcAn.all`
+    * Base packages `PEcAn.all` and `PEcAn.QAQC`
     * Model packages `PEcAn.LDNDC` and `PEcAn.SIBCASA`
 
 ### Removed

--- a/LICENSE
+++ b/LICENSE
@@ -32,3 +32,37 @@ ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
 CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
 
+
+
+
+--------------------
+
+
+Portions of the PEcAn project are distributed under the BSD 3-clause license:
+
+Copyright (c) 2024 Pecan Project
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/base/qaqc/LICENSE
+++ b/base/qaqc/LICENSE
@@ -1,29 +1,3 @@
-University of Illinois/NCSA Open Source License
-
-Copyright (c) 2012, University of Illinois, NCSA.  All rights reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the 
-"Software"), to deal with the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-- Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimers.
-- Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimers in the
-  documentation and/or other materials provided with the distribution.
-- Neither the names of University of Illinois, NCSA, nor the names
-  of its contributors may be used to endorse or promote products
-  derived from this Software without specific prior written permission.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR
-ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
-CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
-
+YEAR: 2024
+COPYRIGHT HOLDER: PEcAn Project
+ORGANIZATION: PEcAn Project, authors affiliations

--- a/base/qaqc/R/taylor.plot.R
+++ b/base/qaqc/R/taylor.plot.R
@@ -1,12 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the
-# University of Illinois/NCSA Open Source License
-# which accompanies this distribution, and is available at
-# http://opensource.ncsa.illinois.edu/license.html
-#-------------------------------------------------------------------------------
-
 ##' Plot taylor diagram for benchmark sites
 ##'
 ##' @param dataset data to plot

--- a/base/qaqc/inst/extdata/extdata.R
+++ b/base/qaqc/inst/extdata/extdata.R
@@ -1,13 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
-# University of Illinois/NCSA Open Source License
-# which accompanies this distribution, and is available at
-# http://opensource.ncsa.illinois.edu/license.html
-#-------------------------------------------------------------------------------
-
-#--------------------------------------------------------------------------------------------------#
 ##' 
 ##' generate benchmarking inputs table
 ##' @title Generate benchmarking inputs

--- a/base/qaqc/tests/testthat.R
+++ b/base/qaqc/tests/testthat.R
@@ -1,11 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
-# University of Illinois/NCSA Open Source License
-# which accompanies this distribution, and is available at
-# http://opensource.ncsa.illinois.edu/license.html
-#-------------------------------------------------------------------------------
 library(testthat)
 library(PEcAn.qaqc)
 

--- a/base/qaqc/tests/testthat/test-taylorplot.R
+++ b/base/qaqc/tests/testthat/test-taylorplot.R
@@ -1,12 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
-# University of Illinois/NCSA Open Source License
-# which accompanies this distribution, and is available at
-# http://opensource.ncsa.illinois.edu/license.html
-#-------------------------------------------------------------------------------
-
 test_that("taylor diagram", {
 
     set.seed(1)

--- a/base/qaqc/vignettes/function_relationships.Rmd
+++ b/base/qaqc/vignettes/function_relationships.Rmd
@@ -6,17 +6,6 @@ vignette: >
    %\VignetteEngine{knitr::rmarkdown}
 ---
 
-<!--
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
-# University of Illinois/NCSA Open Source License
-# which accompanies this distribution, and is available at
-# http://opensource.ncsa.illinois.edu/license.html
-#-------------------------------------------------------------------------------
--->
-
 This some code helps to visualize the interdependence of functions within PEcAn
 
 

--- a/base/qaqc/vignettes/module_output.Rmd
+++ b/base/qaqc/vignettes/module_output.Rmd
@@ -6,17 +6,6 @@ vignette: >
    %\VignetteEngine{knitr::rmarkdown}
 ---
 
-<!--
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
-# University of Illinois/NCSA Open Source License
-# which accompanies this distribution, and is available at
-# http://opensource.ncsa.illinois.edu/license.html
-#-------------------------------------------------------------------------------
--->
-
 To get a better understanding on what files are created where, Rob created a workflow as an SVG diagram. You can find the diagram at
 
 http://isda.ncsa.illinois.edu/~kooper/EBI/workflow.svg

--- a/models/stics/LICENSE
+++ b/models/stics/LICENSE
@@ -1,34 +1,3 @@
-## This is the master copy of the PEcAn License
-
-University of Illinois/NCSA Open Source License
-
-Copyright (c) 2012, University of Illinois, NCSA.  All rights reserved.
-
-PEcAn project
-www.pecanproject.org
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the 
-"Software"), to deal with the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-- Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimers.
-- Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimers in the
-  documentation and/or other materials provided with the distribution.
-- Neither the names of University of Illinois, NCSA, nor the names
-  of its contributors may be used to endorse or promote products
-  derived from this Software without specific prior written permission.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR
-ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
-CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
-
+YEAR: 2024
+COPYRIGHT HOLDER: PEcAn Project
+ORGANIZATION: PEcAn Project, authors affiliations

--- a/models/stics/R/met2model.STICS.R
+++ b/models/stics/R/met2model.STICS.R
@@ -1,13 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
-# University of Illinois/NCSA Open Source License
-# which accompanies this distribution, and is available at
-# http://opensource.ncsa.illinois.edu/license.html
-#-------------------------------------------------------------------------------
-
-##-------------------------------------------------------------------------------------------------#
 ##' Converts a met CF file to a model specific met file. The input
 ##' files are calld <in.path>/<in.prefix>.YYYY.cf
 ##'

--- a/models/stics/R/model2netcdf.STICS.R
+++ b/models/stics/R/model2netcdf.STICS.R
@@ -1,13 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
-# University of Illinois/NCSA Open Source License
-# which accompanies this distribution, and is available at
-# http://opensource.ncsa.illinois.edu/license.html
-#-------------------------------------------------------------------------------
-
-##-------------------------------------------------------------------------------------------------#
 ##' Convert STICS output into the NACP Intercomparison format (ALMA using netCDF)
 ##' 
 ##' @name model2netcdf.STICS

--- a/models/stics/R/write.config.STICS.R
+++ b/models/stics/R/write.config.STICS.R
@@ -1,13 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
-# University of Illinois/NCSA Open Source License
-# which accompanies this distribution, and is available at
-# http://opensource.ncsa.illinois.edu/license.html
-#-------------------------------------------------------------------------------
-
-##-------------------------------------------------------------------------------------------------#
 ##' Writes STICS configurations.
 ##'
 ##' Requires a pft xml object, a list of trait values for a single model run,

--- a/models/stics/tests/testthat.R
+++ b/models/stics/tests/testthat.R
@@ -1,11 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012 University of Illinois, NCSA.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the 
-# University of Illinois/NCSA Open Source License
-# which accompanies this distribution, and is available at
-# http://opensource.ncsa.illinois.edu/license.html
-#-------------------------------------------------------------------------------
 library(testthat)
 library(PEcAn.utils)
 


### PR DESCRIPTION
Updating the license file upon noting we have agreement from all contributors whose code is still present in that package.
* QAQC: @ashiklom , @infotroph, @DongchenZ, @mdietze, @robkooper, @allgandalf, @mccabete, @tonygardella, @istfer, @meetagrawal09     
* STICS: @infotroph, @DongchenZ, @robkooper, @nanu1605, @istfer, @qdbell
