### PR TITLE
remove version tag from Compose files

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,8 +2,6 @@
 # 
 # docker-compose -f docker-compose.yml -f docker-compose.dev.yml
 
-version: '3.2'
-
 services:
 
   # web application. This expects the config.php to be copied from docker/web

--- a/docker-compose.https.yml
+++ b/docker-compose.https.yml
@@ -1,5 +1,4 @@
 # Use this file to enable https
-version: "3.2"
 
 services:
   traefik:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.2"
-
 services:
 
   # webserver to handle all traffic. This can use let's encrypt to generate a SSL cert.

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -1,7 +1,3 @@
-# you need a version entry, and this should be the same version as the
-# docker-compose.yml file.
-version: "3"
-
 # if you change any of the services you will need the services header.
 services:
 


### PR DESCRIPTION
The Docker folks declared this tag obsolete and have made Compose warn about it every time it processes a yml file that contains it. I think they were wrong to do this, but the decision is made and I don't think they'll reconsider.

See https://github.com/docker/compose/issues/11628 for the full flame war.


<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
