### PR TITLE
make a named volume for the Bety logs mountpoint

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -81,6 +81,8 @@ services:
       - SECRET_KEY_BASE=${BETY_SECRET_KEY:-notasecret}
       - RAILS_RELATIVE_URL_ROOT=/bety
       - LOCAL_SERVER=${BETY_LOCAL_SERVER:-99}
+    volumes:
+      - bety:/home/bety/log
     depends_on:
       - postgres
     labels:
@@ -279,6 +281,7 @@ networks:
 volumes:
   traefik:
   postgres:
+  bety:
   rabbitmq:
   pecan:
   rstudio:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,8 @@ services:
       - SECRET_KEY_BASE=${BETY_SECRET_KEY:-notasecret}
       - RAILS_RELATIVE_URL_ROOT=/bety
       - LOCAL_SERVER=${BETY_LOCAL_SERVER:-99}
+    volumes:
+      - bety:/home/bety/log
     depends_on:
       - postgres
     labels:
@@ -346,6 +348,7 @@ networks:
 volumes:
   traefik:
   postgres:
+  bety:
   rabbitmq:
   pecan:
   rstudio:


### PR DESCRIPTION
Best I can tell nothing gets written to this, but because the Bety image [specifies](https://github.com/PecanProject/bety/blob/develop/Dockerfile#L65) this path as a VOLUME, we were creating a new anonymous-but-permanent volume every time Compose spun up. Having one named one that stays empty seems a touch cleaner.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
