### PR TITLE
[build] avoid recursive installation of a zillion indirect Suggests

### DIFF
--- a/scripts/confirm_deps.R
+++ b/scripts/confirm_deps.R
@@ -37,16 +37,23 @@ confirm_deps <- function(pkg,
                          install = TRUE,
                          dependencies = NA,
                          ...) {
+
+  # Q: "Why a separate variable instead of overwriting `dependencies`?"
+  # A: As a quick workaround for a bug in remotes::install_deps():
+  # `dependencies = TRUE` correctly installs optional deps of the current
+  # package but only hard deps of its dependencies,
+  # whereas `dependencies = c(..., "Suggests")` installs the whole
+  # recursive chain of Suggests of Suggests of Suggests.
   if (all(is.na(dependencies)) || all(dependencies == "hard")) {
-    dependencies <- c("Depends", "Imports", "LinkingTo")
+    dependency_types <- c("Depends", "Imports", "LinkingTo")
   } else if (isTRUE(dependencies) || all(dependencies == "soft")) {
-    dependencies <- c("Depends", "Imports", "LinkingTo", "Suggests")
+    dependency_types <- c("Depends", "Imports", "LinkingTo", "Suggests")
   } else if (isFALSE(dependencies)) {
     return() # for compatibility with remotes::install_deps
   }
 
   deps <- desc::desc_get_deps(pkg)
-  deps <- deps[deps$type %in% dependencies, ]
+  deps <- deps[deps$type %in% dependency_types, ]
 
   pkgs <- as.data.frame(installed.packages(), stringsAsFactors = FALSE)[, c("Package", "Version")]
   colnames(pkgs) <- c("package", "installed_version")

--- a/scripts/confirm_deps.R
+++ b/scripts/confirm_deps.R
@@ -39,9 +39,9 @@ confirm_deps <- function(pkg,
                          ...) {
 
   # Q: "Why a separate variable instead of overwriting `dependencies`?"
-  # A: As a quick workaround for a bug in remotes::install_deps():
-  # `dependencies = TRUE` correctly installs optional deps of the current
-  # package but only hard deps of its dependencies,
+  # A: As a quick workaround for https://github.com/r-lib/remotes/issues/809:
+  # remotes::install_deps(pkgdir, `dependencies = TRUE`) correctly installs
+  # optional deps of `pkgdir` but only hard deps of its dependencies,
   # whereas `dependencies = c(..., "Suggests")` installs the whole
   # recursive chain of Suggests of Suggests of Suggests.
   if (all(is.na(dependencies)) || all(dependencies == "hard")) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
Avoids an undocumented behavior/possible bug in `remotes::install_deps`, which correctly handles `dependencies = TRUE` (by installing mandatory + optional dependencies of your package, but only mandatory dependencies of the dependencies), but the supposedly equivalent `dependencies = c("Depends", "Imports", "LinkingTo", "Suggests")` will recursively install Suggests of Suggests of Suggests.

Tested with `docker run --rm -it -v ${PWD}:/work -w /work rocker/tidyverse:4.4 ./scripts/confirm_deps.R models/stics TRUE`

<details><summary>Output before</summary>

```
Downloading GitHub repo SticsRPacks/SticsRFiles@HEAD
Installing 12 packages: lazyeval, hunspell, renv, markdown, checkmate, rex, spelling, learnr, formatR, covr, xslt, XML
Installing packages into ‘/usr/local/lib/R/site-library’
(as ‘lib’ is unspecified)
Warning: dependencies ‘marray’, ‘affy’, ‘Biobase’, ‘limma’, ‘cmdstanr’, ‘glmmADMB’, ‘rnaturalearthhires’, ‘graph’, ‘ComplexHeatmap’, ‘starsdata’, ‘subselect’, ‘INLA’, ‘globaltest’, ‘sylly.de’, ‘sylly.es’, ‘M3C’, ‘Rgraphviz’, ‘gurobi’, ‘rrelaxiv’, ‘Biostrings’, ‘seqLogo’, ‘spDataLarge’, ‘biomaRt’, ‘KEGGgraph’, ‘Rcampdf’, ‘tm.lexicon.GeneralInquirer’, ‘ExactData’, ‘rtracklayer’, ‘GenomicRanges’, ‘IRanges’, ‘S4Vectors’, ‘RandomFields’, ‘bold’, ‘Icens’, ‘loe’, ‘cairoDevice’, ‘RGtk2’, ‘rhdf5’, ‘RDCOMClient’, ‘genefilter’, ‘sva’, ‘mixOmics’, ‘taxidata’, ‘aods3’, ‘RTCGA.rnaseq’, ‘snpStats’ are not available
also installing the dependencies ‘bmp’, ‘doSNOW’, ‘RPMG’, ‘Rwave’, ‘Rmosek’, ‘readbitmap’, ‘betapart’, ‘gaston’, ‘polysat’, ‘poweRlaw’, ‘bspec’, ‘RSEIS’, ‘signal’, ‘mixsqp’, ‘etrunct’, ‘REBayes’, ‘perryExamples’, ‘ff’, ‘imager’, ‘adespatial’, ‘pegas’, ‘hierfstat’, ‘poppr’, ‘psd’, ‘slp’, ‘calculus’, ‘ashr’, ‘logging’, ‘RandVar’, ‘RobAStBase’, ‘RobLox’, ‘perry’, ‘mrfDepth’, ‘redland’, ‘repurrrsive’, ‘jsonld’, ‘thor’, ‘contentid’, ‘ratelimitr’, ‘lda’, ‘OAIHarvester’, ‘anMC’, ‘pso’, ‘rmio’, ‘bigreadr’, ‘memuse’, ‘kriging’, ‘gsignal’, ‘tiff’, ‘qdapDictionaries’, ‘discretization’, ‘additivityTests’, ‘isa2’, ‘lambda.r’, ‘futile.options’, ‘BayesXsrc’, ‘MBA’, ‘RJDBC’, ‘adegenet’, ‘multitaper’, ‘ncbit’, ‘TreeSim’, ‘mosaicCalc’, ‘rdd’, ‘bartMachineJARs’, ‘ncvreg’, ‘EMCluster’, ‘Lmoments’, ‘tdigest’, ‘ConvergenceConcepts’, ‘emulator’, ‘calibrator’, ‘mbest’, ‘rintrojs’, ‘GGMselect’, ‘geozoo’, ‘startupmsg’, ‘distrEx’, ‘distrMod’, ‘ROptEst’, ‘robustHD’, ‘rospca’, ‘ssgraph’, ‘tmvtnorm’, ‘kutils’, ‘gggenes’, ‘ggpolypath’, ‘triebeard’, ‘rdflib’, ‘rfigshare’, ‘knitcitations’, ‘taxalight’, ‘WikipediR’, ‘WikidataQueryServiceR’, ‘pageviews’, ‘MatrixExtra’, ‘topicmodels’, ‘sendmailR’, ‘binda’, ‘KrigInv’, ‘GPareto’, ‘dint’, ‘ulid’, ‘RcppAnnoy’, ‘dqrng’, ‘bigstatsr’, ‘RcppHNSW’, ‘rnndescent’, ‘lamW’, ‘SurvMetrics’, ‘naivebayes’, ‘sparsediscrim’, ‘skmeans’, ‘ggmap’, ‘sphereplot’, ‘maptiles’, ‘metR’, ‘OpenImageR’, ‘cccd’, ‘coRanking’, ‘diffusionMap’, ‘pcaL1’, ‘fuzzyjoin’, ‘arulesCBA’, ‘arulesViz’, ‘biclust’, ‘rchallenge’, ‘classGraph’, ‘VarianceGamma’, ‘storr’, ‘qdapRegex’, ‘iotools’, ‘futile.logger’, ‘R2BayesX’, ‘scalreg’, ‘bigmemory.sri’, ‘gsubfn’, ‘RH2’, ‘svUnit’, ‘ade4TkGUI’, ‘adegraphics’, ‘adephylo’, ‘waveslim’, ‘geiger’, ‘missForest’, ‘CCP’, ‘rlecuyer’, ‘audio’, ‘RcmdrMisc’, ‘tcltk2’, ‘aplpack’, ‘nortest’, ‘hipread’, ‘diagis’, ‘ramcmc’, ‘sitmo’, ‘sde’, ‘qcc’, ‘AlgDesign’, ‘ggformula’, ‘mosaicData’, ‘mosaicCore’, ‘NHANES’, ‘pammtools’, ‘exactRankTests’, ‘KMsurv’, ‘km.ci’, ‘icenReg’, ‘grf’, ‘chandwich’, ‘bang’, ‘influenceR’, ‘netrankr’, ‘NetSwan’, ‘origami’, ‘cvAUC’, ‘bartMachine’, ‘biglasso’, ‘LogicReg’, ‘SIS’, ‘details’, ‘svgPanZoom’, ‘ecp’, ‘fdapace’, ‘evgam’, ‘ROOPSD’, ‘meboot’, ‘hdrcde’, ‘elliptic’, ‘contfrac’, ‘zipfR’, ‘stable’, ‘statip’, ‘skpr’, ‘capushe’, ‘shock’, ‘slippymath’, ‘nipals’, ‘RcmdrPlugin.HH’, ‘microplot’, ‘sommer’, ‘svGUI’, ‘ECOSolveR’, ‘scs’, ‘clarabel’, ‘hasseDiagram’, ‘cccp’, ‘flock’, ‘ggExtra’, ‘gglm’, ‘esc’, ‘mschart’, ‘otrimle’, ‘LDRTools’, ‘tourr’, ‘twosamples’, ‘distr’, ‘cellWise’, ‘fdrtool’, ‘BDgraph’, ‘huge’, ‘lisrelToR’, ‘rockchalk’, ‘FactoInvestigate’, ‘ash’, ‘BSDA’, ‘fANCOVA’, ‘Rfit’, ‘operators’, ‘ConsRank’, ‘shapviz’, ‘declared’, ‘venn’, ‘gcookbook’, ‘urltools’, ‘httpcode’, ‘fauxpas’, ‘webmockr’, ‘rentrez’, ‘rncl’, ‘phylobase’, ‘RNeXML’, ‘solrium’, ‘WikidataR’, ‘xmlrpc2’, ‘norm’, ‘bibtex’, ‘ccaPP’, ‘rsparse’, ‘mlapi’, ‘udpipe’, ‘eaf’, ‘BatchJobs’, ‘crossval’, ‘entropy’, ‘DiceOptim’, ‘mldr.datasets’, ‘cmaesr’, ‘pbs’, ‘dtw’, ‘maptree’, ‘Mcomp’, ‘rotor’, ‘PRROC’, ‘oaqc’, ‘uwot’, ‘dr’, ‘lsa’, ‘LambertW’, ‘synchronicity’, ‘wrapr’, ‘rquery’, ‘rqdatatable’, ‘forge’, ‘git2r’, ‘trust’, ‘survival’, ‘aorsf’, ‘discrim’, ‘flexclust’, ‘RcppHungarian’, ‘betacal’, ‘quantregForest’, ‘inlabru’, ‘tidyterra’, ‘irr’, ‘glmertree’, ‘protolite’, ‘warp’, ‘linprog’, ‘R.matlab’, ‘janeaustenr’, ‘r2d3’, ‘clisymbols’, ‘ClusterR’, ‘clustMixType’, ‘dimRed’, ‘nestedmodels’, ‘QSARdata’, ‘xrf’, ‘FMStable’, ‘libstable4u’, ‘wdm’, ‘cobs’, ‘mvPot’, ‘gmm’, ‘ismev’, ‘TruncatedNormal’, ‘sets’, ‘mathjaxr’, ‘kdecopula’, ‘ada’, ‘amap’, ‘arules’, ‘neighbr’, ‘rattle’, ‘RWekajars’, ‘likert’, ‘stablelearner’, ‘gss’, ‘gbutils’, ‘x13binary’, ‘seasonalview’, ‘multicool’, ‘oz’, ‘truncnorm’, ‘DistributionUtils’, ‘GeneralizedHyperbolic’, ‘shadowtext’, ‘rdhs’, ‘sae’, ‘Iso’, ‘PASWR’, ‘VennDiagram’, ‘splancs’, ‘gamboostLSS’, ‘hdi’, ‘bvls’, ‘shapefiles’, ‘bigmemory’, ‘sqldf’, ‘NLP’, ‘antiword’, ‘filehash’, ‘Rpoppler’, ‘SnowballC’, ‘caper’, ‘ade4’, ‘FD’, ‘phytools’, ‘circular’, ‘MplusAutomation’, ‘bain’, ‘progressr’, ‘tidyLPA’, ‘dagitty’, ‘snow’, ‘beepr’, ‘job’, ‘future.batchtools’, ‘inlinedocs’, ‘rclipboard’, ‘Rcmdr’, ‘TeachingDemos’, ‘BMA’, ‘DescTools’, ‘pryr’, ‘invgamma’, ‘ipumsr’, ‘bssm’, ‘EnvStats’, ‘TRAMPR’, ‘measures’, ‘logmult’, ‘gdata’, ‘agricolae’, ‘mosaic’, ‘relsurv’, ‘maxstat’, ‘survMisc’, ‘ggtext’, ‘SQUAREM’, ‘mets’, ‘targeted’, ‘exdex’, ‘rust’, ‘tidygraph’, ‘flashClust’, ‘Publish’, ‘smcfcs’, ‘casebase’, ‘grpreg’, ‘hal9001’, ‘SuperLearner’, ‘gRbase’, ‘gRain’, ‘texPreview’, ‘base64url’, ‘kmi’, ‘ftsa’, ‘rainbow’, ‘HMDHFDplus’, ‘date’, ‘hypergeo’, ‘languageR’, ‘tmvnsim’, ‘modeest’, ‘pwr’, ‘transformr’, ‘ggside’, ‘numbers’, ‘DoE.wrapper’, ‘FrF2.catlg128’, ‘BsMD’, ‘mc2d’, ‘dismo’, ‘arsenal’, ‘BiasedUrn’, ‘pimeta’, ‘estmeansd’, ‘robvis’, ‘wildmeta’, ‘metaBLUE’, ‘HaploSim’, ‘Rmixmod’, ‘xLLiM’, ‘elevatr’, ‘desplot’, ‘gge’, ‘HH’, ‘lucid’, ‘NADA’, ‘nullabor’, ‘qicharts’, ‘qtl’, ‘SpATS’, ‘svDialogs’, ‘SemiPar’, ‘robumeta’, ‘CVXR’, ‘DEoptim’, ‘pbmcapply’, ‘netmeta’, ‘geomtextpath’, ‘skimr’, ‘fmsb’, ‘matrixcalc’, ‘bigassertr’, ‘bigparallelr’, ‘nabor’, ‘Gmedian’, ‘mbend’, ‘ppcor’, ‘rmcorr’, ‘openxlsx2’, ‘pixmap’, ‘ICSNP’, ‘moments’, ‘ICSClust’, ‘REPPlab’, ‘opdisDownsampling’, ‘qqconf’, ‘shinyBS’, ‘bootES’, ‘ggsignif’, ‘interactions’, ‘Rmisc’, ‘rpart.plot’, ‘diffviewer’, ‘ggdendro’, ‘GSE’, ‘WWGbook’, ‘RLRsim’, ‘oompaData’, ‘dominanceanalysis’, ‘relaimpo’, ‘CVST’, ‘glasso’, ‘qgraph’, ‘semPlot’, ‘missMDA’, ‘Factoshiny’, ‘cpm’, ‘kSamples’, ‘BWStest’, ‘NSM3’, ‘rsvd’, ‘gfonts’, ‘locatexec’, ‘rvg’, ‘operator.tools’, ‘rtf’, ‘trajectories’, ‘sgeostat’, ‘LearnBayes’, ‘dotCall64’, ‘spam64’, ‘truncdist’, ‘wkb’, ‘rARPACK’, ‘mcmcse’, ‘rngtools’, ‘doMPI’, ‘doRedis’, ‘pkgmaker’, ‘pinp’, ‘adabag’, ‘AmesHousing’, ‘ICEbox’, ‘fastshap’, ‘NeuralNetTools’, ‘fds’, ‘showtextdb’, ‘QCA’, ‘hrbrthemes’, ‘paran’, ‘cocor’, ‘rhub’, ‘denstrip’, ‘equate’, ‘randomNames’, ‘toOrdinal’, ‘SGPdata’, ‘crul’, ‘rredlist’, ‘rotl’, ‘ritis’, ‘worrms’, ‘natserv’, ‘wikitaxa’, ‘conditionz’, ‘vcr’, ‘ggsci’, ‘rstatix’, ‘ROI.plugin.lpsolve’, ‘lpSolveAPI’, ‘ROI.plugin.ecos’, ‘ROI.plugin.alabama’, ‘ROI.plugin.neos’, ‘profileModel’, ‘MNP’, ‘osqp’, ‘misaem’, ‘ISOweek’, ‘RefManageR’, ‘regions’, ‘giscoR’, ‘iBreakDown’, ‘hnp’, ‘plot3Drgl’, ‘Metrics’, ‘ALEPlot’, ‘yaImpute’, ‘text2vec’, ‘ParamHelpers’, ‘BBmisc’, ‘parallelMap’, ‘batchtools’, ‘brnn’, ‘bst’, ‘care’, ‘clusterSim’, ‘cmaes’, ‘crs’, ‘deepnet’, ‘DiceKriging’, ‘elasticnet’, ‘emoa’, ‘evtree’, ‘fda.usc’, ‘FDboost’, ‘frbs’, ‘FSelector’, ‘FSelectorRcpp’, ‘GenSA’, ‘GPfit’, ‘irace’, ‘laGP’, ‘mco’, ‘mldr’, ‘mlrMBO’, ‘mRMRe’, ‘neuralnet’, ‘praznik’, ‘refund’, ‘rFerns’, ‘rotationForest’, ‘RRF’, ‘RSNNS’, ‘rucrdtw’, ‘sda’, ‘smoof’, ‘sparseLDA’, ‘stepPlr’, ‘survAUC’, ‘tgp’, ‘tsfeatures’, ‘wavelets’, ‘lgr’, ‘mlr3measures’, ‘mockr’, ‘MLEcens’, ‘graphlayouts’, ‘sfnetworks’, ‘philentropy’, ‘lmom’, ‘distances’, ‘scclust’, ‘redux’, ‘rush’, ‘apcluster’, ‘LPCM’, ‘Boruta’, ‘carSurv’, ‘stabm’, ‘genalg’, ‘lhs’, ‘quanteda’, ‘stopwords’, ‘bestNormalize’, ‘NMF’, ‘vtreat’, ‘mlflow’, ‘precrec’, ‘BMisc’, ‘DRDID’, ‘svd’, ‘censored’, ‘finetune’, ‘tidyclust’, ‘probably’, ‘fmesher’, ‘fishMod’, ‘visreg’, ‘stddiff’, ‘tableone’, ‘RSGHB’, ‘bgw’, ‘beanplot’, ‘vioplot’, ‘tfestimators’, ‘segmented’, ‘jqr’, ‘dm’, ‘pixarfilms’, ‘adehabitatMA’, ‘CircStats’, ‘RcppCCTZ’, ‘RcppDate’, ‘ggiraph’, ‘proj4’, ‘crsmeta’, ‘PROJ’, ‘glmnetUtils’, ‘pre’, ‘tree’, ‘RPEIF’, ‘RPEGLMEN’, ‘pyinit’, ‘attempt’, ‘attachment’, ‘dockerfiler’, ‘geojson’, ‘gistr’, ‘slider’, ‘geometry’, ‘DiceDesign’, ‘sfd’, ‘C50’, ‘kknn’, ‘LiblineaR’, ‘sparklyr’, ‘modelenv’, ‘butcher’, ‘rngWELL’, ‘ADGofTest’, ‘stabledist’, ‘pspline’, ‘crop’, ‘lcopula’, ‘mev’, ‘mvnormtest’, ‘partitions’, ‘Runuran’, ‘VineCopula’, ‘inum’, ‘pmml’, ‘RWeka’, ‘psychotools’, ‘psychotree’, ‘fBasics’, ‘cvar’, ‘fracdiff’, ‘forecTheta’, ‘rticles’, ‘seasonal’, ‘uroot’, ‘ks’, ‘Rsolnp’, ‘spd’, ‘SkewHyperbolic’, ‘miscTools’, ‘CompQuadForm’, ‘SUMMER’, ‘fastverse’, ‘kit’, ‘dlm’, ‘plot3D’, ‘rbibutils’, ‘gbRd’, ‘pglm’, ‘splm’, ‘mcmc’, ‘NlcOptim’, ‘adagio’, ‘cowplot’, ‘actuar’, ‘geoR’, ‘stabs’, ‘nnls’, ‘BayesX’, ‘kangar00’, ‘mix’, ‘tm’, ‘pez’, ‘picante’, ‘rbenchmark’, ‘tidySEM’, ‘faraway’, ‘dcurver’, ‘SimDesign’, ‘directlabels’, ‘plink’, ‘mirtCAT’, ‘scdhlm’, ‘Bessel’, ‘round’, ‘relimp’, ‘Ecfun’, ‘wooldridge’, ‘varImp’, ‘gnm’, ‘gmodels’, ‘Fahrmeir’, ‘Sleuth2’, ‘cba’, ‘mstate’, ‘muhaz’, ‘flexsurvcure’, ‘survminer’, ‘lava’, ‘Exact’, ‘BlakerCI’, ‘revdbayes’, ‘networkD3’, ‘treemap’, ‘visNetwork’, ‘DiagrammeRsvg’, ‘riskRegression’, ‘timereg’, ‘bnlearn’, ‘KernelKnn’, ‘smotefamily’, ‘slackr’, ‘RPushbullet’, ‘telegram’, ‘rsyslog’, ‘txtq’, ‘botor’, ‘syslognet’, ‘etm’, ‘demography’, ‘popEpi’, ‘benchr’, ‘BayesFactor’, ‘bayesQR’, ‘blavaan’, ‘effectsize’, ‘ordbetareg’, ‘see’, ‘energy’, ‘pgirmess’, ‘Vdgraph’, ‘conf.design’, ‘DoE.base’, ‘FrF2’, ‘unmarked’, ‘fitdistrplus’, ‘maxlike’, ‘R2OpenBUGS’, ‘jagsUI’, ‘gap.datasets’, ‘DOT’, ‘calibrate’, ‘genetics’, ‘haplo.stats’, ‘magic’, ‘manhattanly’, ‘meta’, ‘metafor’, ‘pedigree’, ‘pedigreemm’, ‘valr’, ‘rcdd’, ‘Infusion’, ‘IsoriX’, ‘blackbox’, ‘ROI.plugin.glpk’, ‘rsae’, ‘multilevel’, ‘agridat’, ‘censReg’, ‘cgam’, ‘clubSandwich’, ‘cplm’, ‘epiR’, ‘feisr’, ‘fungible’, ‘gmnl’, ‘httptest2’, ‘JM’, ‘lavaSearch2’, ‘merTools’, ‘metaBMA’, ‘metadat’, ‘metaplus’, ‘nestedLogit’, ‘panelr’, ‘PROreg’, ‘serp’, ‘svylme’, ‘bigutilsr’, ‘correlation’, ‘ICS’, ‘ICSOutlier’, ‘ISLR’, ‘multimode’, ‘qqplotr’, ‘rempsyc’, ‘candisc’, ‘corrgram’, ‘animation’, ‘mvinfluence’, ‘archdata’, ‘qqtest’, ‘fastGHQuad’, ‘lqmm’, ‘rlme’, ‘lemon’, ‘ggh4x’, ‘robustvarComp’, ‘BayesFM’, ‘cAIC4’, ‘ClassDiscovery’, ‘domir’, ‘drc’, ‘DRR’, ‘EGAnet’, ‘factoextra’, ‘FactoMineR’, ‘lm.beta’, ‘mfx’, ‘NbClust’, ‘nFactors’, ‘PCDimension’, ‘PMCMRplus’, ‘sparsepca’, ‘WRS2’, ‘gridGraphics’, ‘gdtools’, ‘doconv’, ‘equatags’, ‘officedown’, ‘devEMF’, ‘formula.tools’, ‘psychTools’, ‘Rcsdp’, ‘sftime’, ‘tkrplot’, ‘alphahull’, ‘spatialreg’, ‘spam’, ‘rgeoda’, ‘ggplot2movies’, ‘changepoint’, ‘KFAS’, ‘MSwM’, ‘lfda’, ‘Brobdingnag’, ‘runjags’, ‘nimble’, ‘doRNG’, ‘future.callr’, ‘doFuture’, ‘evd’, ‘glba’, ‘binom’, ‘LaplacesDemon’, ‘skellam’, ‘triangle’, ‘RcppZiggurat’, ‘pdp’, ‘vip’, ‘fda’, ‘beeswarm’, ‘sysfonts’, ‘showtext’, ‘BRugs’, ‘admisc’, ‘rpf’, ‘snowfall’, ‘umx’, ‘ifaTools’, ‘mi’, ‘rpanel’, ‘sjstats’, ‘stringdist’, ‘purrrlyr’, ‘cmm’, ‘SGP’, ‘taxize’, ‘webutils’, ‘swagger’, ‘coro’, ‘geojsonsf’, ‘redoc’, ‘rapidoc’, ‘jtools’, ‘ggpubr’, ‘ggpol’, ‘ez’, ‘ggResidpanel’, ‘profmem’, ‘enrichwith’, ‘detectseparation’, ‘brglm’, ‘mbrglm’, ‘extraoperators’, ‘chk’, ‘mvnfast’, ‘WeightIt’, ‘twang’, ‘twangContinuous’, ‘Matching’, ‘ebal’, ‘CBPS’, ‘designmatch’, ‘optweight’, ‘MatchThem’, ‘cem’, ‘sbw’, ‘eurostat’, ‘ISOcodes’, ‘scoringRules’, ‘DALEX’, ‘auditor’, ‘h2o’, ‘iml’, ‘ingredients’, ‘lime’, ‘localModel’, ‘mlr’, ‘mlr3’, ‘stacks’, ‘interval’, ‘PairedData’, ‘fabricatr’, ‘randomizr’, ‘prediction’, ‘stargazer’, ‘ggparty’, ‘ggraph’, ‘Rfast’, ‘aplore3’, ‘GLMsData’, ‘gld’, ‘plotfunctions’, ‘RcppProgress’, ‘rgenoud’, ‘quickmatch’, ‘highs’, ‘Rglpk’, ‘Rsymphony’, ‘bbotk’, ‘mlr3cluster’, ‘mlr3data’, ‘mlr3filters’, ‘mlr3fselect’, ‘mlr3hyperband’, ‘mlr3learners’, ‘mlr3mbo’, ‘mlr3misc’, ‘mlr3pipelines’, ‘mlr3tuning’, ‘mlr3tuningspaces’, ‘mlr3viz’, ‘paradox’, ‘gganimate’, ‘report’, ‘did’, ‘gtExtras’, ‘wesanderson’, ‘rlemon’, ‘RItools’, ‘readstata13’, ‘survPen’, ‘infer’, ‘tune’, ‘workflowsets’, ‘yardstick’, ‘Ckmeans.1d.dp’, ‘float’, ‘sdmTMB’, ‘cardx’, ‘smd’, ‘apollo’, ‘fastDummies’, ‘mixl’, ‘clusterGeneration’, ‘sasr’, ‘ggsurvfit’, ‘janitor’, ‘gginnards’, ‘vipor’, ‘permute’, ‘tfruns’, ‘zeallot’, ‘tfdatasets’, ‘irlba’, ‘weights’, ‘prefmod’, ‘MPsychoR’, ‘config’, ‘tfautograph’, ‘keras3’, ‘seqinr’, ‘sn’, ‘GetoptLong’, ‘leafgl’, ‘colourvalues’, ‘googlePolylines’, ‘jsonify’, ‘sfheaders’, ‘geometries’, ‘interleave’, ‘rapidjsonr’, ‘spatialwidget’, ‘googleway’, ‘constructive’, ‘tensor’, ‘fftw’, ‘relations’, ‘ozmaps’, ‘areal’, ‘CFtime’, ‘intervals’, ‘adehabitatLT’, ‘cshapes’, ‘googleVis’, ‘nanotime’, ‘packcircles’, ‘reproj’, ‘logcondens’, ‘rules’, ‘plotmo’, ‘ROSE’, ‘tth’, ‘RPESE’, ‘RobStatTM’, ‘TTR’, ‘downloader’, ‘golem’, ‘thematic’, ‘rlist’, ‘rjson’, ‘geojsonio’, ‘fontBitstreamVera’, ‘fontLiberation’, ‘colourpicker’, ‘clock’, ‘gower’, ‘hardhat’, ‘ipred’, ‘ddalpha’, ‘dials’, ‘kernlab’, ‘modeldata’, ‘parsnip’, ‘RANN’, ‘RcppRoll’, ‘rsample’, ‘RSpectra’, ‘splines2’, ‘workflows’, ‘R2HTML’, ‘spacefillr’, ‘randtoolbox’, ‘copula’, ‘partykit’, ‘fGarch’, ‘forecast’, ‘ineq’, ‘longmemo’, ‘mlogit’, ‘np’, ‘ROCR’, ‘rugarch’, ‘sampleSelection’, ‘systemfit’, ‘truncreg’, ‘urca’, ‘vars’, ‘carData’, ‘alr4’, ‘survey’, ‘collapse’, ‘maxLik’, ‘Rdpack’, ‘pder’, ‘MCMCpack’, ‘pkgKitten’, ‘pracma’, ‘setRNG’, ‘BB’, ‘ucminf’, ‘lbfgsb3c’, ‘lbfgs’, ‘subplex’, ‘marqLevAlg’, ‘doBy’, ‘flexmix’, ‘gamair’, ‘gee’, ‘mboost’, ‘mclust’, ‘rmeta’, ‘wordcloud’, ‘HSAUR2’, ‘tweedie’, ‘phylolm’, ‘phyr’, ‘gsl’, ‘piecewiseSEM’, ‘nonnest2’, ‘mirt’, ‘lmeInfo’, ‘rrcov’, ‘lokern’, ‘Rmpfr’, ‘gmp’, ‘qvcalc’, ‘glmmML’, ‘Ecdat’, ‘party’, ‘vcdExtra’, ‘penalized’, ‘proxy’, ‘slam’, ‘TSA’, ‘quadprog’, ‘survPresmooth’, ‘coneproj’, ‘polynom’, ‘orthopolynom’, ‘eha’, ‘flexsurv’, ‘prodlim’, ‘exact2x2’, ‘exactci’, ‘bpcp’, ‘perm’, ‘ssanv’, ‘bootstrap’, ‘gamlss.dist’, ‘distributions3’, ‘data.tree’, ‘DiagrammeR’, ‘pec’, ‘imbalance’, ‘sylly’, ‘sylly.en’, ‘logger’, ‘descr’, ‘reshape’, ‘memisc’, ‘Epi’, ‘cubature’, ‘alpaca’, ‘bayestestR’, ‘compositions’, ‘multcompView’, ‘rsm’, ‘emdbook’, ‘AICcmodavg’, ‘gap’, ‘qgam’, ‘mgcViz’, ‘spaMM’, ‘insight’, ‘performance’, ‘poLCA’, ‘heplots’, ‘betareg’, ‘robustlmm’, ‘parameters’, ‘patchwork’, ‘ggstance’, ‘flextable’, ‘ftExtra’, ‘officer’, ‘openxlsx’, ‘psych’, ‘RcppGSL’, ‘expint’, ‘gstat’, ‘rnaturalearthdata’, ‘leaflet.providers’, ‘RJSONIO’, ‘orientlib’, ‘misc3d’, ‘plotrix’, ‘tripack’, ‘alphashape3d’, ‘js’, ‘manipulateWidget’, ‘spdep’, ‘ggridges’, ‘ggfortify’, ‘mnormt’, ‘pbivnorm’, ‘bridgesampling’, ‘future.apply’, ‘nleqslv’, ‘projpred’, ‘RWiener’, ‘rtdists’, ‘extraDistr’, ‘arm’, ‘optimParallel’, ‘corpcor’, ‘tensorA’, ‘combinat’, ‘bayesm’, ‘msm’, ‘SuppDists’, ‘speedglm’, ‘distributional’, ‘gbm’, ‘ggdist’, ‘rjags’, ‘R2WinBUGS’, ‘lobstr’, ‘polycor’, ‘ROI’, ‘OpenMx’, ‘sem’, ‘semTools’, ‘Rmpi’, ‘pbv’, ‘sm’, ‘datawizard’, ‘sjmisc’, ‘sjPlot’, ‘snakecase’, ‘proto’, ‘mipfp’, ‘rmutil’, ‘broman’, ‘GPArotation’, ‘WrightMap’, ‘dygraphs’, ‘gtools’, ‘shinythemes’, ‘threejs’, ‘PKI’, ‘plumber’, ‘afex’, ‘aod’, ‘bench’, ‘bife’, ‘brglm2’, ‘brmsmargins’, ‘causaldata’, ‘clarify’, ‘cjoint’, ‘cobalt’, ‘countrycode’, ‘crch’, ‘DALEXtra’, ‘DCchoice’, ‘dbarts’, ‘dfidx’, ‘equivalence’, ‘estimatr’, ‘fmeffects’, ‘fwb’, ‘gam’, ‘ggokabeito’, ‘glmtoolbox’, ‘glmx’, ‘itsadug’, ‘ivreg’, ‘logistf’, ‘MatchIt’, ‘mclogit’, ‘missRanger’, ‘mlr3verse’, ‘modelbased’, ‘modelsummary’, ‘optmatch’, ‘poorman’, ‘Rchoice’, ‘REndo’, ‘rstpm2’, ‘scam’, ‘tictoc’, ‘tidymodels’, ‘titanic’, ‘tsModel’, ‘xgboost’, ‘altdoc’, ‘extrafontdb’, ‘Rttf2pt1’, ‘fontcm’, ‘cyclocomp’, ‘xmlparsedata’, ‘patrick’, ‘cards’, ‘cmprsk’, ‘ggeffects’, ‘gtsummary’, ‘logitr’, ‘margins’, ‘mmrm’, ‘multgee’, ‘tidycmprsk’, ‘som’, ‘gclus’, ‘tweenr’, ‘concaveman’, ‘latex2exp’, ‘igraphdata’, ‘questionr’, ‘statnet.common’, ‘rJava’, ‘ggpp’, ‘prettydoc’, ‘ggbeeswarm’, ‘shades’, ‘gridtext’, ‘ca’, ‘qap’, ‘registry’, ‘TSP’, ‘vegan’, ‘dbscan’, ‘GA’, ‘keras’, ‘Rtsne’, ‘smacof’, ‘tensorflow’, ‘umap’, ‘expm’, ‘phangorn’, ‘caTools’, ‘r2d2’, ‘prabclus’, ‘diptest’, ‘tclust’, ‘pdfCluster’, ‘GlobalOptions’, ‘gridBase’, ‘bezier’, ‘spData’, ‘NISTunits’, ‘measurements’, ‘leafem’, ‘leafpop’, ‘satellite’, ‘leaflet.extras2’, ‘leafsync’, ‘mapdeck’, ‘plainview’, ‘DBItest’, ‘RMySQL’, ‘rasterVis’, ‘fields’, ‘exactextractr’, ‘spatstat.data’, ‘spatstat.univar’, ‘spatstat.explore’, ‘spatstat.model’, ‘fftwtools’, ‘spatstat.sparse’, ‘goftest’, ‘locfit’, ‘OpenStreetMap’, ‘PCICt’, ‘RNetCDF’, ‘clue’, ‘cubble’, ‘cubelyr’, ‘FNN’, ‘ncdfgeom’, ‘ncmeta’, ‘spacetime’, ‘tsibble’, ‘tmaptools’, ‘widgetframe’, ‘rmapshaper’, ‘cartogram’, ‘osmdata’, ‘ModelMetrics’, ‘pROC’, ‘BradleyTerry2’, ‘Cubist’, ‘earth’, ‘ellipse’, ‘fastICA’, ‘klaR’, ‘mda’, ‘MLmetrics’, ‘pamr’, ‘spls’, ‘superpc’, ‘themis’, ‘exams’, ‘unix’, ‘PerformanceAnalytics’, ‘fTrading’, ‘quantmod’, ‘bsicons’, ‘bs4Dash’, ‘packer’, ‘prettycode’, ‘highcharter’, ‘V8’, ‘decor’, ‘fontquiver’, ‘shinyAce’, ‘shinydisconnect’, ‘recipes’, ‘R.methodsS3’, ‘R.oo’, ‘R.cache’, ‘R.devices’, ‘ascii’, ‘qrng’, ‘numDeriv’, ‘trtf’, ‘ATR’, ‘vcd’, ‘AER’, ‘car’, ‘geepack’, ‘multiwayvcov’, ‘pcse’, ‘plm’, ‘pscl’, ‘strucchange’, ‘minqa’, ‘nloptr’, ‘RcppEigen’, ‘MEMSS’, ‘mlmRev’, ‘optimx’, ‘gamm4’, ‘pbkrtest’, ‘HSAUR3’, ‘dfoptim’, ‘statmod’, ‘rr2’, ‘semEff’, ‘merDeriv’, ‘DEoptimR’, ‘robust’, ‘fit.models’, ‘MPV’, ‘reshape2’, ‘sfsmisc’, ‘catdata’, ‘skewt’, ‘libcoin’, ‘matrixStats’, ‘modeltools’, ‘e1071’, ‘dynlm’, ‘bdsmatrix’, ‘kinship2’, ‘mratios’, ‘mlt’, ‘variables’, ‘basefun’, ‘mlbench’, ‘SparseGrid’, ‘alabama’, ‘ordinalCont’, ‘mlt.docreg’, ‘ordinal’, ‘asht’, ‘gamlss’, ‘randomForestSRC’, ‘dreamerr’, ‘stringmagic’, ‘pander’, ‘lfe’, ‘emmeans’, ‘estimability’, ‘TMB’, ‘bbmle’, ‘coda’, ‘DHARMa’, ‘MuMIn’, ‘effects’, ‘dotwhisker’, ‘texreg’, ‘huxtable’, ‘mvabund’, ‘blme’, ‘mapdata’, ‘sp’, ‘rnaturalearth’, ‘ncdf4’, ‘leaflet’, ‘MatrixModels’, ‘rgl’, ‘logspline’, ‘nor1mix’, ‘conquer’, ‘loo’, ‘RcppParallel’, ‘StanHeaders’, ‘bayesplot’, ‘shape’, ‘lars’, ‘jomo’, ‘Amelia’, ‘lavaan’, ‘brms’, ‘gamlss.data’, ‘GLMMadaptive’, ‘lmerTest’, ‘MCMCglmm’, ‘mediation’, ‘posterior’, ‘rstanarm’, ‘rstantools’, ‘R2jags’, ‘carrier’, ‘mitools’, ‘RcppArmadillo’, ‘BIFIEsurvey’, ‘CDM’, ‘inline’, ‘MBESS’, ‘mdmb’, ‘pls’, ‘sirt’, ‘sjlabelled’, ‘synthpop’, ‘TAM’, ‘QuickJSR’, ‘shinystan’, ‘rsconnect’, ‘servr’, ‘tufte’, ‘r2rtf’, ‘marginaleffects’, ‘pandoc’, ‘quarto’, ‘tinysnapshot’, ‘extrafont’, ‘lintr’, ‘ggstats’, ‘broom.helpers’, ‘chemometrics’, ‘geosphere’, ‘ggforce’, ‘igraph’, ‘intergraph’, ‘labelled’, ‘network’, ‘scagnostics’, ‘sna’, ‘alluvial’, ‘babynames’, ‘ggrepel’, ‘ggfittext’, ‘seriation’, ‘ape’, ‘gplots’, ‘heatmaply’, ‘dynamicTreeCut’, ‘pvclust’, ‘corrplot’, ‘DendSer’, ‘fpc’, ‘circlize’, ‘classInt’, ‘s2’, ‘units’, ‘nanoarrow’, ‘lwgeom’, ‘mapview’, ‘odbc’, ‘pbapply’, ‘pool’, ‘raster’, ‘RPostgreSQL’, ‘spatstat’, ‘spatstat.geom’, ‘spatstat.random’, ‘spatstat.linnet’, ‘spatstat.utils’, ‘stars’, ‘tmap’, ‘wk’, ‘repr’, ‘caret’, ‘doMC’, ‘VGAMdata’, ‘RODBC’, ‘av’, ‘gapminder’, ‘gifski’, ‘minty’, ‘Deriv’, ‘Ryacas’, ‘polyclip’, ‘mondate’, ‘stinepack’, ‘timeDate’, ‘timeSeries’, ‘tis’, ‘tseries’, ‘xts’, ‘reactR’, ‘tippy’, ‘prismatic’, ‘harrypotter’, ‘oompaBase’, ‘palr’, ‘pals’, ‘scico’, ‘AsioHeaders’, ‘rootSolve’, ‘minpack.lm’, ‘diagram’, ‘gettz’, ‘fresh’, ‘waiter’, ‘styler’, ‘shinyEffects’, ‘shinyjqui’, ‘debugme’, ‘lpSolve’, ‘asciicast’, ‘svglite’, ‘shinyjs’, ‘whoami’, ‘palmerpenguins’, ‘R.rsp’, ‘mvtnorm’, ‘TH.data’, ‘sandwich’, ‘lme4’, ‘robustbase’, ‘coin’, ‘lmtest’, ‘coxme’, ‘SimComp’, ‘ISwR’, ‘tram’, ‘fixest’, ‘glmmTMB’, ‘egg’, ‘hexbin’, ‘dichromat’, ‘mapproj’, ‘maps’, ‘terra’, ‘quantreg’, ‘SparseM’, ‘rmsb’, ‘glmnet’, ‘mitml’, ‘broom.mixed’, ‘furrr’, ‘miceadds’, ‘pan’, ‘parallelly’, ‘ranger’, ‘randomForest’, ‘rstan’, ‘bookdown’, ‘formatters’, ‘tinytable’, ‘ggthemes’, ‘GGally’, ‘ggalluvial’, ‘Cairo’, ‘listviewer’, ‘dendextend’, ‘sf’, ‘IRdisplay’, ‘plotlyGeoAssets’, ‘rsvg’, ‘doParallel’, ‘foreach’, ‘iterators’, ‘itertools’, ‘VGAMextra’, ‘biglm’, ‘magick’, ‘formattable’, ‘webshot2’, ‘writexl’, ‘R.utils’, ‘hexView’, ‘pzfx’, ‘readODS’, ‘rmatio’, ‘nanoparquet’, ‘jpeg’, ‘interp’, ‘deldir’, ‘zoo’, ‘bigD’, ‘juicyjuice’, ‘reactable’, ‘katex’, ‘paletteer’, ‘RApiSerialize’, ‘stringfish’, ‘BH’, ‘sodium’, ‘websocket’, ‘scatterplot3d’, ‘FME’, ‘anytime’, ‘shinydashboard’, ‘shinydashboardPlus’, ‘parsedate’, ‘webdriver’, ‘flexdashboard’, ‘listenv’, ‘RhpcBLASctl’, ‘filelock’, ‘pingr’, ‘pkgcache’, ‘pkgdepends’, ‘pkgsearch’, ‘RcppTOML’, ‘here’, ‘png’, ‘brotli’, ‘multcomp’, ‘RUnit’, ‘gridExtra’, ‘htmlTable’, ‘viridis’, ‘Formula’, ‘qreport’, ‘acepack’, ‘chron’, ‘rms’, ‘mice’, ‘tables’, ‘plotly’, ‘plyr’, ‘VGAM’, ‘leaps’, ‘pcaPP’, ‘polspline’, ‘abind’, ‘kableExtra’, ‘rio’, ‘latticeExtra’, ‘gt’, ‘sparkline’, ‘qs’, ‘getPass’, ‘keyring’, ‘safer’, ‘htm2txt’, ‘qpdf’, ‘webp’, ‘tesseract’, ‘chromote’, ‘globals’, ‘deSolve’, ‘shinyWidgets’, ‘shinytest’, ‘shinyvalidate’, ‘showimage’, ‘vdiffr’, ‘webshot’, ‘crosstalk’, ‘future’, ‘packrat’, ‘pak’, ‘reticulate’, ‘webfakes’, ‘RCurl’, ‘fastmatch’, ‘microbenchmark’, ‘tinytest’, ‘Hmisc’, ‘pdftools’, ‘shinytest2’, ‘sortable’, ‘testit’, ‘DT’, ‘mockery’, ‘bitops’
[snip]
```

</details> 

<details><summary>Output with this patch</summary>

```
chrisb@ulmus pecan % docker run --rm -it -v ${PWD}:/work -w /work rocker/tidyverse:4.4 ./scripts/confirm_deps.R models/stics TRUE

Downloading GitHub repo SticsRPacks/SticsRFiles@HEAD
Installing 2 packages: xslt, XML
[snip]
```

</details> 

## Motivation and Context

We've had periodic reports of `make` on a fresh system running for inordinate amounts of time and installing multiple gigabytes of R packages with no obvious connection to any known PEcAn dependency,  but had not previously been able to track down the cause. 

Thanks to @robkooper for spotting a reprex-sized example and tracing the problem into install_deps.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
