### PR TITLE
WIP: use pak instead of confirm_deps for dependency installation

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -17,7 +17,6 @@ ARG PECAN_GIT_DATE="unknown"
 # copy folders
 COPY Makefile Makefile.depends /pecan/
 COPY scripts/time.sh /pecan/scripts/time.sh
-COPY scripts/confirm_deps.R /pecan/scripts/confirm_deps.R
 COPY base     /pecan/base/
 COPY modules  /pecan/modules/
 COPY models   /pecan/models/

--- a/scripts/confirm_deps.R
+++ b/scripts/confirm_deps.R
@@ -4,7 +4,8 @@
 # ./confirm_deps path/to/package [dependencies]
 # Usage as a function: source in and use as documented below
 
-
+# NOTE: Superseded.
+# `pak::local_install_deps(..., upgrade = FALSE)` now does this nicely.
 
 #' Check whether a local package's dependencies are already satisfied
 #'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
EXPERIMENTAL, NEEDS TESTING: Use pak::local_install_deps() instead of our confirm_deps script. 

Before merging, need to show that local_install_deps (1) behaves the same as confirm_deps with respect to installation behavior, and (2) does not query overeagerly for updates to dependencies. Recall that the original impetus for `confirm_deps` was `devtools::install_deps` making too many queries to remote repos that we'd already checked earlier in the process. My read of the documentation suggests we should _expect_ pak to be better about this, but I have not yet checked. Probably the easiest way to check would be by running the install process inside a container instrumented to monitor outgoing IP requests.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
