### PR TITLE
Add Doxygen to sipnet action

### DIFF
--- a/.github/workflows/sipnet.yml
+++ b/.github/workflows/sipnet.yml
@@ -38,7 +38,7 @@ jobs:
 
     # install additional tools needed
     - name: install utils
-      run: apt-get update && apt-get install -y doxygen postgresql-client qpdf
+      run: apt-get update && apt-get install -y postgresql-client qpdf
     - name: install new dependencies
       run: Rscript scripts/generate_dependencies.R && cd docker/depends && Rscript pecan.depends.R
 
@@ -58,7 +58,7 @@ jobs:
     - name: install sipnet
       run: |
         cd ${GITHUB_WORKSPACE}/sipnet
-        make
+        make sipnet
 
     # compile PEcAn code
     - name: build

--- a/.github/workflows/sipnet.yml
+++ b/.github/workflows/sipnet.yml
@@ -38,7 +38,7 @@ jobs:
 
     # install additional tools needed
     - name: install utils
-      run: apt-get update && apt-get install -y postgresql-client qpdf
+      run: apt-get update && apt-get install -y doxygen postgresql-client qpdf
     - name: install new dependencies
       run: Rscript scripts/generate_dependencies.R && cd docker/depends && Rscript pecan.depends.R
 


### PR DESCRIPTION
Fixes build error https://github.com/PecanProject/pecan/actions/runs/12740766141/job/35506419353#step:11:43

By installing Doxygen. Similar to this commit to the SIPNET repository. https://github.com/PecanProject/sipnet/commit/f379cb9a95f5790a465aa15bac7d7ce26170c190

Perhaps a 'cleaner' option (so that PEcAn tests don't depend on SIPNET's build process would be for SIPNET's action to automatically compile and store a binary that can later be accessed by this GHA. But this is the easiest, quickest fix.