### PR TITLE
SM_CDS: fix for "Error in do_next$reply : $ operator is invalid for atomic vectors"

### DIFF
--- a/modules/data.land/R/download.SM_CDS.R
+++ b/modules/data.land/R/download.SM_CDS.R
@@ -88,7 +88,7 @@ download.SM_CDS <- function(outfolder, time.points, overwrite = FALSE, auto.crea
     if (file.exists(fname) && !overwrite) {
       PEcAn.logger::logger.warn(glue::glue(
         "File `{fname}` already exists, and `overwrite` is FALSE. ",
-        "Skipping to next variable."
+        "Skipping to next date."
       ))
       next
     }
@@ -105,13 +105,11 @@ download.SM_CDS <- function(outfolder, time.points, overwrite = FALSE, auto.crea
         'type_of_record'= 'cdr',
         'version'= 'v202212'
       ),
-      'download.zip'
+      fname.zip
     )))) {
       Sys.sleep(10)
       PEcAn.logger::logger.info("Encounter error! Will try download in 10 seconds.")
     }
-    #download file to local.
-    utils::download.file(do_next$reply$location, destfile = fname.zip)
     #unzip file.
     unzipPath <- utils::unzip(zipfile = fname.zip, exdir = outfolder)
     #rename unziped file.

--- a/modules/data.land/R/download.SM_CDS.R
+++ b/modules/data.land/R/download.SM_CDS.R
@@ -56,32 +56,6 @@ download.SM_CDS <- function(outfolder, time.points, overwrite = FALSE, auto.crea
       conditionMessage(e)
     )
   })
-  #define function for building credential file.
-  #maybe as a helper function.
-  getnetrc <- function (dl_dir) {
-    netrc <- file.path(dl_dir, ".cdsapirc")
-    if (file.exists(netrc) == FALSE ||
-        any(grepl("https://cds.climate.copernicus.eu/api/v2",
-                  readLines(netrc))) == FALSE) {
-      netrc_conn <- file(netrc)
-      writeLines(c(
-        sprintf(
-          "url: %s",
-          getPass::getPass(msg = "Enter URL from the following link \n (https://cds.climate.copernicus.eu/api-how-to#install-the-cds-api-key):")
-        ),
-        sprintf(
-          "key: %s",
-          getPass::getPass(msg = "Enter KEY from the following link \n (https://cds.climate.copernicus.eu/api-how-to#install-the-cds-api-key):")
-        )
-      ),
-      netrc_conn)
-      close(netrc_conn)
-      message(
-        "A netrc file with your CDS Login credentials was stored in the output directory "
-      )
-    }
-    return(netrc)
-  }
   #check if the token exists for the cdsapi.
   if (!file.exists(file.path(Sys.getenv("HOME"), ".cdsapirc")) & auto.create.key) {
     getnetrc(Sys.getenv("HOME"))
@@ -149,4 +123,34 @@ download.SM_CDS <- function(outfolder, time.points, overwrite = FALSE, auto.crea
     utils::setTxtProgressBar(pb, pbi)
   }
   file.names
+}
+
+
+
+
+
+# helper function for building credential file.
+getnetrc <- function(dl_dir) {
+  netrc <- file.path(dl_dir, ".cdsapirc")
+  if (file.exists(netrc) == FALSE ||
+      any(grepl("https://cds.climate.copernicus.eu/api/v2",
+                readLines(netrc))) == FALSE) {
+    netrc_conn <- file(netrc)
+    writeLines(c(
+      sprintf(
+        "url: %s",
+        getPass::getPass(msg = "Enter URL from the following link \n (https://cds.climate.copernicus.eu/api-how-to#install-the-cds-api-key):")
+      ),
+      sprintf(
+        "key: %s",
+        getPass::getPass(msg = "Enter KEY from the following link \n (https://cds.climate.copernicus.eu/api-how-to#install-the-cds-api-key):")
+      )
+    ),
+    netrc_conn)
+    close(netrc_conn)
+    message(
+      "A netrc file with your CDS Login credentials was stored in the output directory "
+    )
+  }
+  return(netrc)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
looks like the cdsapi `retrieve()` method already downloads the file, no separate processing of the reply needed.

Also moved `getnetrc` helper out of the main SM_CDS function definition for clarity.

For a further refinement we could probably speed up retrieval quite a bit by refactoring to request multiple days at once, but that can be a separate PR; I think the trickiest part there would be the need to rename multiple NCs out the downloaded zip archive instead of assuming it contains only one file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
