### PR TITLE
fix(docker): linux/amd64 platform issue in docker compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,6 +3,7 @@ services:
   # webserver to handle all traffic. This can use let's encrypt to generate a SSL cert.
   traefik:
     image: "traefik:v2.9"
+    platform: linux/amd64
     command:
       - --log.level=INFO
       - --api=true
@@ -62,6 +63,7 @@ services:
   # postgresql + postgis to hold all the data
   postgres:
     image: mdillon/postgis:9.5
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -73,6 +75,7 @@ services:
   # ----------------------------------------------------------------------
   bety:
     image: pecan/bety:${BETY_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -97,6 +100,7 @@ services:
   # PEcAn documentation as well as PEcAn home page
   docs:
     image: pecan/docs:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -109,6 +113,7 @@ services:
   pecan:
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/web:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -132,6 +137,7 @@ services:
   monitor:
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/monitor:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -152,6 +158,7 @@ services:
   executor:
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/executor:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -174,6 +181,7 @@ services:
   basgra:
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/model-basgra-basgra_n_v1.0:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -188,6 +196,7 @@ services:
   sipnet:
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/model-sipnet-git:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -202,6 +211,7 @@ services:
   ed2:
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/model-ed2-2.2.0:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -216,6 +226,7 @@ services:
   maespa:
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/model-maespa-git:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -230,6 +241,7 @@ services:
   biocro:
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/model-biocro-0.95:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -246,6 +258,7 @@ services:
   api:
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/api:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -207,6 +207,7 @@ services:
   ed2:
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/model-ed2-2.2.0:${PECAN_VERSION:-latest}
+    restart: unless-stopped
     platform: linux/amd64
     networks:
       - pecan

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,7 +3,6 @@ services:
   # webserver to handle all traffic. This can use let's encrypt to generate a SSL cert.
   traefik:
     image: "traefik:v2.9"
-    platform: linux/amd64
     command:
       - --log.level=INFO
       - --api=true
@@ -63,7 +62,6 @@ services:
   # postgresql + postgis to hold all the data
   postgres:
     image: mdillon/postgis:9.5
-    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -113,7 +111,6 @@ services:
   pecan:
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/web:${PECAN_VERSION:-latest}
-    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -137,7 +134,6 @@ services:
   monitor:
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/monitor:${PECAN_VERSION:-latest}
-    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -212,7 +208,6 @@ services:
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/model-ed2-2.2.0:${PECAN_VERSION:-latest}
     platform: linux/amd64
-    restart: unless-stopped
     networks:
       - pecan
     environment:
@@ -241,7 +236,6 @@ services:
   biocro:
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/model-biocro-0.95:${PECAN_VERSION:-latest}
-    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -258,7 +252,6 @@ services:
   api:
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/api:${PECAN_VERSION:-latest}
-    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -433,3 +433,5 @@ volumes:
   rabbitmq:
   pecan:
   rstudio:
+
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   traefik:
     hostname: traefik
     image: "traefik:v2.9"
+    platform: linux/amd64
     command:
       - --log.level=INFO
       - --api=true
@@ -68,6 +69,7 @@ services:
   postgres:
     hostname: postgres
     image: mdillon/postgis:9.5
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -85,6 +87,7 @@ services:
   bety:
     hostname: bety
     image: pecan/bety:${BETY_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -114,6 +117,7 @@ services:
   rstudio:
     hostname: rstudio
     image: pecan/base:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     command: /work/rstudio.sh
     restart: unless-stopped
     networks:
@@ -158,6 +162,7 @@ services:
   docs:
     hostname: docs
     image: pecan/docs:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -176,6 +181,7 @@ services:
     hostname: pecan-web
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/web:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -207,6 +213,7 @@ services:
     hostname: monitor
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/monitor:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -236,6 +243,7 @@ services:
     hostname: executor
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/executor:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -260,6 +268,7 @@ services:
     hostname: fates
     user: "${UID:-1001}:${GID:-1001}"
     image: ghcr.io/noresmhub/ctsm-api:latest
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -276,6 +285,7 @@ services:
     hostname: basgra
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/model-basgra-basgra_n_v1.0:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -292,6 +302,7 @@ services:
     hostname: sipnet-git
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/model-sipnet-git:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -308,6 +319,7 @@ services:
     hostname: ed2-2_2_0
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/model-ed2-2.2.0:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -324,6 +336,7 @@ services:
     hostname: maespa-git
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/model-maespa-git:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -340,6 +353,7 @@ services:
     hostname: biocro-0_95
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/model-biocro-0.95:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -358,6 +372,7 @@ services:
   dbsync:
     hostname: dbsync
     image: pecan/shiny-dbsync:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -382,6 +397,7 @@ services:
     hostname: api
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/api:${PECAN_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -427,4 +443,3 @@ volumes:
   rabbitmq:
   pecan:
   rstudio:
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   traefik:
     hostname: traefik
     image: "traefik:v2.9"
-    platform: linux/amd64
     command:
       - --log.level=INFO
       - --api=true
@@ -69,7 +68,6 @@ services:
   postgres:
     hostname: postgres
     image: mdillon/postgis:9.5
-    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -87,7 +85,6 @@ services:
   bety:
     hostname: bety
     image: pecan/bety:${BETY_VERSION:-latest}
-    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -117,7 +114,6 @@ services:
   rstudio:
     hostname: rstudio
     image: pecan/base:${PECAN_VERSION:-latest}
-    platform: linux/amd64
     command: /work/rstudio.sh
     restart: unless-stopped
     networks:
@@ -181,7 +177,6 @@ services:
     hostname: pecan-web
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/web:${PECAN_VERSION:-latest}
-    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -268,7 +263,6 @@ services:
     hostname: fates
     user: "${UID:-1001}:${GID:-1001}"
     image: ghcr.io/noresmhub/ctsm-api:latest
-    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -319,7 +313,6 @@ services:
     hostname: ed2-2_2_0
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/model-ed2-2.2.0:${PECAN_VERSION:-latest}
-    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -336,7 +329,6 @@ services:
     hostname: maespa-git
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/model-maespa-git:${PECAN_VERSION:-latest}
-    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -372,7 +364,6 @@ services:
   dbsync:
     hostname: dbsync
     image: pecan/shiny-dbsync:${PECAN_VERSION:-latest}
-    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan
@@ -397,7 +388,6 @@ services:
     hostname: api
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/api:${PECAN_VERSION:-latest}
-    platform: linux/amd64
     restart: unless-stopped
     networks:
       - pecan


### PR DESCRIPTION
fixes #3415 
## Description  
Fix Docker container pull errors on `linux/arm64/v8`.  

## Motivation and Context  
Some images lack `arm64` support; forcing `amd64` works but breaks RabbitMQ.  

## Review Time Estimate  
- [ ] Immediately  
- [ ] Within one week  
- [ ] When possible  

## Types of changes  
- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  

## Checklist  
- [ ] Requires doc update  
- [ ] Added to CITATION.cff  
- [ ] Updated CHANGELOG  
- [ ] Updated docs  
- [ ] Read **CONTRIBUTING**  
- [ ] Added tests  
- [x] All tests passed