### PR TITLE
Fix : Linkages for no visible bindings warnings 

### DIFF
--- a/models/linkages/R/model2netcdf.LINKAGES.R
+++ b/models/linkages/R/model2netcdf.LINKAGES.R
@@ -16,6 +16,8 @@ model2netcdf.LINKAGES <- function(outdir, sitelat, sitelon, start_date = NULL,
                                   end_date = NULL, pft_names = NULL) {
   # , PFTs) { logger.severe('NOT IMPLEMENTED')
   
+  ## Create a new enviroment 
+  linkages_env <- new.env()
   ### Read in model output in linkages format
   load(file.path(outdir, "linkages.out.Rdata"))
   # linkages.output.dims <- dim(linkages.output)

--- a/models/linkages/R/model2netcdf.LINKAGES.R
+++ b/models/linkages/R/model2netcdf.LINKAGES.R
@@ -15,11 +15,11 @@
 model2netcdf.LINKAGES <- function(outdir, sitelat, sitelon, start_date = NULL,
                                   end_date = NULL, pft_names = NULL) {
   # , PFTs) { logger.severe('NOT IMPLEMENTED')
-  
+
   ## Create a new enviroment 
   linkages_env <- new.env()
   ### Read in model output in linkages format
-  load(file.path(outdir, "linkages.out.Rdata"))
+  load(file.path(outdir, "linkages.out.Rdata"),envir = linkages_env)
   # linkages.output.dims <- dim(linkages.output)
   
   ### Determine number of years and output timestep
@@ -49,20 +49,20 @@ model2netcdf.LINKAGES <- function(outdir, sitelat, sitelon, start_date = NULL,
     ## Setup outputs for netCDF file in appropriate units
     output <- list()
     ## standard variables: Carbon Pools
-    output[[1]]  <- ag.biomass[y, ]  # Above Ground Biomass in kgC/m2
-    output[[2]]  <- ag.biomass[y, ]  # Total Live Biomass in kgC/m2 (no distinction from AGB in linkages)
-    output[[3]]  <- total.soil.carbon[y, ]  # TotSoilCarb in kgC/m2
-    output[[4]]  <- c(ag.biomass[y, ], total.soil.carbon[y, ], leaf.litter[y, ], area[y, ])  # Carb Pools in kgC/m2
+    output[[1]]  <- linkages_env$ag.biomass[y, ]  # Above Ground Biomass in kgC/m2
+    output[[2]]  <- linkages_env$ag.biomass[y, ]  # Total Live Biomass in kgC/m2 (no distinction from AGB in linkages)
+    output[[3]]  <- linkages_env$total.soil.carbon[y, ]  # TotSoilCarb in kgC/m2
+    output[[4]]  <- c(linkages_env$ag.biomass[y, ], linkages_env$total.soil.carbon[y, ], linkages_env$leaf.litter[y, ], area[y, ])  # Carb Pools in kgC/m2
     output[[5]]  <- c("AGB", "Soil Organic Matter", "Leaf Litter", "LAI")  # poolname
-    output[[6]]  <- ag.npp[y, ]  # GWBI = NPP in linkages
-    output[[7]]  <- hetero.resp[y, ]  # HeteroResp in kgC/m^2/s
-    output[[8]]  <- ag.npp[y, ]  # NPP = GWBI in linkages
-    output[[9]]  <- nee[y, ]  # NEE #possibly questionable
-    output[[10]] <- et[y, ]  # Evap in kg/m^2/s
-    output[[11]] <- agb.pft[, y, ]
-    output[[12]] <- f.comp[, y]
-    output[[13]] <- area[y, ]  #LAI
-    output[[14]] <- water[y, ]  #soil moisture
+    output[[6]]  <- linkages_env$ag.npp[y, ]  # GWBI = NPP in linkages
+    output[[7]]  <- linkages_env$hetero.resp[y, ]  # HeteroResp in kgC/m^2/s
+    output[[8]]  <- linkages_env$ag.npp[y, ]  # NPP = GWBI in linkages
+    output[[9]]  <- linkages_env$nee[y, ]  # NEE #possibly questionable
+    output[[10]] <- linkages_env$et[y, ]  # Evap in kg/m^2/s
+    output[[11]] <- linkages_env$agb.pft[, y, ]
+    output[[12]] <- linkages_env$f.comp[, y]
+    output[[13]] <- linkages_env$area[y, ]  #LAI
+    output[[14]] <- linkages_env$water[y, ]  #soil moisture
     output[[15]] <- abvgroundwood.biomass[y,] #AbvGroundWood just wood no leaves
     output[[16]] <- seq_along(pft_names) 
     
@@ -77,7 +77,7 @@ model2netcdf.LINKAGES <- function(outdir, sitelat, sitelon, start_date = NULL,
     dim.cpools <- ncdf4::ncdim_def("cpools", "", vals = 1:4, longname = "Carbon Pools")
     dim.cpools1 <- ncdf4::ncdim_def("cpools", "", vals = 1:4, longname = "Carbon Pools", create_dimvar = FALSE)
     #dim.pfts <- ncdim_def("pfts", "", vals = 1:nrow(agb.pft), longname = "PFTs", create_dimvar = FALSE)
-    dim.pfts <- ncdf4::ncdim_def(name = "pft", units = "unitless", vals = 1:length(agb.pft[, 1, 1]), longname = "Plant Functional Type", unlim = TRUE)
+    dim.pfts <- ncdf4::ncdim_def(name = "pft", units = "unitless", vals = 1:length(linkages_env$agb.pft[, 1, 1]), longname = "Plant Functional Type", unlim = TRUE)
     
     
     for (i in seq_along(output)) {

--- a/models/linkages/R/model2netcdf.LINKAGES.R
+++ b/models/linkages/R/model2netcdf.LINKAGES.R
@@ -52,7 +52,7 @@ model2netcdf.LINKAGES <- function(outdir, sitelat, sitelon, start_date = NULL,
     output[[1]]  <- linkages_env$ag.biomass[y, ]  # Above Ground Biomass in kgC/m2
     output[[2]]  <- linkages_env$ag.biomass[y, ]  # Total Live Biomass in kgC/m2 (no distinction from AGB in linkages)
     output[[3]]  <- linkages_env$total.soil.carbon[y, ]  # TotSoilCarb in kgC/m2
-    output[[4]]  <- c(linkages_env$ag.biomass[y, ], linkages_env$total.soil.carbon[y, ], linkages_env$leaf.litter[y, ], area[y, ])  # Carb Pools in kgC/m2
+    output[[4]]  <- c(linkages_env$ag.biomass[y, ], linkages_env$total.soil.carbon[y, ], linkages_env$leaf.litter[y, ], linkages_env$area[y, ])  # Carb Pools in kgC/m2
     output[[5]]  <- c("AGB", "Soil Organic Matter", "Leaf Litter", "LAI")  # poolname
     output[[6]]  <- linkages_env$ag.npp[y, ]  # GWBI = NPP in linkages
     output[[7]]  <- linkages_env$hetero.resp[y, ]  # HeteroResp in kgC/m^2/s
@@ -63,7 +63,7 @@ model2netcdf.LINKAGES <- function(outdir, sitelat, sitelon, start_date = NULL,
     output[[12]] <- linkages_env$f.comp[, y]
     output[[13]] <- linkages_env$area[y, ]  #LAI
     output[[14]] <- linkages_env$water[y, ]  #soil moisture
-    output[[15]] <- abvgroundwood.biomass[y,] #AbvGroundWood just wood no leaves
+    output[[15]] <- linkages_env$abvgroundwood.biomass[y,] #AbvGroundWood just wood no leaves
     output[[16]] <- seq_along(pft_names) 
     
     # ******************** Declare netCDF variables ********************#

--- a/models/linkages/R/write_restart.LINKAGES.R
+++ b/models/linkages/R/write_restart.LINKAGES.R
@@ -134,16 +134,21 @@ write_restart.LINKAGES <- function(outdir, runid, start.time, stop.time,
   }
   print(paste0("runid = ", runid))
   
+  # Create a new enviroment
+  linkages_env <- new.env()
   # load output
-  load(outfile)
+  load(outfile, envir = linkages_env)
   
-  ntrees <- ntrees.kill[, ncol(ntrees.kill), 1]  # number of trees
+  ntrees <- linkages_env$ntrees.kill[, ncol(linkages_env$ntrees.kill), 1]  # number of trees
   
   if(sum(ntrees)==0) {
     #reloads spin up if theres nothing in the output file
     print('No survivors. Reusing spinup.')
-    load(file.path(outdir, runid,list.files(file.path(outdir, runid))[grep(list.files(file.path(outdir, runid)),pattern='linkages')][1]))
-    ntrees <- ntrees.kill[, ncol(ntrees.kill), 1]  # number of trees
+    # new enviroment for spin up data 
+    linkages_env_spinup <- new.env()
+    spinup_file <- file.path(outdir, runid,list.files(file.path(outdir, runid))[grep(list.files(file.path(outdir, runid)),pattern='linkages')][1])
+    load(spinup_file, envir = linkages_env_spinup)
+    ntrees <- linkages_env_spinup$ntrees.kill[, ncol(linkages_env_spinup$ntrees.kill), 1]  # number of trees
     
   }
   
@@ -152,11 +157,11 @@ write_restart.LINKAGES <- function(outdir, runid, start.time, stop.time,
   tyl    <- tyl
   C.mat  <- C.mat
   
-  nogro  <- as.vector(nogro.save[, ncol(nogro.save), 1])  ## no growth indicator
+  nogro  <- as.vector(linkages_env$nogro.save[, ncol(linkages_env$nogro.save), 1])  ## no growth indicator
   ksprt  <- matrix(0, 1, nspec)  ## kill sprout indicator ## LOOK INTO THIS
-  iage   <- as.vector(iage.save[, ncol(iage.save), 1])  # individual age
+  iage   <- as.vector(linkages_env$iage.save[, ncol(linkages_env$iage.save), 1])  # individual age
   
-  dbh    <- as.vector(dbh.save[, ncol(dbh.save), 1])
+  dbh    <- as.vector(linkages_env$dbh.save[, ncol(linkages_env$dbh.save), 1])
   
   n.index <- c(rep(1, ntrees[1]))
   for (i in 2:length(settings$pfts)) {

--- a/models/linkages/tests/Rcheck_reference.log
+++ b/models/linkages/tests/Rcheck_reference.log
@@ -50,37 +50,7 @@ Suggests or Enhances not in mainstream repositories:
 * checking S3 generic/method consistency ... OK
 * checking replacement functions ... OK
 * checking foreign function calls ... OK
-* checking R code for possible problems ... NOTE
-model2netcdf.LINKAGES: no visible binding for global variable
-  ‘ag.biomass’
-model2netcdf.LINKAGES: no visible binding for global variable
-  ‘total.soil.carbon’
-model2netcdf.LINKAGES: no visible binding for global variable
-  ‘leaf.litter’
-model2netcdf.LINKAGES: no visible binding for global variable ‘area’
-model2netcdf.LINKAGES: no visible binding for global variable ‘ag.npp’
-model2netcdf.LINKAGES: no visible binding for global variable
-  ‘hetero.resp’
-model2netcdf.LINKAGES: no visible binding for global variable ‘nee’
-model2netcdf.LINKAGES: no visible binding for global variable ‘et’
-model2netcdf.LINKAGES: no visible binding for global variable ‘agb.pft’
-model2netcdf.LINKAGES: no visible binding for global variable ‘f.comp’
-model2netcdf.LINKAGES: no visible binding for global variable ‘water’
-model2netcdf.LINKAGES: no visible binding for global variable
-  ‘abvgroundwood.biomass’
-write_restart.LINKAGES: no visible binding for global variable
-  ‘ntrees.kill’
-write_restart.LINKAGES: no visible binding for global variable
-  ‘nogro.save’
-write_restart.LINKAGES: no visible binding for global variable
-  ‘iage.save’
-write_restart.LINKAGES: no visible binding for global variable
-  ‘dbh.save’
-Undefined global functions or variables:
-  abvgroundwood.biomass ag.biomass ag.npp agb.pft area
-  db.close db.open db.query dbh.save et f.comp
-  hetero.resp iage.save leaf.litter nee nogro.save
-  ntrees.kill total.soil.carbon water
+* checking R code for possible problems ... OK
 * checking Rd files ... OK
 * checking Rd metadata ... OK
 * checking Rd line widths ... OK


### PR DESCRIPTION
This PR addresses the following changes in the package:

Fixes a part of the issue #2758 : Resolved the issues related to "no visible bindings" warnings in the package linkages. All relevant variables have been correctly scoped and assigned, ensuring that no variables are left unreferenced or improperly bound.

Loading Environment Fix: Updated the logic for loading the output data to prevent conflicts with variables in the environment. Specifically, when no survivors are found in the initial output, the backup spinup file is now correctly loaded into a separate environment or with renamed variables to avoid overwriting existing data.

Reference Log Update: Updated the reference.log file to reflect these changes 

These changes should resolve the issues previously encountered with missing or unreferenced bindings, improve the environment management during data loading, and maintain the integrity of the logging.

Rechecked for the remaining issues , if any by Rcmdcheck .