### PR TITLE
Tag Docker images with R version as well as branch

### DIFF
--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -84,12 +84,12 @@ jobs:
           tags: |
             type=schedule
             type=ref,event=branch,enable=${{ inputs.r-version == '4.1' }}
-            type=ref,event=branch,suffix=R${{ inputs.r-version }}
+            type=ref,event=branch,suffix=-R${{ inputs.r-version }}
             type=ref,event=pr
             type=semver,pattern={{version}},enable=${{ inputs.r-version == '4.1' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ inputs.r-version == '4.1' }}
             type=semver,pattern={{major}},enable=${{ inputs.r-version == '4.1' }}
-            type=semver,pattern={{version}},suffix=R${{ inputs.r-version }}
+            type=semver,pattern={{version}},suffix=-R${{ inputs.r-version }}
 
       # setup docker build
       - name: Set up QEMU

--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -83,11 +83,13 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule
-            type=ref,event=branch
+            type=ref,event=branch,enable=${{ inputs.r-version == '4.1' }}
+            type=ref,event=branch,suffix=R${{ inputs.r-version }}
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{version}},enable=${{ inputs.r-version == '4.1' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ inputs.r-version == '4.1' }}
+            type=semver,pattern={{major}},enable=${{ inputs.r-version == '4.1' }}
+            type=semver,pattern={{version}},suffix=R${{ inputs.r-version }}
 
       # setup docker build
       - name: Set up QEMU


### PR DESCRIPTION
Trying to implement the system @robkooper recommended in Slack:

> How about we use `pecan/depends:<branch>-R<version>`, so
> * `pecan/depends:develop` == develop branch, default R
> * `pecan/depends:develop-R4.4` == develop branch, with R 4.4
> * `pecan/depends:latest` == master/main branch, default R
> * `pecan/depends:1.8.0` == release 1.8.0, default R
> * `pecan/depends:1.8.0-R4.4` == release 1.8.0, with R 4.4

