### PR TITLE
[build] clean all packages with src dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ help:
 	@echo "Examples:"
 	@echo "  make all"
 	@echo "  make document"
-	@echo "  make document modules/assim.sequential  # Generate documentation for a specific package"
+	@echo "  make .doc/modules/assim.sequential  # Generate documentation for a specific package"
 	@echo ""
 	@echo "Notes:"
 	@echo "  - Components not included: cable (models), data.mining and DART (modules)."

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ MODELS_D := $(MODELS:%=.doc/%)
 MODULES_D := $(MODULES:%=.doc/%)
 ALL_PKGS_D := $(BASE_D) $(MODULES_D) $(MODELS_D)
 
+SRC_PKGS := $(strip $(foreach d,$(ALL_PKGS),$(wildcard ${d}/src)))
+
 SETROPTIONS := "options(Ncpus = ${NCPUS})"
 
 EXPECTED_ROXYGEN_VERSION := 7.3.2
@@ -101,7 +103,7 @@ depends = .doc/$(1) .install/$(1) .check/$(1) .test/$(1)
 
 ### Rules
 
-.PHONY: all install check test document shiny \
+.PHONY: all install check test document clean shiny \
             check_base check_models check_modules document help
 
 all: install document
@@ -165,8 +167,9 @@ include Makefile.depends
 
 clean: 
 	rm -rf .install .check .test .doc
-	find modules/rtm/src \( -name \*.mod -o -name \*.o -o -name \*.so \) -delete
-	find models/basgra/src \( -name \*.mod -o -name \*.o -o -name \*.so \) -delete
+	for p in $(SRC_PKGS); do \
+		find "$$p" \( -name \*.mod -o -name \*.o -o -name \*.so \) -delete; \
+	done
 
 .install/devtools: | .install
 	+ ./scripts/time.sh "devtools ${1}" Rscript -e ${SETROPTIONS} -e "if(!requireNamespace('devtools', quietly = TRUE)) install.packages('devtools')"

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ MODELS_D := $(MODELS:%=.doc/%)
 MODULES_D := $(MODULES:%=.doc/%)
 ALL_PKGS_D := $(BASE_D) $(MODULES_D) $(MODELS_D)
 
-SRC_PKGS := $(strip $(foreach d,$(ALL_PKGS),$(wildcard ${d}/src)))
+SRCS_TO_CLEAN := $(strip $(foreach d,$(ALL_PKGS),$(wildcard ${d}/src)))
 
 SETROPTIONS := "options(Ncpus = ${NCPUS})"
 
@@ -127,6 +127,12 @@ book:
 .doc .install .check .test .shiny_depends $(call depends,base) $(call depends,models) $(call depends,modules):
 	mkdir -p $@
 
+clean:
+	rm -rf .install .check .test .doc
+	for p in $(SRCS_TO_CLEAN); do \
+		find "$$p" \( -name \*.mod -o -name \*.o -o -name \*.so \) -delete; \
+	done
+
 help:
 	@echo "Usage: make [target]"
 	@echo ""
@@ -164,12 +170,6 @@ $(subst .doc/models/template,,$(MODELS_D)): .install/models/template
 # (i.e. prerequisites must exist before building target, but
 # target need not be rebuilt when a prerequisite changes)
 include Makefile.depends
-
-clean: 
-	rm -rf .install .check .test .doc
-	for p in $(SRC_PKGS); do \
-		find "$$p" \( -name \*.mod -o -name \*.o -o -name \*.so \) -delete; \
-	done
 
 .install/devtools: | .install
 	+ ./scripts/time.sh "devtools ${1}" Rscript -e ${SETROPTIONS} -e "if(!requireNamespace('devtools', quietly = TRUE)) install.packages('devtools')"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
When running `make clean`, compiled objects named `*.o`, `*.mod`, and `*.so` will now be deleted from every package that has a `src` directory instead of needing to manually list each one in the Makefile.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Recent changes to PEcAn.LPJGUESS added compiled code to the package without any edits to the `make clean` command in PEcAn's Makefile, meaning there wasn't an easy way to get back to known clean state and causing some unexpected behavior when trying to recompile. 

The fix implemented here should make it so we can add or subtract compilateion from  future packages without needing to edit the Makefile.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
