### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,7 @@ services:
   # ----------------------------------------------------------------------
   rstudio:
     hostname: rstudio
+    platform: linux/amd64
     image: pecan/base:${PECAN_VERSION:-latest}
     command: /work/rstudio.sh
     restart: unless-stopped
@@ -327,6 +328,7 @@ services:
   # PEcAn MAESPA model runner
   maespa:
     hostname: maespa-git
+    platform: linux/amd64
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/model-maespa-git:${PECAN_VERSION:-latest}
     restart: unless-stopped
@@ -363,6 +365,7 @@ services:
   # PEcAn DB Sync visualization
   dbsync:
     hostname: dbsync
+    platform: linux/amd64
     image: pecan/shiny-dbsync:${PECAN_VERSION:-latest}
     restart: unless-stopped
     networks:
@@ -386,6 +389,7 @@ services:
   # ----------------------------------------------------------------------
   api:
     hostname: api
+    platform: linux/amd64
     user: "${UID:-1001}:${GID:-1001}"
     image: pecan/api:${PECAN_VERSION:-latest}
     restart: unless-stopped


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
- Maybe finally fixes #3415. 

> I guess docker compose pull still won't work for Mac as long as you don't specify the versions of `dbsync`, `api`, `maespa` and `rstudio` as `linux/amd64`. Need to work on this issue again. I'll do a remnant PR.

Adding `linux/amd64` tags to these images make this compatible for  Mac Silicon as well finally.

<img width="1440" alt="Screenshot 2025-02-28 at 12 43 16 AM" src="https://github.com/user-attachments/assets/f197b16a-41f9-449c-abcd-515331a4c875" />
