### PR TITLE
Avoid bottleneck from duplicating settings during sublist extraction

### DIFF
--- a/base/settings/R/MultiSettings.R
+++ b/base/settings/R/MultiSettings.R
@@ -105,13 +105,7 @@ is.MultiSettings <- function(x) {
 } # "[[.MultiSettings"
 
 .allListElementsEqual <- function(x) {
-  firstElement <- x[[1]]
-  replicatedFirstElement <- replicate(
-    length(x),
-    firstElement,
-    simplify = FALSE)
-  return(isTRUE(
-    all.equal(replicatedFirstElement, x, check.attributes = FALSE)))
+  all(sapply(x, identical, x[[1]]))
 } # .allListElementsEqual
 
 #' @export


### PR DESCRIPTION
Previous code created extra copies of items on every subsetting operation, even if the extracted item was not modified.

Profiling with a 98-site MultiSettings showed ~90% of runtime spent here even for tasks like "check if this setting exists for one specific site", where the values of other nodes are irrelevant. 

I switch here to comparing x[[1]] in place, which completely eliminates GC pauses and the runtime of the script that sent me down this road goes from 4.5 minutes down to 1.5 seconds. Folks working with only a few sites will probably not see as big a speedup, but this should be either an efficiency win or at worst a no-change for everyone.

All package tests pass and I can't find any differences in output from the settings-manipulation scripts I have handy, but more tests appreciated since this is a component that's been stable in lots of workflows for a while now.

Complementary to the path insertion changes in #3456, but submitting separately because it's an improvement whether or not those go in.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
