### PR TITLE
[build] Ignore,  for now,  warning about RPreles installation failure

### DIFF
--- a/models/preles/tests/Rcheck_reference.log
+++ b/models/preles/tests/Rcheck_reference.log
@@ -20,7 +20,8 @@ Strong dependencies not in mainstream repositories:
 Suggests or Enhances not in mainstream repositories:
   Rpreles
 * checking package namespace information ... OK
-* checking package dependencies ... OK
+* checking package dependencies ... NOTE
+  Package suggested but not available for checking: ‘Rpreles’
 * checking if this is a source package ... OK
 * checking if there is a namespace ... OK
 * checking for executable files ... OK


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
Tells  CI package checks to treat checks of PEcAn.PRELES as successful even though they weren't able to install the wrapped RPreles package (because it fails compilation with messages about two unused variables). 

This is [needed to get CI checks passing](https://github.com/PecanProject/pecan/actions/runs/13709110606/job/38341512383) with R 4.4; The RPreles failure happens in all R versions (and has been for most of a year), but doesn't kill the build in older versions.

The longer-term fix is for https://github.com/MikkoPeltoniemi/Rpreles/pull/7 to be merged upstream, but we don't control the timeline for that.
