### PR TITLE
use R4.4 by default

### DIFF
--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -36,7 +36,7 @@ on:
         required: false
 
 env:
-  DEFAULT_R_VERSION: "4.1"
+  DEFAULT_R_VERSION: "4.4"
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,7 @@
 name: Docker GHA
 
 env:
-  DEFAULT_R_VERSION: 4.1
+  DEFAULT_R_VERSION: 4.4
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 
 ### Changed
 
+- Docker images now use R 4.4 by default, with other supported versions available by appending the R version to the tag, e.g. `pecan/base:develop-R4.2`.
 - Is is now easier to run PEcAn workflows with no active database connection by setting `settings$database$bety$write` to FALSE or missing (#3398, #3419). In this mode you are reponsible for providing the correct paths/ids for all needed files, and run metadata are not written back to the database.
 - The following components have changed their licensing. With approval of all their contributors, we now provide them under a BSD 3-clause license rather than the previously used NCSA Open Source license. As a reminder, we intend to relicense the entire system and this list will expand as we gather permission from the relevant copyright owners.
     * `apps/api`

--- a/docker/depends/Dockerfile
+++ b/docker/depends/Dockerfile
@@ -1,4 +1,4 @@
-ARG R_VERSION="4.1"
+ARG R_VERSION="4.4"
 ARG PARENT_IMAGE="rocker/tidyverse"
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
Bumps default Docker build to use R 4.4; other tasks (including CI) that use Docker images without a version specified will pick up 4.4 from there.
Once this is merged I will update branch protection rules to make R 4.4 the required version in the CI builds.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
