### PR TITLE
met.process: ensure host arg is passed on as a list

### DIFF
--- a/docker/depends/pecan_package_dependencies.csv
+++ b/docker/depends/pecan_package_dependencies.csv
@@ -655,6 +655,7 @@
 "utils","*","modules/assim.batch","Imports",FALSE
 "utils","*","modules/assim.sequential","Suggests",FALSE
 "utils","*","modules/benchmark","Imports",FALSE
+"utils","*","modules/data.atmosphere","Imports",FALSE
 "utils","*","modules/data.remote","Suggests",FALSE
 "utils","*","modules/photosynthesis","Imports",FALSE
 "vdiffr",">= 1.0.2","base/qaqc","Suggests",FALSE

--- a/modules/data.atmosphere/DESCRIPTION
+++ b/modules/data.atmosphere/DESCRIPTION
@@ -54,8 +54,8 @@ Imports:
     tidyr,
     tidyselect,
     truncnorm,
-    utils,
     units,
+    utils,
     XML (>= 3.98-1.4),
     xts,
     zoo

--- a/modules/data.atmosphere/DESCRIPTION
+++ b/modules/data.atmosphere/DESCRIPTION
@@ -54,6 +54,7 @@ Imports:
     tidyr,
     tidyselect,
     truncnorm,
+    utils,
     units,
     XML (>= 3.98-1.4),
     xts,

--- a/modules/data.atmosphere/R/met.process.R
+++ b/modules/data.atmosphere/R/met.process.R
@@ -92,7 +92,16 @@ met.process <- function(site, input_met, start_date, end_date, model,
 
   on.exit(PEcAn.DB::db.close(con), add = TRUE)
   username <- ifelse(is.null(input_met$username), "pecan", input_met$username)
-  machine.host <- ifelse(host == "localhost" || host$name == "localhost", PEcAn.remote::fqdn(), host$name)
+
+  if (length(host) == 1 && !hasName(host, "name")) {
+    # We were passed a bare hostname; wrap in a list as downstream fns expect
+    host <- list(name = host)
+  }
+  if (host$name == "localhost") {
+    machine.host <- PEcAn.remote::fqdn()
+  } else {
+    machine.host <- host$name
+  }
   machine <- PEcAn.DB::db.query(paste0("SELECT * from machines where hostname = '", machine.host, "'"), con)
 
 

--- a/modules/data.atmosphere/R/met.process.R
+++ b/modules/data.atmosphere/R/met.process.R
@@ -93,7 +93,7 @@ met.process <- function(site, input_met, start_date, end_date, model,
   on.exit(PEcAn.DB::db.close(con), add = TRUE)
   username <- ifelse(is.null(input_met$username), "pecan", input_met$username)
 
-  if (length(host) == 1 && !hasName(host, "name")) {
+  if (length(host) == 1 && !utils::hasName(host, "name")) {
     # We were passed a bare hostname; wrap in a list as downstream fns expect
     host <- list(name = host)
   }

--- a/modules/data.land/R/ic_process.R
+++ b/modules/data.land/R/ic_process.R
@@ -112,7 +112,11 @@ ic_process <- function(settings, input, dir, overwrite = FALSE){
 
   }
   # set up host information
-  machine.host <- ifelse(host == "localhost" || host$name == "localhost", PEcAn.remote::fqdn(), host$name)
+  if (host$name == "localhost") {
+    machine.host <- PEcAn.remote::fqdn()
+  } else {
+    machine.host <- host$name
+  }
   machine <- PEcAn.DB::db.query(paste0("SELECT * from machines where hostname = '", machine.host, "'"), con)
   
   # retrieve model type info

--- a/modules/data.land/R/soil_process.R
+++ b/modules/data.land/R/soil_process.R
@@ -101,8 +101,11 @@ soil_process <- function(settings, input, dbfiles, overwrite = FALSE,run.local=T
   }  ## otherwise continue to process soil
 
     # set up host information
-  machine.host <- ifelse(host == "localhost" || host$name == "localhost" || run.local,
-                         PEcAn.remote::fqdn(), host$name)
+  if (host$name == "localhost" || run.local) {
+    machine.host <- PEcAn.remote::fqdn()
+  } else {
+    machine.host <- host$name
+  }
   machine <- PEcAn.DB::db.query(paste0("SELECT * from machines where hostname = '", machine.host, "'"), con)
 
   # retrieve model type info


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
The immediate bug, reported by @AritraDey-Dev in Slack: When passing a whole settings$host block in to `met.process`, R >=4.3 fails because we put a condition with length >1 into a scalar `||` operator. Fixed by refactoring to only look at the element we care about.

Potential issue addressed while I was here: When `host` isn't specified, `met.process` defaults to the bare string "localhost", which is fine in this file but is then passed along to some downstream functions that are documented to expect a named list. Fixed by wrapping bare strings as `host <- list(name = host)` before passing it along.





## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
