### PR TITLE
Fix `Deprecated: htmlspecialchars()` for null warning

### DIFF
--- a/web/08-finished.php
+++ b/web/08-finished.php
@@ -42,7 +42,7 @@ $stmt->closeCursor();
 $start = substr($workflow['start_date'], 0, 4);
 $end = substr($workflow['end_date'], 0, 4);
 $folder = $workflow['folder'];
-$notes = htmlspecialchars($workflow['notes']);
+$notes = htmlspecialchars($workflow['notes'] ?? '');
 if ($workflow['value'] != '') {
   $params = json_decode($workflow['value'], true);
 } else {


### PR DESCRIPTION
## Description

This PR fixes a small error : `Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/pecan/08-finished.php on line 45` which arises when we try to open a pre-existing workflow run from "http://pecan.localhost/bety". For example, if I chose to open Results for the workflow run of `/home/carya/output/PEcAn_5000000241`, we got the above error because PEcAn expected `/home/carya/output/PEcAn_5000000241` directory to exist. If the data directory isn't present within the user's system, taking me as an example, we would have encountered the above error. 

Another Issue I guess we can actually raise here is : _"Should the actual path of data outputs be `/home/carya/output/<x_path>` or should it have been like the current data directory we use, for eg: `output folder = /data/workflows/<x_workflow_executed>` ?"_ .

**Note that this error only arises when I tried opening a pre-existing workflow by @dlebauer  to run from BETYdb (while I tried experimenting with the database)**.

Currently in BETYdb, I can see the folder path is `/home/dlebauer/.pecan/biocrotest`.

## Review Time Estimate
- [x] When possible

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
