### PR TITLE
Fix API to correctly use x_var from request in plotResults

### DIFF
--- a/apps/api/R/runs.R
+++ b/apps/api/R/runs.R
@@ -237,8 +237,9 @@ getRunOutputFile <- function(req, run_id, filename, res){
 #' @author Tezan Sahu
 #* @get /<run_id>/graph/<year>/<y_var>
 #* @serializer contentType list(type='image/png')
+plotResults <- function(req, run_id, year, y_var, width, height = 600, res) {
+  x_var <- ifelse(!is.null(req$args$xvar), req$args$xvar, "time")
 
-plotResults <- function(req, run_id, year, y_var, x_var="time", width=800, height=600, res) {
   # Get workflow_id for the run
   Run <- tbl(global_db_pool, "runs") %>%
     filter(id == !!run_id)
@@ -273,7 +274,7 @@ plotResults <- function(req, run_id, year, y_var, x_var="time", width=800, heigh
   
   # Plot & return
   filename <- paste0(Sys.getenv("DATA_DIR", "/data/"), "workflows/temp", stringi::stri_rand_strings(1, 10), ".png")
-  PEcAn.visualization::plot_netcdf(datafile, y_var, x_var, as.integer(width), as.integer(height), year=year, filename=filename)
+  PEcAn.visualization::plot_netcdf(datafile, y_var, x_var, as.integer(width), as.integer(height), filename=filename, year=year)
   img_bin <- readBin(filename,'raw',n = file.info(filename)$size)
   file.remove(filename)
   return(img_bin)

--- a/apps/api/R/runs.R
+++ b/apps/api/R/runs.R
@@ -237,7 +237,7 @@ getRunOutputFile <- function(req, run_id, filename, res){
 #' @author Tezan Sahu
 #* @get /<run_id>/graph/<year>/<y_var>
 #* @serializer contentType list(type='image/png')
-plotResults <- function(req, run_id, year, y_var, width, height = 600, res) {
+plotResults <- function(req, run_id, year, y_var, width = 800, height = 600, res) {
   x_var <- ifelse(!is.null(req$args$xvar), req$args$xvar, "time")
 
   # Get workflow_id for the run


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
The issue was that the API endpoint for plotting results always used `"time"` as the x-axis variable, regardless of what was passed from the web ui. This made the x-axis selection in the UI non-functional.

I fixed this by modifying the `plotResults` function to correctly extract and use the `xvar` parameter passed from the request object `(req$args$xvar)`. Previously, the value of x_var was being `hardcoded` or ignored, leading to time being used unconditionally.

Now, the function dynamically checks if xvar is provided in the request and uses that as the x_var in the plotting logic:
```
x_var <- ifelse(!is.null(req$args$xvar), req$args$xvar, "time")
```
This ensures that the front-end selection for the x-axis is respected in the plots generated by the API.

**screenshots**:
![Screenshot from 2025-05-24 16-32-26](https://github.com/user-attachments/assets/c2934cd8-4480-4a72-b88b-ea3fa27ae2cc)
![Screenshot from 2025-05-24 16-32-37](https://github.com/user-attachments/assets/45544975-fe27-4443-a054-47f51f0d9a20)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #3328 

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [x] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
