### PR TITLE
Correct XML error when writing MultiSettings with only one site

### DIFF
--- a/base/settings/DESCRIPTION
+++ b/base/settings/DESCRIPTION
@@ -5,7 +5,7 @@ Authors@R: c(person("David", "LeBauer", role = c("aut", "cre"),
              person("Rob", "Kooper", role = c("aut"),
                      email = "kooper@illinois.edu"),
              person("University of Illinois, NCSA", role = c("cph")))
-Version: 1.9.0
+Version: 1.9.1
 License: BSD_3_clause + file LICENSE
 Copyright: Authors
 LazyLoad: yes

--- a/base/settings/NEWS.md
+++ b/base/settings/NEWS.md
@@ -1,3 +1,9 @@
+# PEcAn.settings 1.9.1
+
+## Fixed
+
+* listToXml.MultiSettings now produces valid XML from a MultiSettings with length 1.
+
 # PEcAn.settings 1.9.0
 
 ## Changed

--- a/base/settings/R/MultiSettings.R
+++ b/base/settings/R/MultiSettings.R
@@ -177,7 +177,7 @@ printAll.MultiSettings <- function(x) {
 
 #' @export
 listToXml.MultiSettings <- function(item, tag, collapse = TRUE) {
-  if (collapse && length(item) > 1) {
+  if (collapse) {
     if (.expandableItemsTag %in% names(item)) {
       stop("Settings can't contain reserved tag 'multisettings'.")
     }

--- a/base/settings/tests/testthat/test.MultiSettings.class.R
+++ b/base/settings/tests/testthat/test.MultiSettings.class.R
@@ -14,8 +14,10 @@ test_that("MultiSettings constructor works as expected", {
   expect_error(MultiSettings(settings, l))
 
   multiSettings <- MultiSettings(settings, settings, settings)
+  multiSettings1 <- MultiSettings(settings)
   multiSettings2 <- MultiSettings(list(settings, settings, settings))
   multiSettings3 <- MultiSettings(multiSettings)
+  expect_identical(multiSettings1[[1]], settings)
   expect_identical(multiSettings2, multiSettings)
   expect_identical(multiSettings3, multiSettings)
 
@@ -289,6 +291,12 @@ test_that("multiSettings write to and read from xml as expcted (i.e., with colla
   msNew <- expandMultiSettings(listNew)
 
   expect_true(are.equal.possiblyNumericToCharacter(msNew, msOrig))
+})
+
+test_that("length one MultiSettings is collapsed same as longer ones", {
+  ms1 <- MultiSettings(settings)
+  ms1XML <- listToXml(ms1, "pecan")
+  expect_length(XML::getNodeSet(ms1XML, "/pecan/multisettings"), 1)
 })
 
 


### PR DESCRIPTION
Removes assumption that length > 1 from `listToXml.MultiSettings` -- the rest of the MultiSettings class seems to already be fine with "multi" happening to be only one site.

Yes, this is a corner case, but a useful one: I've been using and liking `createMultiSiteSettings(settings, site_info)` as a single-step way of injecting site-specific information into my run settings, and I'd like to be able to use the same pipelines with only one location in site_info.



## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
