### PR TITLE
fix: rendered the target link for the update bety documentation

### DIFF
--- a/book_source/02_demos_tutorials_workflows/05_developer_workflows/01_update_pecan_code.Rmd
+++ b/book_source/02_demos_tutorials_workflows/05_developer_workflows/01_update_pecan_code.Rmd
@@ -2,7 +2,7 @@
 
 Release notes for all releases can be found [here](https://github.com/PecanProject/pecan/releases).
 
-This page will only list any steps you have to do to upgrade an existing system. When updating PEcAn it is highly encouraged to update BETY. You can find instructions on how to do this, as well on how to update the database in the [Updating BETYdb](https://pecan.gitbooks.io/betydb-documentation/content/updating_betydb_when_new_versions_are_released.html) gitbook page.
+This page will only list any steps you have to do to upgrade an existing system. When updating PEcAn it is highly encouraged to update BETY. You can find instructions on how to do this, as well on how to update the database in the [Updating BETYdb](https://pecan.gitbook.io/betydbdoc-dataentry) gitbook page.
 
 
 ### Updating PEcAn {#pecan-make}


### PR DESCRIPTION
fixes - https://github.com/PecanProject/PecanProject.github.io/issues/110
The new target link is now set to open the page to the introduction sub bar directly , fixing the issue of page not found .
