### PR TITLE
ERA5 Extraction: Raster-Free, 4D-aware, and metadata-resilient implem…

### DIFF
--- a/modules/data.atmosphere/R/extract_ERA5.R
+++ b/modules/data.atmosphere/R/extract_ERA5.R
@@ -44,6 +44,9 @@ extract.nc.ERA5 <-
     # library(xts)
     # Distributing the job between whatever core is available. 
     
+    # Ensure valid inputs
+    if (is.na(slat) || is.na(slon)) PEcAn.logger.severe("Invalid latitude or longitude provided")
+
     years <- seq(lubridate::year(start_date),
                  lubridate::year(end_date),
                  1
@@ -72,37 +75,70 @@ extract.nc.ERA5 <-
                 
                 #msg
                 PEcAn.logger::logger.info(paste0(year, " is being processed ", "for ensemble #", ens, " "))
-              }
-              
+              }   
               #open the file
               nc_data <- ncdf4::nc_open(ncfile)
-              # time stamp
-              
-              t <- ncdf4::ncvar_get(nc_data, "time")
-              tunits <- ncdf4::ncatt_get(nc_data, 'time')
+              # Ensure file closure
+              on.exit(ncdf4::nc_close(nc_data), add = TRUE)
+              # time stamp - handle both 'time' and 'valid_time' variables
+              time_var <- if ("time" %in% names(nc_data$var)) "time" else "valid_time"
+              t <- ncdf4::ncvar_get(nc_data, time_var)
+              tunits <- ncdf4::ncatt_get(nc_data, time_var)
               tustr <- strsplit(tunits$units, " ")
-              timestamp <-
-                as.POSIXct(t * 3600, tz = "UTC", origin = tustr[[1]][3])
-              try(ncdf4::nc_close(nc_data))
               
+              # Handle different time units: 'time' uses hours, 'valid_time' uses seconds
+              if (time_var == "time") {
+                # Traditional format: "hours since YYYY-MM-DD HH:MM:SS"
+                timestamp <- as.POSIXct(t * 3600, tz = "UTC", origin = tustr[[1]][3])
+              } else {
+                # New format: "seconds since YYYY-MM-DD HH:MM:SS" (typically 1970-01-01)
+                timestamp <- as.POSIXct(t, tz = "UTC", origin = tustr[[1]][3])
+              }
               
-              # set the vars
-              if (is.null(vars))
-                vars <- names(nc_data$var)
+              # Get spatial coordinates 
+              lon <- ncdf4::ncvar_get(nc_data, "longitude")
+              lat <- ncdf4::ncvar_get(nc_data, "latitude")
+              lon_ix <- which.min(abs(lon - slon))
+              lat_iy <- which.min(abs(lat - slat))
+              
+              # set the vars - filter for valid geophysical variables
+              if (is.null(vars)) {
+                all_vars <- names(nc_data$var)
+                vars <- all_vars[sapply(all_vars, function(v) {
+                  var_info <- nc_data$var[[v]]
+                  var_info$ndims %in% c(3,4) && 
+                    var_info$prec %in% c("float", "double", "integer")
+                })]
+                if (verbose && length(vars) < length(all_vars)) {
+                  skipped <- setdiff(all_vars, vars)
+                  PEcAn.logger::logger.info(paste0("Skipped metadata variables: ", paste(skipped, collapse=", ")))
+                }
+              }
+              
               # for the variables extract the data
               all.data.point <- vars %>%
                 purrr::set_names(vars) %>%
                 purrr::map_dfc(function(vname) {
                   if (verbose) {
-                    PEcAn.logger::logger.info(paste0(" \t ",vname, "is being extracted ! "))
+                    PEcAn.logger::logger.info(paste0(" \t ",vname, " is being extracted ! "))
                   }
                   
-                  brick.tmp <-
-                    raster::brick(ncfile, varname = vname, level = ens)
-                  nn <-
-                    raster::extract(brick.tmp,
-                                    sp::SpatialPoints(cbind(slon, slat)),
-                                    method = 'simple')
+                  # Use direct ncvar_get for better performance
+                  vals <- ncdf4::ncvar_get(nc_data, vname)
+                  missval <- if (!is.null(nc_data$var[[vname]]$missval)) nc_data$var[[vname]]$missval else NA
+                  
+                  # Dynamic dimension handling
+                  if (length(dim(vals)) == 4) {
+                    # 4D: lon, lat, time, ensemble
+                    nn <- vals[lon_ix, lat_iy, , ens]
+                  } else if (length(dim(vals)) == 3) {
+                    # 3D: lon, lat, time (no ensemble dimension)
+                    nn <- vals[lon_ix, lat_iy, ]
+                  } else {
+                    PEcAn.logger::logger.severe(paste0("Unexpected dimension in variable ", vname))
+                    nn <- rep(NA, length(timestamp))
+                  }
+                  
                   if (verbose) {
                     if (!is.numeric(nn)) {
                       PEcAn.logger::logger.severe(paste0(
@@ -112,27 +148,24 @@ extract.nc.ERA5 <-
                       ))
                     }
                   }
-                  
                   # replacing the missing/filled values with NA
-                  nn[nn == nc_data$var[[vname]]$missval] <- NA
+                  nn[nn == missval] <- NA
                   # send out the extracted var as a new col
-                  t(nn)
-                  
+                  nn
                 })
               
-              #close the connection
-              
+              #close the connection - handled by on.exit
+
               # send out as xts object
               xts::xts(all.data.point, order.by = timestamp)
             }) %>%
             stats::setNames(paste0("ERA_ensemble_", ensemblesN))
-          
-          #Merge mean and the speard
+
+          #Merge mean and spread
           return(point.data)
           
         }) %>%
         stats::setNames(years)
-      
       
       # The order of one.year.out is year and then Ens - Mainly because of the spead  / I wanted to touch each file just once.
       # This now changes the order to ens - year
@@ -143,7 +176,6 @@ extract.nc.ERA5 <-
             purrr::map( ~ .x [[Ensn]]) %>%
             do.call("rbind.xts", .)
         })
-      
       
       # Calling the met2CF inside extract bc in met process met2CF comes before extract !
       out <-met2CF.ERA5(
@@ -158,7 +190,6 @@ extract.nc.ERA5 <-
         verbose = verbose
       )
       return(out)
-      
     }, error = function(e) {
       PEcAn.logger::logger.severe(paste0(conditionMessage(e)))
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
This PR refactors the `extract.nc.ERA5()` function to address critical issues with ERA5 NetCDF data processing, ensuring robust handling of 4D ensemble data and preventing common pitfalls associated with metadata variables.

### Key Improvements
- Removed raster dependency:
   - Eliminates dependency on `raster::brick()` and `raster::extract()` 
   - Uses `ncdf4::ncvar_get()` for direct, efficient NetCDF access
   - _This ensures correct indexing for 3D (lon, lat, time) and 4D (lon, lat, time, ensemble) structures; which raster::brick() **cannot properly handle 4D**, especially for ensemble slices._
   
- 4D-aware variable extraction:
   - Dynamically detects whether each variable is 3D or 4D ([`lon, lat, time`] or [`lon, lat, time, ens`]) and extracts the correct slice.
   - Supports ensemble indexing for accurate per-member data extraction
  
-  Excludes metadata/non-geophysical variables:
    - Automatically filters out non-geophysical variables (e.g, `expver`)
    - Skips variables with unsupported dimensions or non-numeric types
    - CRS info or missing value attributes inconsistent with physical measurements.
    
- Timestamp handling:
    - Supports both time (hours since reference) and valid_time (seconds since epoch)
    - Converts to POSIXct using the correct origin and units

- Fixes for `xts` and shape errors:
  - Prevents **`xts(...): nrow(x) != length(order.by)`** errors by ensuring all columns align with timestamps
  - Ensures all extracted variable columns align perfectly with timestamps.
 
 - Ensures final result is a list of 10 ensemble members (`xts` objects), each covering the full time range across years.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- ERA5 NetCDF files often include metadata variables (e.g., `expver`) and use different time variable conventions (time vs. valid_time). 
- The original code relied on the `raster` package, which does not safely handle 4D arrays or non-geophysical variables, leading to silent bugs, shape mismatches, and downstream failures. This update replaces raster with direct ncdf4 access, making the function robust, reliable, and future-proof for all ERA5 use cases
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
