### PR TITLE
Refactor ic_process.R to get model-name from settings

### DIFF
--- a/modules/data.land/R/ic_process.R
+++ b/modules/data.land/R/ic_process.R
@@ -120,7 +120,7 @@ ic_process <- function(settings, input, dir, overwrite = FALSE){
   machine <- PEcAn.DB::db.query(paste0("SELECT * from machines where hostname = '", machine.host, "'"), con)
   
   # retrieve model type info
-  if(!is.null(settings$model$name)){
+  if(isTRUE(nzchar(settings$model$name))){
     model$name <- settings$model$name
   } else {
     modeltype_id <- PEcAn.DB::db.query(paste0("SELECT modeltype_id FROM models where id = '", model$id, "'"), con)[[1]]

--- a/modules/data.land/R/ic_process.R
+++ b/modules/data.land/R/ic_process.R
@@ -122,8 +122,7 @@ ic_process <- function(settings, input, dir, overwrite = FALSE){
   # retrieve model type info
   if(!is.null(settings$model$name)){
     model$name <- settings$model$name
-  }
- else {
+  } else {
     modeltype_id <- PEcAn.DB::db.query(paste0("SELECT modeltype_id FROM models where id = '", model$id, "'"), con)[[1]]
     model$name <- PEcAn.DB::db.query(paste0("SELECT name FROM modeltypes where id = '", modeltype_id, "'"), con)[[1]]
   }

--- a/modules/data.land/R/ic_process.R
+++ b/modules/data.land/R/ic_process.R
@@ -120,9 +120,12 @@ ic_process <- function(settings, input, dir, overwrite = FALSE){
   machine <- PEcAn.DB::db.query(paste0("SELECT * from machines where hostname = '", machine.host, "'"), con)
   
   # retrieve model type info
-  if(is.null(model)){
-    modeltype_id <- PEcAn.DB::db.query(paste0("SELECT modeltype_id FROM models where id = '", settings$model$id, "'"), con)[[1]]
-    model <- PEcAn.DB::db.query(paste0("SELECT name FROM modeltypes where id = '", modeltype_id, "'"), con)[[1]]
+  if(!is.null(settings$model$name)){
+    model$name <- settings$model$name
+  }
+ else {
+    modeltype_id <- PEcAn.DB::db.query(paste0("SELECT modeltype_id FROM models where id = '", model$id, "'"), con)[[1]]
+    model$name <- PEcAn.DB::db.query(paste0("SELECT name FROM modeltypes where id = '", modeltype_id, "'"), con)[[1]]
   }
 
 
@@ -197,7 +200,7 @@ ic_process <- function(settings, input, dir, overwrite = FALSE){
                                        n.ensemble = i,
                                        dir        = dir,
                                        machine    = machine,
-                                       model      = model,
+                                       model      = model$name,
                                        start_date = start_date,
                                        end_date   = end_date,
                                        new_site   = new.site,


### PR DESCRIPTION
- **Removed redundant `is.null(model)` check**  
  `model` was always initialised as a list just before the conditional, so `is.null(model)` would always return `FALSE`. This check was unnecessary and has been removed to simplify the logic.

- **Added support for retrieving `model$name` directly from `settings.xml`**  
  If `settings$model$name` is present, it will now be used to populate `model$name` without requiring a database query.

- **Retained DB lookup as a fallback**  
  If `settings$model$name` is not provided, the function will fall back to querying BETYdb for the model name, maintaining backward compatibility.

---
This update improves efficiency, removes dead code, and uses user-defined values when available.

