### PR TITLE
removed redundant parameter

### DIFF
--- a/modules/data.land/DESCRIPTION
+++ b/modules/data.land/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PEcAn.data.land
 Type: Package
 Title: PEcAn Functions Used for Ecological Forecasts and Reanalysis
-Version: 1.8.1
+Version: 1.8.2
 Authors@R: c(person("Mike", "Dietze", role = c("aut", "cre"),
                      email = "dietze@bu.edu"),
              person("David", "LeBauer", role = c("aut"),

--- a/modules/data.land/NEWS.md
+++ b/modules/data.land/NEWS.md
@@ -1,5 +1,7 @@
 # PEcAn.data.land 1.8.2
-- Removed unused parameter `machine` from put_veg_module.R and updated documentation.
+- Removed unused parameter `machine` from put_veg_module()
+
+
 # PEcAn.data.land 1.8.1
 
 * Dependency `datapack` is now optional. It is only used by `dataone_download()` (#3373).

--- a/modules/data.land/NEWS.md
+++ b/modules/data.land/NEWS.md
@@ -1,3 +1,5 @@
+# PEcAn.data.land 1.8.2
+- Removed unused parameter `machine` from put_veg_module.R and updated documentation.
 # PEcAn.data.land 1.8.1
 
 * Dependency `datapack` is now optional. It is only used by `dataone_download()` (#3373).

--- a/modules/data.land/R/ic_process.R
+++ b/modules/data.land/R/ic_process.R
@@ -207,7 +207,6 @@ ic_process <- function(settings, input, dir, overwrite = FALSE){
                                        outfolder  = outfolder,
                                        n.ensemble = i,
                                        dir        = dir,
-                                       machine    = machine,
                                        model      = model$name,
                                        start_date = start_date,
                                        end_date   = end_date,

--- a/modules/data.land/R/put_veg_module.R
+++ b/modules/data.land/R/put_veg_module.R
@@ -7,7 +7,6 @@
 ##' @param outfolder path to where the processed files will be written
 ##' @param n.ensemble integer, ensemble member number
 ##' @param dir dir path to dbfiles on local machine
-##' @param machine data frame, DB info regarding localhost machine id/hostname etc.
 ##' @param model model name, e.g. "ED2"
 ##' @param start_date date in "YYYY-MM-DD" format, in case of source==FIA it's the settings$run$start.date, otherwise start_date of the IC file in DB
 ##' @param end_date date in "YYYY-MM-DD" format, in case of source==FIA it's the settings$run$end.date, otherwise end_date of the IC file in DB
@@ -21,7 +20,7 @@
 put_veg_module <- function(getveg.id, dbparms,
                             input_veg, pfts,
                             outfolder, n.ensemble,
-                            dir, machine, model,
+                            dir, model,
                             start_date, end_date,
                             new_site,
                             host, overwrite){

--- a/modules/data.land/man/put_veg_module.Rd
+++ b/modules/data.land/man/put_veg_module.Rd
@@ -12,7 +12,6 @@ put_veg_module(
   outfolder,
   n.ensemble,
   dir,
-  machine,
   model,
   start_date,
   end_date,
@@ -35,8 +34,6 @@ put_veg_module(
 \item{n.ensemble}{integer, ensemble member number}
 
 \item{dir}{dir path to dbfiles on local machine}
-
-\item{machine}{data frame, DB info regarding localhost machine id/hostname etc.}
 
 \item{model}{model name, e.g. "ED2"}
 


### PR DESCRIPTION
Removed unused parameter machine from `put_veg_module()` in `data.land` package.

Updated Roxygen2 docs accordingly.

Regenerated documentation using `roxygen2::roxygenise()`

No functional changes — just cleanup for clarity and consistency.

