### PR TITLE
fix(biocro): handle met data end time in met2model.BIOCRO to prevent run end date error

### DIFF
--- a/models/biocro/R/met2model.BIOCRO.R
+++ b/models/biocro/R/met2model.BIOCRO.R
@@ -30,8 +30,8 @@ met2model.BIOCRO <- function(in.path, in.prefix, outfolder, overwrite = FALSE,
 
   res <- list()
   for (year in years_wanted) {
-    yrstart = max(lubridate::date(start_date), lubridate::ymd(paste0(year, "-01-01")))
-    yrend = min(lubridate::date(end_date), lubridate::ymd(paste0(year, "-12-31")))
+    yrstart = max(start_date, as.POSIXct(paste0(year, "-01-01 00:00:00"), tz = "UTC"))
+    yrend = min(end_date, as.POSIXct(paste0(year, "-12-31 23:59:59"), tz = "UTC"))
 
     ncfile <- file.path(in.path, paste(in.prefix, year, "nc", sep = "."))
     csvfile <- file.path(outfolder, paste(in.prefix, year, "csv", sep = "."))

--- a/models/biocro/R/met2model.BIOCRO.R
+++ b/models/biocro/R/met2model.BIOCRO.R
@@ -30,8 +30,8 @@ met2model.BIOCRO <- function(in.path, in.prefix, outfolder, overwrite = FALSE,
 
   res <- list()
   for (year in years_wanted) {
-    yrstart = max(start_date, as.POSIXct(paste0(year, "-01-01 00:00:00"), tz = "UTC"))
-    yrend = min(end_date, as.POSIXct(paste0(year, "-12-31 23:59:59"), tz = "UTC"))
+    yrstart = max(lubridate::date(start_date), lubridate::ymd(paste0(year, "-01-01")))
+    yrend = min(lubridate::date(end_date), lubridate::ymd(paste0(year, "-12-31")))
 
     ncfile <- file.path(in.path, paste(in.prefix, year, "nc", sep = "."))
     csvfile <- file.path(outfolder, paste(in.prefix, year, "csv", sep = "."))

--- a/models/biocro/tests/testthat/test.met2model.R
+++ b/models/biocro/tests/testthat/test.met2model.R
@@ -5,10 +5,6 @@ setup(dir.create(outfolder, showWarnings = FALSE))
 teardown(unlink(outfolder, recursive = TRUE))
 
 test_that("Met conversion runs without error", {
-  skip(paste0(
-    "BIOCRO met2model is currently broken. ",
-    "See issue #2274 (https://github.com/PecanProject/pecan/issues/2274)."
-  ))
   nc_path <- system.file("test-data", "CRUNCEP.2000.nc",
                          package = "PEcAn.utils")
   in.path <- dirname(nc_path)

--- a/models/biocro/tests/testthat/test.met2model.R
+++ b/models/biocro/tests/testthat/test.met2model.R
@@ -5,16 +5,12 @@ setup(dir.create(outfolder, showWarnings = FALSE))
 teardown(unlink(outfolder, recursive = TRUE))
 
 test_that("Met conversion runs without error", {
-  skip(paste0(
-    "BIOCRO met2model is currently broken. ",
-    "See issue #2274 (https://github.com/PecanProject/pecan/issues/2274)."
-  ))
   nc_path <- system.file("test-data", "CRUNCEP.2000.nc",
                          package = "PEcAn.utils")
   in.path <- dirname(nc_path)
   in.prefix <- "CRUNCEP"
   start_date <- "2000-01-01"
-  end_date <- "2000-12-31"
+  end_date <- "2000-12-31 21:00:00"
   result <- met2model.BIOCRO(in.path, in.prefix, outfolder,
                              lat = 45.25,
                              lon = -84.75,

--- a/models/biocro/tests/testthat/test.met2model.R
+++ b/models/biocro/tests/testthat/test.met2model.R
@@ -10,7 +10,7 @@ test_that("Met conversion runs without error", {
   in.path <- dirname(nc_path)
   in.prefix <- "CRUNCEP"
   start_date <- "2000-01-01"
-  end_date <- "2000-12-31 21:00:00"
+  end_date <- "2000-12-31"
   result <- met2model.BIOCRO(in.path, in.prefix, outfolder,
                              lat = 45.25,
                              lon = -84.75,

--- a/modules/data.atmosphere/R/load.cfmet.R
+++ b/modules/data.atmosphere/R/load.cfmet.R
@@ -51,10 +51,11 @@ load.cfmet <- function(met.nc, lat, lon, start.date, end.date) {
 
   all.dates <- data.frame(index = seq_along(time.idx), date = date)
   
-  if (nrow(all.dates) > 1) {
-    delta <- stats::median(diff(all.dates$date), na.rm = TRUE)
-  } else {
-    delta <- as.difftime(1, units = "hours")  
+  delta <- stats::median(diff(all.dates$date), na.rm = TRUE)
+  if (is.na(delta)) {
+    # probably only happens with a one-line met file
+    # fall back to requiring exact match
+    delta <- 0
   }
   
   if (start.date < (min(all.dates$date) - delta)) {

--- a/modules/data.atmosphere/R/load.cfmet.R
+++ b/modules/data.atmosphere/R/load.cfmet.R
@@ -51,11 +51,21 @@ load.cfmet <- function(met.nc, lat, lon, start.date, end.date) {
 
   all.dates <- data.frame(index = seq_along(time.idx), date = date)
   
-  if (start.date + lubridate::days(1) < min(all.dates$date)) {
-   PEcAn.logger::logger.severe("run start date", start.date, "before met data starts", min(all.dates$date))
+  # Calculate the typical timestep of the met data using median for robustness
+  if (nrow(all.dates) > 1) {
+    delta <- stats::median(diff(all.dates$date), na.rm = TRUE)
+  } else {
+    delta <- as.difftime(1, units = "hours")  # default to 1 hour if only one timestamp
   }
-  if (end.date > max(all.dates$date)) {
-   PEcAn.logger::logger.severe("run end date", end.date, "after met data ends", max(all.dates$date))
+  
+  # Check if start date is more than one timestep before the first available data
+  if (start.date < (min(all.dates$date) - delta)) {
+    PEcAn.logger::logger.severe("run start date", start.date, "before met data starts", min(all.dates$date))
+  }
+  
+  # Check if end date is more than one timestep after the last available data
+  if (end.date > (max(all.dates$date) + delta)) {
+    PEcAn.logger::logger.severe("run end date", end.date, "after met data ends", max(all.dates$date))
   }
   
   run.dates <- all.dates %>%

--- a/modules/data.atmosphere/R/load.cfmet.R
+++ b/modules/data.atmosphere/R/load.cfmet.R
@@ -51,19 +51,16 @@ load.cfmet <- function(met.nc, lat, lon, start.date, end.date) {
 
   all.dates <- data.frame(index = seq_along(time.idx), date = date)
   
-  # Calculate the typical timestep of the met data using median for robustness
   if (nrow(all.dates) > 1) {
     delta <- stats::median(diff(all.dates$date), na.rm = TRUE)
   } else {
-    delta <- as.difftime(1, units = "hours")  # default to 1 hour if only one timestamp
+    delta <- as.difftime(1, units = "hours")  
   }
   
-  # Check if start date is more than one timestep before the first available data
   if (start.date < (min(all.dates$date) - delta)) {
     PEcAn.logger::logger.severe("run start date", start.date, "before met data starts", min(all.dates$date))
   }
   
-  # Check if end date is more than one timestep after the last available data
   if (end.date > (max(all.dates$date) + delta)) {
     PEcAn.logger::logger.severe("run end date", end.date, "after met data ends", max(all.dates$date))
   }

--- a/modules/data.atmosphere/tests/testthat/test.load.cfmet.R
+++ b/modules/data.atmosphere/tests/testthat/test.load.cfmet.R
@@ -49,7 +49,7 @@ test_that("load.cfmet throws error if start/end date out of range",{
                           start.date = "1950-12-31", end.date = "1951-12-31"),
                "run start date .* before met data starts")
   expect_error(load.cfmet(met.nc = daily.nc, lat = 39, lon = -88,
-                          start.date = "1951-01-02", end.date = "1952-01-01"),
+                          start.date = "1951-01-02", end.date = "1952-01-15"),
                "run end date .* after met data ends")
 })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
This PR addresses a runtime error encountered when running the BIOCRO model via the PEcAn web interface. The error is as follows:
```
remotefunc <- function() {PEcAn.BIOCRO::met2model.BIOCRO(lst=-8, lat=41.0310397553517, lon=-116.357721712155, spin_nyear=NULL, spin_nsample=NULL, spin_resample=NULL, dbfile.id=99000000167, overwrite=FALSE, in.path='/data/dbfiles/CRUNCEP_site_2-1087', in.prefix='CRUNCEP', outfolder='/data/dbfiles/CRUNCEP_BIOCRO_site_2-1087/', start_date='2004/01/01', end_date='2004/12/31')}
> remoteout <- remotefunc()
2025-07-20 12:50:19.723249 SEVERE [PEcAn.data.atmosphere::load.cfmet] :
run end date 1104537599 after met data ends 1104526800
Error in PEcAn.logger::logger.severe("run end date", end.date, "after met data ends", :
run end date 2004-12-31 23:59:59 after met data ends 2004-12-31 21:00:00
Calls: remotefunc -> -> ->
Execution halted
```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

may be related to [Issue #2274](https://github.com/PecanProject/pecan/issues/2274).
## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [x] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
