### PR TITLE
checks: file-path for met.proces in do_conversions

### DIFF
--- a/base/workflow/R/do_conversions.R
+++ b/base/workflow/R/do_conversions.R
@@ -104,7 +104,6 @@ do_conversions <- function(settings, overwrite.met = FALSE, overwrite.fia = FALS
       if (!is.null(settings$run$inputs$met$path)) {
       PEcAn.logger::logger.info("Skipping met.process: model-ready path provided")
       settings$run$inputs[[i]] <- settings$run$inputs$met
-      needsave <- TRUE
 
       }else if ( (PEcAn.utils::status.check(name) == 0)) { ## previously is.null(input$path) && 
         PEcAn.logger::logger.info("calling met.process: ",settings$run$inputs[[i]][['path']])

--- a/base/workflow/R/do_conversions.R
+++ b/base/workflow/R/do_conversions.R
@@ -98,8 +98,15 @@ do_conversions <- function(settings, overwrite.met = FALSE, overwrite.fia = FALS
     # met conversion
     
     if (input.tag == "met") {
+
       name <- "MET Process"
-      if ( (PEcAn.utils::status.check(name) == 0)) { ## previously is.null(input$path) && 
+
+      if (!is.null(settings$run$inputs$met$path)) {
+      PEcAn.logger::logger.info("Skipping met.process: model-ready path provided")
+      settings$run$inputs[[i]] <- settings$run$inputs$met
+      needsave <- TRUE
+
+      }else if ( (PEcAn.utils::status.check(name) == 0)) { ## previously is.null(input$path) && 
         PEcAn.logger::logger.info("calling met.process: ",settings$run$inputs[[i]][['path']])
         settings$run$inputs[[i]] <- 
           PEcAn.data.atmosphere::met.process(


### PR DESCRIPTION
This PR adds a simple check in do_conversions() to skip calling met.process() if a valid path is already supplied in the settings.

✅ Avoids unnecessary processing step
✅ Improves performance and clarity 
✅ Keeps met.process() callable directly if needed

This helps streamline workflows where users provide pre-processed met data.
