### PR TITLE
added check for file paths

### DIFF
--- a/base/workflow/R/do_conversions.R
+++ b/base/workflow/R/do_conversions.R
@@ -28,6 +28,12 @@ do_conversions <- function(settings, overwrite.met = FALSE, overwrite.fia = FALS
       next
     }
     
+  # Check for existing file paths , skips if the file exists
+    if (!is.null(input$path) && is.null(input$force)) {
+      PEcAn.logger::logger.info("Skipping input with existing path:", input.tag)
+      next
+    }
+    
     input.tag <- names(settings$run$input)[i]
     PEcAn.logger::logger.info("PROCESSING: ",input.tag)
     

--- a/base/workflow/R/do_conversions.R
+++ b/base/workflow/R/do_conversions.R
@@ -28,14 +28,14 @@ do_conversions <- function(settings, overwrite.met = FALSE, overwrite.fia = FALS
       next
     }
     
-  # Check for existing file paths , skips if the file exists
+    input.tag <- names(settings$run$input)[i]
+    PEcAn.logger::logger.info("PROCESSING: ",input.tag)
+
+    # Check for existing file paths , skips if the file exists
     if (!is.null(input$path) && is.null(input$force)) {
       PEcAn.logger::logger.info("Skipping input with existing path:", input.tag)
       next
     }
-    
-    input.tag <- names(settings$run$input)[i]
-    PEcAn.logger::logger.info("PROCESSING: ",input.tag)
     
     
     ic.flag <- fia.flag <- FALSE


### PR DESCRIPTION
This PR refactors do_conversions() to introduce a centralised check that skips input conversion if a valid path is already provided, unless the user explicitly sets force = TRUE for that input.

Key Improvements : 
Generalised path check applies to all inputs (met, soil, IC, etc.)

Supports per-input override with <force>TRUE</force> to trigger conversion even when a path is present.

Improves performance and clarity in workflows where inputs are already pre-processed.

Overhead work of  PR #3579 