### PR TITLE
Logger: setters return old value, coerce all msg components to string before concatenating

### DIFF
--- a/base/logger/DESCRIPTION
+++ b/base/logger/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: PEcAn.logger
 Title: Logger Functions for 'PEcAn'
-Version: 1.8.3
+Version: 1.8.4
 Authors@R: c(person("Rob", "Kooper", role = c("aut", "cre"),
                      email = "kooper@illinois.edu"),
              person("Alexey", "Shiklomanov", role = c("aut"),

--- a/base/logger/NEWS.md
+++ b/base/logger/NEWS.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- All `logger.set*` functions now invisibly return the previously set value. This can be handy for restoring settings after a temporary change.
+
 # PEcAn.logger 1.8.3
 
 - Maintenance release with no user-visible changes.

--- a/base/logger/NEWS.md
+++ b/base/logger/NEWS.md
@@ -1,6 +1,7 @@
-# Unreleased
+# PEcAn.logger 1.8.4 (unreleased)
 
 - All `logger.set*` functions now invisibly return the previously set value. This can be handy for restoring settings after a temporary change.
+- Multipart logger messages passed in `...` now get a more robust conversion to string before concatenating, hopefully giving nicer results for nontext objects such as dates and lists.
 
 # PEcAn.logger 1.8.3
 

--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -247,11 +247,14 @@ logger.getLevel <- function() {
 
 
 ##' Configure logging to console.
-##' 
+##'
 ##' Should the logging to be printed to the console or not.
 ##'
 ##' @param console set to true to print logging to console.
-##' @param stderr set to true (default) to use stderr instead of stdout for logging
+##' @param stderr set to true (default) to log to stderr instead of stdout
+##' @return Invisibly, a list of the previously set values of `console`
+##'   and `stderr`. This can be used to restore the previous settings after a
+##'   temporary change.
 ##' @export
 ##' @author Rob Kooper
 ##' @examples
@@ -259,16 +262,22 @@ logger.getLevel <- function() {
 ##' logger.setUseConsole(TRUE)
 ##' }
 logger.setUseConsole <- function(console, stderr = TRUE) {
+  old <- list(console = .utils.logger$console, stderr = .utils.logger$stderr)
   .utils.logger$console <- console
   .utils.logger$stderr <- stderr
+
+  invisible(old)
 } # logger.setUseConsole
 
 
 ##' Configure logging output filename.
-##' 
+##'
 ##' The name of the file where the logging information should be written to.
 ##'
-##' @param filename the file to send the log messages to (or NA to not write to file)
+##' @param filename the file to send the log messages to
+##'  (or NA to not write to file)
+##' @return Invisibly, the previously set filename.
+##'   This can be used to restore settings after a temporary change.
 ##' @export
 ##' @author Rob Kooper
 ##' @examples
@@ -276,25 +285,32 @@ logger.setUseConsole <- function(console, stderr = TRUE) {
 ##' logger.setOutputFile('pecan.log')
 ##' }
 logger.setOutputFile <- function(filename) {
+  old <- .utils.logger$filename
   .utils.logger$filename <- filename
+
+  invisible(old)
 } # logger.setOutputFile
 
 
 ##' Configure whether severe should quit.
-##' 
-##' The default is for a non-interactive session to quit. Setting this to false is
-##' especially useful for running tests when placed in \code{inst/tests/test.<fn>.R}, 
-##' but is not passed from \code{tests/run.all.R}.
+##'
+##' The default is for a non-interactive session to quit.
+##' Setting this to false is especially useful for running tests.
 ##'
 ##' @param severeQuits should R quit on a severe error.
 ##' @export
+##' @return invisibly, the previous value of `severeQuits`.
+##'   This can be used to restore settings after a temporary change.
 ##' @author Rob Kooper
 ##' @examples
 ##' \dontrun{
 ##' logger.setQuitOnSevere(FALSE)
 ##' }
 logger.setQuitOnSevere <- function(severeQuits) {
+  old <- .utils.logger$quit
   .utils.logger$quit <- severeQuits
+
+  invisible(old)
 } # logger.setQuitOnSevere
 
 
@@ -304,6 +320,8 @@ logger.setQuitOnSevere <- function(severeQuits) {
 ##' wrap the line when printing a message at that many chars.
 ##'
 ##' @param width number of chars to print before wrapping to next line.
+##' @return Invisibly, the previously set width.
+##'   This can be used to restore settings after a temporary change.
 ##' @export
 ##' @author David LeBauer
 ##' @examples
@@ -311,5 +329,8 @@ logger.setQuitOnSevere <- function(severeQuits) {
 ##' logger.setWidth(70)
 ##' }
 logger.setWidth <- function(width) {
+  old <- .utils.logger$width
   .utils.logger$width <- width
+
+  invisible(old)
 } # logger.setWidth

--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -247,7 +247,7 @@ logger.getLevelNumber <- function(level) {
 ##' `logger.getLevel()` is not required to restore the level after a 
 ##' temporary change.
 ##'
-##' @return level the level of the message, one of 
+##' @return A string giving the lowest message level that will be reported, one of 
 ##' "ALL", "DEBUG", "INFO", "WARN", "ERROR", "SEVERE", or "OFF".
 ##' @export
 ##' @author Rob Kooper

--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -181,8 +181,6 @@ logger.message <- function(level, msg, ..., wrap = TRUE) {
 ##'
 ##' @param level the level of the message. One of "ALL", "DEBUG", "INFO", "WARN",
 ##' "ERROR", "SEVERE", or "OFF".
-##' Use "SEVERE" instead of "ERROR" for fatal errors. If `logger.setQuitOnSevere(TRUE)`,
-##' These will the program to stop (default is FALSE). 
 ##'
 ##' @export
 ##' @return When logger level is set, the previous level is returned invisibly.

--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -4,12 +4,12 @@
 .utils.logger$stderr <- TRUE
 .utils.logger$quit <- FALSE
 .utils.logger$level <- 0
-.utils.logger$width <- ifelse(getOption("width") < 10, 
-                              getOption("width"), 
+.utils.logger$width <- ifelse(getOption("width") < 10,
+                              getOption("width"),
                               getOption("width") - 5)
 
 ##' Prints a debug message.
-##' 
+##'
 ##' This function will print a debug message.
 ##'
 ##' @param msg the message that should be printed.
@@ -26,7 +26,7 @@ logger.debug <- function(msg, ...) {
 
 
 ##' Prints an informational message.
-##' 
+##'
 ##' This function will print an informational message.
 ##'
 ##' @param msg the message that should be printed.
@@ -43,7 +43,7 @@ logger.info <- function(msg, ...) {
 
 
 ##' Prints a warning message.
-##' 
+##'
 ##' This function will print a warning message.
 ##'
 ##' @param msg the message that should be printed.
@@ -60,7 +60,7 @@ logger.warn <- function(msg, ...) {
 
 
 ##' Prints an error message.
-##' 
+##'
 ##' This function will print an error message.
 ##'
 ##' @param msg the message that should be printed.
@@ -76,11 +76,11 @@ logger.error <- function(msg, ...) {
 } # logger.error
 
 
-##' Prints an severe message and stops execution.
-##' 
+##' Prints a severe message and stops execution.
+##'
 ##' This function will print a message and stop execution of the code. This
 ##' should only be used if the application should terminate.
-##' 
+##'
 ##' set \code{\link{logger.setQuitOnSevere}(FALSE)} to avoid terminating
 ##' the session. This is set by default to TRUE if interactive or running
 ##' inside Rstudio.
@@ -96,13 +96,13 @@ logger.error <- function(msg, ...) {
 ##' }
 logger.severe <- function(msg, ..., wrap = TRUE) {
   logger.message("SEVERE", msg, ...)
-  
+
   # run option
   error <- getOption("error")
   if (!is.null(error)) {
     eval(error)
   }
-  
+
   # quit if not interactive, otherwise use stop
   if (.utils.logger$quit) {
     quit(save = "no", status = 1)
@@ -113,11 +113,13 @@ logger.severe <- function(msg, ..., wrap = TRUE) {
 
 
 ##' Prints a message at a certain log level.
-##' 
-##' This function will print a message. This is the function that is responsible for
-##' the actual printing of the message.
 ##'
-##' This is a place holder and will be later filled in with a more complex logging set
+##' This function will print a message. This is the function that is responsible
+##' for the actual printing of the message.
+##'
+##' This is a place holder and will be later filled in with a more complex
+##' logging set
+##'
 ##' @param level the level of the message (DEBUG, INFO, WARN, ERROR)
 ##' @param msg the message that should be printed.
 ##' @param ... any additional text that should be printed.
@@ -138,24 +140,28 @@ logger.message <- function(level, msg, ..., wrap = TRUE) {
     if (length(func) == 0) {
       func <- "console"
     }
-    
+
     stamp.text <- sprintf("%s %-6s [%s] :", Sys.time(), level, func)
-    long.msg <- stringi::stri_trans_general(paste(c(msg, ...), collapse = " "), "latin-ascii")
+    args <- sapply(list(...), FUN = toString)
+    long.msg <- stringi::stri_trans_general(
+      paste(c(msg, args), collapse = " "),
+      "latin-ascii"
+    )
     if (nchar(long.msg) > 20 && wrap) {
-      new.msg <- paste("\n", strwrap(long.msg, width = .utils.logger$width, 
+      new.msg <- paste("\n", strwrap(long.msg, width = .utils.logger$width,
                                      indent = 2, exdent = 2), collapse = " ")
     } else {
       new.msg <- long.msg
     }
     text <- paste(stamp.text, new.msg, "\n")
-    
+
     if (.utils.logger$console) {
       if (.utils.logger$stderr) {
         cat(text, file = stderr())
       } else {
         cat(text, file = stdout())
       }
-      
+
     }
     if (!is.na(.utils.logger$filename)) {
       cat(text, file = .utils.logger$filename, append = TRUE)
@@ -165,7 +171,7 @@ logger.message <- function(level, msg, ..., wrap = TRUE) {
 
 
 ##' Configure logging level.
-##' 
+##'
 ##' This will configure the logger level. This allows to turn DEBUG, INFO,
 ##' WARN and ERROR messages on and off.
 ##'
@@ -181,6 +187,7 @@ logger.message <- function(level, msg, ..., wrap = TRUE) {
 logger.setLevel <- function(level) {
   original_level <- logger.getLevel()
   .utils.logger$level <- logger.getLevelNumber(level)
+
   invisible(original_level)
 } # logger.setLevel
 
@@ -217,7 +224,7 @@ logger.getLevelNumber <- function(level) {
 
 
 ##' Get configured logging level.
-##' 
+##'
 ##' This will return the current level configured of the logging messages
 ##'
 ##' @return level the level of the message (ALL, DEBUG, INFO, WARN, ERROR, OFF)

--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -174,6 +174,11 @@ logger.message <- function(level, msg, ..., wrap = TRUE) {
 ##' This will configure the logger level. This allows to turn DEBUG, INFO,
 ##' WARN, ERROR, and SEVERE messages on and off.
 ##'
+##' Note that this controls _printing_ of messages and does not change other behavior.
+##' In particular, suppressing SEVERE by setting the level to "OFF" does not prevent
+##' logger.severe() from signaling an error (and terminating the program if 
+##' `logger.setQuitOnSevere(TRUE)`).
+##'
 ##' @param level the level of the message. One of "ALL", "DEBUG", "INFO", "WARN",
 ##' "ERROR", "SEVERE", or "OFF".
 ##' Use "SEVERE" instead of "ERROR" for fatal errors. If `logger.setQuitOnSevere(TRUE)`,

--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -214,6 +214,7 @@ logger.setLevel <- function(level) {
 ##
 ## SEVERE is treated as more serious than ERROR,
 ## and will terminate the session if `logger.setQuitOnSevere(TRUE)`
+## or call stop() otherwise
 ##
 ## @return level the level of the message
 ## @author Rob Kooper

--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -81,7 +81,7 @@ logger.error <- function(msg, ...) {
 ##' This function will print a message and stop execution of the code. This
 ##' should only be used if the application should terminate.
 ##'
-##' set \code{\link{logger.setQuitOnSevere}(FALSE)} to avoid terminating
+##' Set \code{\link{logger.setQuitOnSevere}(FALSE)} to avoid terminating
 ##' the session. This is set by default to TRUE if interactive or running
 ##' inside Rstudio.
 ##'
@@ -173,9 +173,13 @@ logger.message <- function(level, msg, ..., wrap = TRUE) {
 ##' Configure logging level.
 ##'
 ##' This will configure the logger level. This allows to turn DEBUG, INFO,
-##' WARN and ERROR messages on and off.
+##' WARN, ERROR, and SEVERE messages on and off.
 ##'
-##' @param level the level of the message (ALL, DEBUG, INFO, WARN, ERROR, OFF)
+##' @param level the level of the message. One of "ALL", "DEBUG", "INFO", "WARN",
+##' "ERROR", "SEVERE", or "OFF".
+##' Use "SEVERE" instead of "ERROR" for fatal errors. If `logger.setQuitOnSevere(TRUE)`,
+##' These will the program to stop (default is FALSE). 
+##'
 ##' @export
 ##' @return When logger level is set, the previous level is returned invisibly.
 ##'   This can be passed to `logger.setLevel()` to restore the previous level.
@@ -183,6 +187,11 @@ logger.message <- function(level, msg, ..., wrap = TRUE) {
 ##' @examples
 ##' \dontrun{
 ##' logger.setLevel('DEBUG')
+##' 
+##' # Temporarily turn logger off
+##' old_logger_level <- logger.setLevel("OFF")
+##'   # code here
+##' logger.setLevel(old_logger_level)
 ##' }
 logger.setLevel <- function(level) {
   original_level <- logger.getLevel()
@@ -193,14 +202,21 @@ logger.setLevel <- function(level) {
 
 
 ## Given the string representation this will return the numeric value
-## DEBUG = 10
-## INFO  = 20
-## WARN  = 30
-## ERROR = 40
-## ALL   = 99
 ##
-##@return level the level of the message
-##@author Rob Kooper
+## Supported levels
+##   ALL    = 0
+##   DEBUG  = 10
+##   INFO   = 20
+##   WARN   = 30
+##   ERROR  = 40
+##   SEVERE = 50
+##   OFF    = 60
+##
+## SEVERE is treated as more serious than ERROR,
+## and will terminate the session if `logger.setQuitOnSevere(TRUE)`
+##
+## @return level the level of the message
+## @author Rob Kooper
 logger.getLevelNumber <- function(level) {
   if (toupper(level) == "ALL") {
     return(0)
@@ -213,7 +229,7 @@ logger.getLevelNumber <- function(level) {
   } else if (toupper(level) == "ERROR") {
     return(40)
   } else if (toupper(level) == "SEVERE") {
-    return(40)
+    return(50)
   } else if (toupper(level) == "OFF") {
     return(60)
   } else {
@@ -225,9 +241,14 @@ logger.getLevelNumber <- function(level) {
 
 ##' Get configured logging level.
 ##'
-##' This will return the current level configured of the logging messages
+##' This will return the current level configured of the logging messages.
+##' 
+##' Note that `logger.setLevel()` invisibly returns current level, so 
+##' `logger.getLevel()` is not required to restore the level after a 
+##' temporary change.
 ##'
-##' @return level the level of the message (ALL, DEBUG, INFO, WARN, ERROR, OFF)
+##' @return level the level of the message, one of 
+##' "ALL", "DEBUG", "INFO", "WARN", "ERROR", "SEVERE", or "OFF".
 ##' @export
 ##' @author Rob Kooper
 ##' @examples

--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -82,8 +82,7 @@ logger.error <- function(msg, ...) {
 ##' should only be used if the application should terminate.
 ##'
 ##' Set \code{\link{logger.setQuitOnSevere}(FALSE)} to avoid terminating
-##' the session. This is set by default to TRUE if interactive or running
-##' inside Rstudio.
+##' the session. The default is to not quit if running interactively.
 ##'
 ##' @param msg the message that should be printed.
 ##' @param ... any additional text that should be printed.

--- a/base/logger/man/logger.getLevel.Rd
+++ b/base/logger/man/logger.getLevel.Rd
@@ -7,7 +7,7 @@
 logger.getLevel()
 }
 \value{
-level the level of the message, one of
+A string giving the lowest message level that will be reported, one of
 "ALL", "DEBUG", "INFO", "WARN", "ERROR", "SEVERE", or "OFF".
 }
 \description{

--- a/base/logger/man/logger.getLevel.Rd
+++ b/base/logger/man/logger.getLevel.Rd
@@ -7,10 +7,16 @@
 logger.getLevel()
 }
 \value{
-level the level of the message (ALL, DEBUG, INFO, WARN, ERROR, OFF)
+level the level of the message, one of
+"ALL", "DEBUG", "INFO", "WARN", "ERROR", "SEVERE", or "OFF".
 }
 \description{
-This will return the current level configured of the logging messages
+This will return the current level configured of the logging messages.
+}
+\details{
+Note that \code{logger.setLevel()} invisibly returns current level, so
+\code{logger.getLevel()} is not required to restore the level after a
+temporary change.
 }
 \examples{
 \dontrun{

--- a/base/logger/man/logger.message.Rd
+++ b/base/logger/man/logger.message.Rd
@@ -18,11 +18,12 @@ logger.message(level, msg, ..., wrap = TRUE)
 for specifically formatted error messages.}
 }
 \description{
-This function will print a message. This is the function that is responsible for
-the actual printing of the message.
+This function will print a message. This is the function that is responsible
+for the actual printing of the message.
 }
 \details{
-This is a place holder and will be later filled in with a more complex logging set
+This is a place holder and will be later filled in with a more complex
+logging set
 }
 \examples{
 \dontrun{

--- a/base/logger/man/logger.setLevel.Rd
+++ b/base/logger/man/logger.setLevel.Rd
@@ -8,9 +8,7 @@ logger.setLevel(level)
 }
 \arguments{
 \item{level}{the level of the message. One of "ALL", "DEBUG", "INFO", "WARN",
-"ERROR", "SEVERE", or "OFF".
-Use "SEVERE" instead of "ERROR" for fatal errors. If \code{logger.setQuitOnSevere(TRUE)},
-These will the program to stop (default is FALSE).}
+"ERROR", "SEVERE", or "OFF".}
 }
 \value{
 When logger level is set, the previous level is returned invisibly.
@@ -19,6 +17,12 @@ This can be passed to \code{logger.setLevel()} to restore the previous level.
 \description{
 This will configure the logger level. This allows to turn DEBUG, INFO,
 WARN, ERROR, and SEVERE messages on and off.
+}
+\details{
+Note that this controls \emph{printing} of messages and does not change other behavior.
+In particular, suppressing SEVERE by setting the level to "OFF" does not prevent
+logger.severe() from signaling an error (and terminating the program if
+\code{logger.setQuitOnSevere(TRUE)}).
 }
 \examples{
 \dontrun{

--- a/base/logger/man/logger.setLevel.Rd
+++ b/base/logger/man/logger.setLevel.Rd
@@ -7,7 +7,10 @@
 logger.setLevel(level)
 }
 \arguments{
-\item{level}{the level of the message (ALL, DEBUG, INFO, WARN, ERROR, OFF)}
+\item{level}{the level of the message. One of "ALL", "DEBUG", "INFO", "WARN",
+"ERROR", "SEVERE", or "OFF".
+Use "SEVERE" instead of "ERROR" for fatal errors. If \code{logger.setQuitOnSevere(TRUE)},
+These will the program to stop (default is FALSE).}
 }
 \value{
 When logger level is set, the previous level is returned invisibly.
@@ -15,11 +18,16 @@ This can be passed to \code{logger.setLevel()} to restore the previous level.
 }
 \description{
 This will configure the logger level. This allows to turn DEBUG, INFO,
-WARN and ERROR messages on and off.
+WARN, ERROR, and SEVERE messages on and off.
 }
 \examples{
 \dontrun{
 logger.setLevel('DEBUG')
+
+# Temporarily turn logger off
+old_logger_level <- logger.setLevel("OFF")
+  # code here
+logger.setLevel(old_logger_level)
 }
 }
 \author{

--- a/base/logger/man/logger.setOutputFile.Rd
+++ b/base/logger/man/logger.setOutputFile.Rd
@@ -7,7 +7,12 @@
 logger.setOutputFile(filename)
 }
 \arguments{
-\item{filename}{the file to send the log messages to (or NA to not write to file)}
+\item{filename}{the file to send the log messages to
+(or NA to not write to file)}
+}
+\value{
+Invisibly, the previously set filename.
+This can be used to restore settings after a temporary change.
 }
 \description{
 The name of the file where the logging information should be written to.

--- a/base/logger/man/logger.setQuitOnSevere.Rd
+++ b/base/logger/man/logger.setQuitOnSevere.Rd
@@ -9,10 +9,13 @@ logger.setQuitOnSevere(severeQuits)
 \arguments{
 \item{severeQuits}{should R quit on a severe error.}
 }
+\value{
+invisibly, the previous value of \code{severeQuits}.
+This can be used to restore settings after a temporary change.
+}
 \description{
-The default is for a non-interactive session to quit. Setting this to false is
-especially useful for running tests when placed in \code{inst/tests/test.<fn>.R},
-but is not passed from \code{tests/run.all.R}.
+The default is for a non-interactive session to quit.
+Setting this to false is especially useful for running tests.
 }
 \examples{
 \dontrun{

--- a/base/logger/man/logger.setUseConsole.Rd
+++ b/base/logger/man/logger.setUseConsole.Rd
@@ -9,7 +9,12 @@ logger.setUseConsole(console, stderr = TRUE)
 \arguments{
 \item{console}{set to true to print logging to console.}
 
-\item{stderr}{set to true (default) to use stderr instead of stdout for logging}
+\item{stderr}{set to true (default) to log to stderr instead of stdout}
+}
+\value{
+Invisibly, a list of the previously set values of \code{console}
+and \code{stderr}. This can be used to restore the previous settings after a
+temporary change.
 }
 \description{
 Should the logging to be printed to the console or not.

--- a/base/logger/man/logger.setWidth.Rd
+++ b/base/logger/man/logger.setWidth.Rd
@@ -9,6 +9,10 @@ logger.setWidth(width)
 \arguments{
 \item{width}{number of chars to print before wrapping to next line.}
 }
+\value{
+Invisibly, the previously set width.
+This can be used to restore settings after a temporary change.
+}
 \description{
 The default is for 60 chars per line. Setting this to any value will
 wrap the line when printing a message at that many chars.

--- a/base/logger/man/logger.severe.Rd
+++ b/base/logger/man/logger.severe.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/logger.R
 \name{logger.severe}
 \alias{logger.severe}
-\title{Prints an severe message and stops execution.}
+\title{Prints a severe message and stops execution.}
 \usage{
 logger.severe(msg, ..., wrap = TRUE)
 }

--- a/base/logger/man/logger.severe.Rd
+++ b/base/logger/man/logger.severe.Rd
@@ -21,8 +21,7 @@ should only be used if the application should terminate.
 }
 \details{
 Set \code{\link{logger.setQuitOnSevere}(FALSE)} to avoid terminating
-the session. This is set by default to TRUE if interactive or running
-inside Rstudio.
+the session. The default is to not quit if running interactively.
 }
 \examples{
 \dontrun{

--- a/base/logger/man/logger.severe.Rd
+++ b/base/logger/man/logger.severe.Rd
@@ -20,7 +20,7 @@ This function will print a message and stop execution of the code. This
 should only be used if the application should terminate.
 }
 \details{
-set \code{\link{logger.setQuitOnSevere}(FALSE)} to avoid terminating
+Set \code{\link{logger.setQuitOnSevere}(FALSE)} to avoid terminating
 the session. This is set by default to TRUE if interactive or running
 inside Rstudio.
 }

--- a/base/logger/tests/testthat/test.logger.R
+++ b/base/logger/tests/testthat/test.logger.R
@@ -7,7 +7,7 @@ test_that("`logger.getLevelNumber` returns correct level number",{
   expect_equal(logger.getLevelNumber("info"), 20)
   expect_equal(logger.getLevelNumber("warn"), 30)
   expect_equal(logger.getLevelNumber("error"), 40)
-  expect_equal(logger.getLevelNumber("severe"), 40)
+  expect_equal(logger.getLevelNumber("severe"), 50)
   expect_equal(logger.getLevelNumber("off"), 60)
   
   old_settings <- logger.setLevel("ERROR")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description

### Setters return old value
`logger.set*(op)` now invisibly returns the value of `op` that was in effect before the call, for ease of undoing temporary changes by the same pattern you might know from `op <- options(...); on.exit(options(op))`. I found I was wanting this to keep state clean during testing.

### More robust string conversion
Cases where the message is composed from objects of mixed type now convert each argument to a string before concatenating them. 

Before: 

```
> logger.info("dates were", as.Date(c("2024-01-01", "2025-01-23")))
2025-08-06 02:19:58.225157 INFO   [console] : 
   dates were 19723 20111 
```

After:

```
> logger.info("dates were", as.Date(c("2024-01-01", "2025-01-23")))'
2025-08-06 02:09:12.461013 INFO   [console] : 
   dates were 2024-01-01, 2025-01-23
```

### Also

- whitespace cleanup
- couple minor Roxygen wording tweaks


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
