### PR TITLE
Fixed two issues in pecan-to-sipnet parameter conversion.

### DIFF
--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -191,31 +191,34 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
     pft.traits <- as.numeric(pft.traits)
     
     # Leaf carbon concentration
-    leafC <- 0.48  #0.5
+    leafC <- 0.48
     if ("leafC" %in% pft.names) {
       leafC <- pft.traits[which(pft.names == "leafC")]
       id <- which(param[, 1] == "cFracLeaf")
-      param[id, 2] <- leafC * 0.01  # convert to percentage from 0 to 1
+      param[id, 2] <- leafC * 0.01  # convert from percentage to fraction
     }
     
     # Specific leaf area converted to SLW
+    # leafCSpWt [gC/m2 leaf], SLA [m2 leaf/kg C], leafC [percentage C]
     SLA <- NA
     id <- which(param[, 1] == "leafCSpWt")
     if ("SLA" %in% pft.names) {
       SLA <- pft.traits[which(pft.names == "SLA")]
-      param[id, 2] <- 1000 * leafC * 0.01 / SLA
+      param[id, 2] <- 10 * leafC / SLA
     } else {
-      SLA <- 1000 * leafC / param[id, 2]
+      SLA <- 10 * leafC / param[id, 2]
     }
     
     # Maximum photosynthesis
+    # amax [nmol CO2 * g^{-1} leaf * sec^{-1}]
+    # Amax [umol CO2 * m^2 leaf * sec^{-1}]
     Amax <- NA
     id <- which(param[, 1] == "aMax")
     if ("Amax" %in% pft.names) {
       Amax <- pft.traits[which(pft.names == "Amax")]
       param[id, 2] <- Amax * SLA
     } else {
-      Amax <- param[id, 2] * SLA
+      Amax <- param[id, 2] / SLA
     }
     # Daily fraction of maximum photosynthesis
     if ("AmaxFrac" %in% pft.names) {

--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -221,7 +221,7 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
       param[id, 2] <- PEcAn.utils::ud_convert(Amax_area * SLA_g, "umol", "nmol") # [nmol/g/s]
     } else {
       amax_mass <- param[id, 2] # [nmol/g/s]
-      Amax <- PEcAn.utils::ud_convert(amax_mass / SLA_g, "nmol", "umol") # [umol/m2/s]
+      Amax_area <- PEcAn.utils::ud_convert(amax_mass / SLA_g, "nmol", "umol") # [umol/m2/s]
     }
     
     # Daily fraction of maximum photosynthesis

--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -165,7 +165,7 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
   }
   for (pft in seq_along(trait.values)) {
     pft.traits <- unlist(trait.values[[pft]])
-    pft.names <- names(pft.traits)
+    pft.trait.names <- names(pft.traits)
     
     ## Append/replace params specified as constants
     constant.traits <- unlist(defaults[[1]]$constants)
@@ -173,10 +173,10 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
     
     # Replace matches
     for (i in seq_along(constant.traits)) {
-      ind <- match(constant.names[i], pft.names)
+      ind <- match(constant.names[i], pft.trait.names)
       if (is.na(ind)) {
         # Add to list
-        pft.names <- c(pft.names, constant.names[i])
+        pft.trait.names <- c(pft.trait.names, constant.names[i])
         pft.traits <- c(pft.traits, constant.traits[i])
       } else {
         # Replace existing value
@@ -186,24 +186,26 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
     
     # Remove NAs. Constants may be specified as NA to request template defaults. Note that it is 'NA'
     # (character) not actual NA due to being read in as XML
-    pft.names <- pft.names[pft.traits != "NA" & !is.na(pft.traits)]
+    pft.trait.names <- pft.trait.names[pft.traits != "NA" & !is.na(pft.traits)]
     pft.traits <- pft.traits[pft.traits != "NA" & !is.na(pft.traits)]
     pft.traits <- as.numeric(pft.traits)
     
-    # Leaf carbon concentration
-    leafC <- 0.48
-    if ("leafC" %in% pft.names) {
-      leafC <- pft.traits[which(pft.names == "leafC")]
+    # Leaf carbon concentration    
+    leafC <- NA
+    if ("leafC" %in% pft.trait.names) {
+      leafC <- pft.traits[which(pft.trait.names == "leafC")]
       id <- which(param[, 1] == "cFracLeaf")
-      param[id, 2] <- leafC * 0.01  # convert from percentage to fraction
+      param[id, 2] <- PEcAn.utils::ud_convert(leafC, "percent", "1") # Convert from percentage to fraction
+    } else {
+      leafC <- 0.48 # Fixed value if not available, because it is used in downstream calculations
     }
     
     # Specific leaf area converted to SLW
     # leafCSpWt [gC/m2 leaf], SLA [m2 leaf/kg C], leafC [percentage C]
     SLA <- NA
     id <- which(param[, 1] == "leafCSpWt")
-    if ("SLA" %in% pft.names) {
-      SLA <- pft.traits[which(pft.names == "SLA")]
+    if ("SLA" %in% pft.trait.names) {
+      SLA <- pft.traits[which(pft.trait.names == "SLA")]
       param[id, 2] <- PEcAn.utils::ud_convert(leafC / SLA, "kg/m2", "g/m2")
     } else {
       SLA <- PEcAn.utils::ud_convert(leafC / param[id, 2], "kg", "g")
@@ -213,8 +215,8 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
     # PEcAn:  Amax [umol CO2 / m^2 leaf / sec]
     id <- which(param[, 1] == "aMax")
     SLA_g <- PEcAn.utils::ud_convert(SLA, "1/kg", "1/g") 
-    if ("Amax" %in% pft.names) {
-      Amax_area <- pft.traits[which(pft.names == "Amax")] # [µmol/m2/s]
+    if ("Amax" %in% pft.trait.names) {
+      Amax_area <- pft.traits[which(pft.trait.names == "Amax")] # [µmol/m2/s]
       param[id, 2] <- PEcAn.utils::ud_convert(Amax_area * SLA_g, "umol/m2/s", "nmol/g/s")
     } else {
       amax_mass <- param[id, 2] # [nmol/g/s]
@@ -222,46 +224,46 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
     }
     
     # Daily fraction of maximum photosynthesis
-    if ("AmaxFrac" %in% pft.names) {
-      param[which(param[, 1] == "aMaxFrac"), 2] <- pft.traits[which(pft.names == "AmaxFrac")]
+    if ("AmaxFrac" %in% pft.trait.names) {
+      param[which(param[, 1] == "aMaxFrac"), 2] <- pft.traits[which(pft.trait.names == "AmaxFrac")]
     }
     
     ### Canopy extinction coefficiet (k)
-    if ("extinction_coefficient" %in% pft.names) {
-      param[which(param[, 1] == "attenuation"), 2] <- pft.traits[which(pft.names == "extinction_coefficient")]
+    if ("extinction_coefficient" %in% pft.trait.names) {
+      param[which(param[, 1] == "attenuation"), 2] <- pft.traits[which(pft.trait.names == "extinction_coefficient")]
     }
     
     # Leaf respiration rate converted to baseFolRespFrac
-    if ("leaf_respiration_rate_m2" %in% pft.names) {
-      Rd <- pft.traits[which(pft.names == "leaf_respiration_rate_m2")]
+    if ("leaf_respiration_rate_m2" %in% pft.trait.names) {
+      Rd <- pft.traits[which(pft.trait.names == "leaf_respiration_rate_m2")]
       id <- which(param[, 1] == "baseFolRespFrac")
       param[id, 2] <- max(min(Rd/Amax, 1), 0)
     }
     
     # Low temp threshold for photosynethsis
-    if ("Vm_low_temp" %in% pft.names) {
-      param[which(param[, 1] == "psnTMin"), 2] <- pft.traits[which(pft.names == "Vm_low_temp")]
+    if ("Vm_low_temp" %in% pft.trait.names) {
+      param[which(param[, 1] == "psnTMin"), 2] <- pft.traits[which(pft.trait.names == "Vm_low_temp")]
     }
     
     # Opt. temp for photosynthesis
-    if ("psnTOpt" %in% pft.names) {
-      param[which(param[, 1] == "psnTOpt"), 2] <- pft.traits[which(pft.names == "psnTOpt")]
+    if ("psnTOpt" %in% pft.trait.names) {
+      param[which(param[, 1] == "psnTOpt"), 2] <- pft.traits[which(pft.trait.names == "psnTOpt")]
     }
     
     # Growth respiration factor (fraction of GPP)
-    if ("growth_resp_factor" %in% pft.names) {
-      param[which(param[, 1] == "growthRespFrac"), 2] <- pft.traits[which(pft.names == "growth_resp_factor")]
+    if ("growth_resp_factor" %in% pft.trait.names) {
+      param[which(param[, 1] == "growthRespFrac"), 2] <- pft.traits[which(pft.trait.names == "growth_resp_factor")]
     }
     ### !!! NOT YET USED
     #Jmax = NA
-    #if("Jmax" %in% pft.names){
-    #  Jmax = pft.traits[which(pft.names == 'Jmax')]
+    #if("Jmax" %in% pft.trait.names){
+    #  Jmax = pft.traits[which(pft.trait.names == 'Jmax')]
     ### Using Jmax scaled to 25 degC. Maybe not be the best approach
     #}
     
     #alpha = NA
-    #if("quantum_efficiency" %in% pft.names){
-    #  alpha = pft.traits[which(pft.names == 'quantum_efficiency')]
+    #if("quantum_efficiency" %in% pft.trait.names){
+    #  alpha = pft.traits[which(pft.trait.names == 'quantum_efficiency')]
     #}
     
     # Half saturation of PAR.  PAR at which photosynthesis occurs at 1/2 theoretical maximum (Einsteins * m^-2 ground area * day^-1).
@@ -275,90 +277,90 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
     
     # Half saturation of PAR.  PAR at which photosynthesis occurs at 1/2 theoretical maximum (Einsteins * m^-2 ground area * day^-1).
     # Temporary implementation until above is working.
-    if ("half_saturation_PAR" %in% pft.names) {
-      param[which(param[, 1] == "halfSatPar"), 2] <- pft.traits[which(pft.names == "half_saturation_PAR")]
+    if ("half_saturation_PAR" %in% pft.trait.names) {
+      param[which(param[, 1] == "halfSatPar"), 2] <- pft.traits[which(pft.trait.names == "half_saturation_PAR")]
     }
     
     # Ball-berry slomatal slope parameter m
-    if ("stomatal_slope.BB" %in% pft.names) {
+    if ("stomatal_slope.BB" %in% pft.trait.names) {
       id <- which(param[, 1] == "m_ballBerry")
-      param[id, 2] <- pft.traits[which(pft.names == "stomatal_slope.BB")]
+      param[id, 2] <- pft.traits[which(pft.trait.names == "stomatal_slope.BB")]
     }
     
     # Slope of VPD–photosynthesis relationship. dVpd = 1 - dVpdSlope * vpd^dVpdExp
-    if ("dVPDSlope" %in% pft.names) {
-      param[which(param[, 1] == "dVpdSlope"), 2] <- pft.traits[which(pft.names == "dVPDSlope")]
+    if ("dVPDSlope" %in% pft.trait.names) {
+      param[which(param[, 1] == "dVpdSlope"), 2] <- pft.traits[which(pft.trait.names == "dVPDSlope")]
     }
     
     # VPD–water use efficiency relationship.  dVpd = 1 - dVpdSlope * vpd^dVpdExp
-    if ("dVpdExp" %in% pft.names) {
-      param[which(param[, 1] == "dVpdExp"), 2] <- pft.traits[which(pft.names == "dVpdExp")]
+    if ("dVpdExp" %in% pft.trait.names) {
+      param[which(param[, 1] == "dVpdExp"), 2] <- pft.traits[which(pft.trait.names == "dVpdExp")]
     }
     
     # Leaf turnover rate average turnover rate of leaves, in fraction per day NOTE: read in as
     # per-year rate!
-    if ("leaf_turnover_rate" %in% pft.names) {
-      param[which(param[, 1] == "leafTurnoverRate"), 2] <- pft.traits[which(pft.names == "leaf_turnover_rate")]
+    if ("leaf_turnover_rate" %in% pft.trait.names) {
+      param[which(param[, 1] == "leafTurnoverRate"), 2] <- pft.traits[which(pft.trait.names == "leaf_turnover_rate")]
     }
     
-    if ("wueConst" %in% pft.names) {
-      param[which(param[, 1] == "wueConst"), 2] <- pft.traits[which(pft.names == "wueConst")]
+    if ("wueConst" %in% pft.trait.names) {
+      param[which(param[, 1] == "wueConst"), 2] <- pft.traits[which(pft.trait.names == "wueConst")]
     }
     # vegetation respiration Q10.
-    if ("veg_respiration_Q10" %in% pft.names) {
-      param[which(param[, 1] == "vegRespQ10"), 2] <- pft.traits[which(pft.names == "veg_respiration_Q10")]
+    if ("veg_respiration_Q10" %in% pft.trait.names) {
+      param[which(param[, 1] == "vegRespQ10"), 2] <- pft.traits[which(pft.trait.names == "veg_respiration_Q10")]
     }
     
     # Base vegetation respiration. vegetation maintenance respiration at 0 degrees C (g C respired * g^-1 plant C * day^-1)
     # NOTE: only counts plant wood C - leaves handled elsewhere (both above and below-ground: assumed for now to have same resp. rate)
     # NOTE: read in as per-year rate!
-    if ("stem_respiration_rate" %in% pft.names) {
+    if ("stem_respiration_rate" %in% pft.trait.names) {
       vegRespQ10 <- param[which(param[, 1] == "vegRespQ10"), 2]
       id <- which(param[, 1] == "baseVegResp")
       ## Convert from umols CO2 kg s-1 to gC g day-1
-      stem_resp_g <- (((pft.traits[which(pft.names == "stem_respiration_rate")]) *
+      stem_resp_g <- (((pft.traits[which(pft.trait.names == "stem_respiration_rate")]) *
                          (44.0096 / 1e+06) * (12.01 / 44.0096)) / 1000) * 86400
       ## use Q10 to convert stem resp from reference of 25C to 0C param[id,2] =
-      ## pft.traits[which(pft.names=='stem_respiration_rate')]*vegRespQ10^(-25/10)
+      ## pft.traits[which(pft.trait.names=='stem_respiration_rate')]*vegRespQ10^(-25/10)
       param[id, 2] <- stem_resp_g * vegRespQ10^(-25/10)
     }
     
     # turnover of fine roots (per year rate)
-    if ("root_turnover_rate" %in% pft.names) {
+    if ("root_turnover_rate" %in% pft.trait.names) {
       id <- which(param[, 1] == "fineRootTurnoverRate")
-      param[id, 2] <- pft.traits[which(pft.names == "root_turnover_rate")]
+      param[id, 2] <- pft.traits[which(pft.trait.names == "root_turnover_rate")]
     }
     
     # fine root respiration Q10
-    if ("fine_root_respiration_Q10" %in% pft.names) {
-      param[which(param[, 1] == "fineRootQ10"), 2] <- pft.traits[which(pft.names == "fine_root_respiration_Q10")]
+    if ("fine_root_respiration_Q10" %in% pft.trait.names) {
+      param[which(param[, 1] == "fineRootQ10"), 2] <- pft.traits[which(pft.trait.names == "fine_root_respiration_Q10")]
     }
     
     # base respiration rate of fine roots (per year rate)
-    if ("root_respiration_rate" %in% pft.names) {
+    if ("root_respiration_rate" %in% pft.trait.names) {
       fineRootQ10 <- param[which(param[, 1] == "fineRootQ10"), 2]
       id <- which(param[, 1] == "baseFineRootResp")
       ## Convert from umols CO2 kg s-1 to gC g day-1
-      root_resp_rate_g <- (((pft.traits[which(pft.names == "root_respiration_rate")]) *
+      root_resp_rate_g <- (((pft.traits[which(pft.trait.names == "root_respiration_rate")]) *
                               (44.0096/1e+06) * (12.01 / 44.0096)) / 1000) * 86400
       ## use Q10 to convert stem resp from reference of 25C to 0C param[id,2] =
-      ## pft.traits[which(pft.names=='root_respiration_rate')]*fineRootQ10^(-25/10)
+      ## pft.traits[which(pft.trait.names=='root_respiration_rate')]*fineRootQ10^(-25/10)
       param[id, 2] <- root_resp_rate_g * fineRootQ10 ^ (-25 / 10)
     }
     
     # coarse root respiration Q10
-    if ("coarse_root_respiration_Q10" %in% pft.names) {
-      param[which(param[, 1] == "coarseRootQ10"), 2] <- pft.traits[which(pft.names == "coarse_root_respiration_Q10")]
+    if ("coarse_root_respiration_Q10" %in% pft.trait.names) {
+      param[which(param[, 1] == "coarseRootQ10"), 2] <- pft.traits[which(pft.trait.names == "coarse_root_respiration_Q10")]
     }
     # WARNING: fineRootAllocation + woodAllocation + leafAllocation isn't supposed to exceed 1
     # see sipnet.c code L2005 :
     # fluxes.coarseRootCreation=(1-params.leafAllocation-params.fineRootAllocation-params.woodAllocation)*npp;
     # priors can be chosen accordingly, and SIPNET doesn't really crash when sum>1 but better keep an eye
     alloc_params <- c("root_allocation_fraction", "wood_allocation_fraction", "leaf_allocation_fraction")
-    if (all(alloc_params %in% pft.names)) {
-      sum_alloc <- pft.traits[which(pft.names == "root_allocation_fraction")] +
-        pft.traits[which(pft.names == "wood_allocation_fraction")] +
-        pft.traits[which(pft.names == "leaf_allocation_fraction")]
+    if (all(alloc_params %in% pft.trait.names)) {
+      sum_alloc <- pft.traits[which(pft.trait.names == "root_allocation_fraction")] +
+        pft.traits[which(pft.trait.names == "wood_allocation_fraction")] +
+        pft.traits[which(pft.trait.names == "leaf_allocation_fraction")]
       if(sum_alloc > 1){
         # I want this to be a severe for now, lateer can be changed back to warning
         PEcAn.logger::logger.warn("Sum of allocation parameters exceeds 1 for runid = ", run.id,
@@ -368,52 +370,52 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
     
     
     # fineRootAllocation
-    if ("root_allocation_fraction" %in% pft.names) {
-      param[which(param[, 1] == "fineRootAllocation"), 2] <- pft.traits[which(pft.names == "root_allocation_fraction")]
+    if ("root_allocation_fraction" %in% pft.trait.names) {
+      param[which(param[, 1] == "fineRootAllocation"), 2] <- pft.traits[which(pft.trait.names == "root_allocation_fraction")]
     }
     
     # woodAllocation
-    if ("wood_allocation_fraction" %in% pft.names) {
-      param[which(param[, 1] == "woodAllocation"), 2] <- pft.traits[which(pft.names == "wood_allocation_fraction")]
+    if ("wood_allocation_fraction" %in% pft.trait.names) {
+      param[which(param[, 1] == "woodAllocation"), 2] <- pft.traits[which(pft.trait.names == "wood_allocation_fraction")]
     }
     
     # leafAllocation
-    if ("leaf_allocation_fraction" %in% pft.names) {
-      param[which(param[, 1] == "leafAllocation"), 2] <- pft.traits[which(pft.names == "leaf_allocation_fraction")]
+    if ("leaf_allocation_fraction" %in% pft.trait.names) {
+      param[which(param[, 1] == "leafAllocation"), 2] <- pft.traits[which(pft.trait.names == "leaf_allocation_fraction")]
     }
     
     # wood_turnover_rate
-    if ("wood_turnover_rate" %in% pft.names) {
-      param[which(param[, 1] == "woodTurnoverRate"), 2] <- pft.traits[which(pft.names == "wood_turnover_rate")]
+    if ("wood_turnover_rate" %in% pft.trait.names) {
+      param[which(param[, 1] == "woodTurnoverRate"), 2] <- pft.traits[which(pft.trait.names == "wood_turnover_rate")]
     }
     
     ### ----- Soil parameters soil respiration Q10.
-    if ("soil_respiration_Q10" %in% pft.names) {
-      param[which(param[, 1] == "soilRespQ10"), 2] <- pft.traits[which(pft.names == "soil_respiration_Q10")]
+    if ("soil_respiration_Q10" %in% pft.trait.names) {
+      param[which(param[, 1] == "soilRespQ10"), 2] <- pft.traits[which(pft.trait.names == "soil_respiration_Q10")]
     }
     # soil respiration rate -- units = 1/year, reference = 0C
-    if ("som_respiration_rate" %in% pft.names) {
-      param[which(param[, 1] == "baseSoilResp"), 2] <- pft.traits[which(pft.names == "som_respiration_rate")]
+    if ("som_respiration_rate" %in% pft.trait.names) {
+      param[which(param[, 1] == "baseSoilResp"), 2] <- pft.traits[which(pft.trait.names == "som_respiration_rate")]
     }
     
     # litterBreakdownRate
-    if ("turn_over_time" %in% pft.names) {
+    if ("turn_over_time" %in% pft.trait.names) {
       id <- which(param[, 1] == "litterBreakdownRate")
-      param[id, 2] <- pft.traits[which(pft.names == "turn_over_time")]
+      param[id, 2] <- pft.traits[which(pft.trait.names == "turn_over_time")]
     }
     # frozenSoilEff
-    if ("frozenSoilEff" %in% pft.names) {
-      param[which(param[, 1] == "frozenSoilEff"), 2] <- pft.traits[which(pft.names == "frozenSoilEff")]
+    if ("frozenSoilEff" %in% pft.trait.names) {
+      param[which(param[, 1] == "frozenSoilEff"), 2] <- pft.traits[which(pft.trait.names == "frozenSoilEff")]
     }
     
     # frozenSoilFolREff
-    if ("frozenSoilFolREff" %in% pft.names) {
-      param[which(param[, 1] == "frozenSoilFolREff"), 2] <- pft.traits[which(pft.names == "frozenSoilFolREff")]
+    if ("frozenSoilFolREff" %in% pft.trait.names) {
+      param[which(param[, 1] == "frozenSoilFolREff"), 2] <- pft.traits[which(pft.trait.names == "frozenSoilFolREff")]
     }
     
     # soilWHC
-    if ("soilWHC" %in% pft.names) {
-      param[which(param[, 1] == "soilWHC"), 2] <- pft.traits[which(pft.names == "soilWHC")]
+    if ("soilWHC" %in% pft.trait.names) {
+      param[which(param[, 1] == "soilWHC"), 2] <- pft.traits[which(pft.trait.names == "soilWHC")]
     }
     # 10/31/2017 IF: these were the two assumptions used in the emulator paper in order to reduce dimensionality
     # These results in improved winter soil respiration values
@@ -426,38 +428,38 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
       param[which(param[, 1] == "baseSoilRespCold"), 2] <- param[which(param[, 1] == "baseSoilResp"), 2] * 0.25
     }
     
-    if ("immedEvapFrac" %in% pft.names) {
-      param[which(param[, 1] == "immedEvapFrac"), 2] <- pft.traits[which(pft.names == "immedEvapFrac")]
+    if ("immedEvapFrac" %in% pft.trait.names) {
+      param[which(param[, 1] == "immedEvapFrac"), 2] <- pft.traits[which(pft.trait.names == "immedEvapFrac")]
     }
     
-    if ("leafWHC" %in% pft.names) {
-      param[which(param[, 1] == "leafPoolDepth"), 2] <- pft.traits[which(pft.names == "leafWHC")]
+    if ("leafWHC" %in% pft.trait.names) {
+      param[which(param[, 1] == "leafPoolDepth"), 2] <- pft.traits[which(pft.trait.names == "leafWHC")]
     }
     
-    if ("waterRemoveFrac" %in% pft.names) {
-      param[which(param[, 1] == "waterRemoveFrac"), 2] <- pft.traits[which(pft.names == "waterRemoveFrac")]
+    if ("waterRemoveFrac" %in% pft.trait.names) {
+      param[which(param[, 1] == "waterRemoveFrac"), 2] <- pft.traits[which(pft.trait.names == "waterRemoveFrac")]
     }
     
-    if ("fastFlowFrac" %in% pft.names) {
-      param[which(param[, 1] == "fastFlowFrac"), 2] <- pft.traits[which(pft.names == "fastFlowFrac")]
+    if ("fastFlowFrac" %in% pft.trait.names) {
+      param[which(param[, 1] == "fastFlowFrac"), 2] <- pft.traits[which(pft.trait.names == "fastFlowFrac")]
     }
     
-    if ("rdConst" %in% pft.names) {
-      param[which(param[, 1] == "rdConst"), 2] <- pft.traits[which(pft.names == "rdConst")]
+    if ("rdConst" %in% pft.trait.names) {
+      param[which(param[, 1] == "rdConst"), 2] <- pft.traits[which(pft.trait.names == "rdConst")]
     }
     ### ----- Phenology parameters GDD leaf on
-    if ("GDD" %in% pft.names) {
-      param[which(param[, 1] == "gddLeafOn"), 2] <- pft.traits[which(pft.names == "GDD")]
+    if ("GDD" %in% pft.trait.names) {
+      param[which(param[, 1] == "gddLeafOn"), 2] <- pft.traits[which(pft.trait.names == "GDD")]
     }
     
     # Fraction of leaf fall per year (should be 1 for decid)
-    if ("fracLeafFall" %in% pft.names) {
-      param[which(param[, 1] == "fracLeafFall"), 2] <- pft.traits[which(pft.names == "fracLeafFall")]
+    if ("fracLeafFall" %in% pft.trait.names) {
+      param[which(param[, 1] == "fracLeafFall"), 2] <- pft.traits[which(pft.trait.names == "fracLeafFall")]
     }
     
     # Leaf growth.  Amount of C added to the leaf during the greenup period
-    if ("leafGrowth" %in% pft.names) {
-      param[which(param[, 1] == "leafGrowth"), 2] <- pft.traits[which(pft.names == "leafGrowth")]
+    if ("leafGrowth" %in% pft.trait.names) {
+      param[which(param[, 1] == "leafGrowth"), 2] <- pft.traits[which(pft.trait.names == "leafGrowth")]
     }
 
     #update LeafOnday and LeafOffDay

--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -190,7 +190,7 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
     pft.traits <- pft.traits[pft.traits != "NA" & !is.na(pft.traits)]
     pft.traits <- as.numeric(pft.traits)
     
-    # Leaf carbon concentration    
+    # Leaf carbon concentration
     leafC <- NA
     if ("leafC" %in% pft.trait.names) {
       leafC <- pft.traits[which(pft.trait.names == "leafC")]

--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -218,7 +218,7 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
     SLA_g <- PEcAn.utils::ud_convert(SLA, "1/kg", "1/g") 
     if ("Amax" %in% pft.trait.names) {
       Amax_area <- pft.traits[which(pft.trait.names == "Amax")] # [µmol/m2/s]
-      param[id, 2] <- PEcAn.utils::ud_convert(Amax_area * SLA_g, "umol/m2/s", "nmol/g/s")
+      param[id, 2] <- PEcAn.utils::ud_convert(Amax_area * SLA_g, "umol", "nmol") # [nmol/g/s]
     } else {
       amax_mass <- param[id, 2] # [nmol/g/s]
       Amax <- PEcAn.utils::ud_convert(amax_mass / SLA_g, "nmol/g/s", "umol/m2/s")

--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -238,7 +238,7 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
     if ("leaf_respiration_rate_m2" %in% pft.trait.names) {
       Rd <- pft.traits[which(pft.trait.names == "leaf_respiration_rate_m2")]
       id <- which(param[, 1] == "baseFolRespFrac")
-      param[id, 2] <- max(min(Rd/Amax, 1), 0)
+      param[id, 2] <- max(min(Rd / Amax_area, 1), 0)
     }
     
     # Low temp threshold for photosynethsis

--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -221,7 +221,7 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
       param[id, 2] <- PEcAn.utils::ud_convert(Amax_area * SLA_g, "umol", "nmol") # [nmol/g/s]
     } else {
       amax_mass <- param[id, 2] # [nmol/g/s]
-      Amax <- PEcAn.utils::ud_convert(amax_mass / SLA_g, "nmol/g/s", "umol/m2/s")
+      Amax <- PEcAn.utils::ud_convert(amax_mass / SLA_g, "nmol", "umol") # [umol/m2/s]
     }
     
     # Daily fraction of maximum photosynthesis

--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -211,6 +211,7 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
     
     # SIPNET: aMax [nmol CO2 / g   leaf / sec]
     # PEcAn:  Amax [umol CO2 / m^2 leaf / sec]
+    id <- which(param[, 1] == "aMax")
     SLA_g <- PEcAn.utils::ud_convert(SLA, "1/kg", "1/g") 
     if ("Amax" %in% pft.names) {
       Amax_area <- pft.traits[which(pft.names == "Amax")] # [µmol/m2/s]

--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -211,6 +211,7 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
       SLA <- PEcAn.utils::ud_convert(leafC / param[id, 2], "kg", "g")
     }
     
+    # Maximum photosynthesis
     # SIPNET: aMax [nmol CO2 / g   leaf / sec]
     # PEcAn:  Amax [umol CO2 / m^2 leaf / sec]
     id <- which(param[, 1] == "aMax")

--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -204,22 +204,22 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
     id <- which(param[, 1] == "leafCSpWt")
     if ("SLA" %in% pft.names) {
       SLA <- pft.traits[which(pft.names == "SLA")]
-      param[id, 2] <- 10 * leafC / SLA
+      param[id, 2] <- PEcAn.utils::ud_convert(leafC / SLA, "kg/m2", "g/m2")
     } else {
-      SLA <- 10 * leafC / param[id, 2]
+      SLA <- PEcAn.utils::ud_convert(leafC / param[id, 2], "kg", "g")
     }
     
-    # Maximum photosynthesis
-    # amax [nmol CO2 * g^{-1} leaf * sec^{-1}]
-    # Amax [umol CO2 * m^2 leaf * sec^{-1}]
-    Amax <- NA
-    id <- which(param[, 1] == "aMax")
+    # SIPNET: aMax [nmol CO2 / g   leaf / sec]
+    # PEcAn:  Amax [umol CO2 / m^2 leaf / sec]
+    SLA_g <- PEcAn.utils::ud_convert(SLA, "1/kg", "1/g") 
     if ("Amax" %in% pft.names) {
-      Amax <- pft.traits[which(pft.names == "Amax")]
-      param[id, 2] <- Amax * SLA
+      Amax_area <- pft.traits[which(pft.names == "Amax")] # [µmol/m2/s]
+      param[id, 2] <- PEcAn.utils::ud_convert(Amax_area * SLA_g, "umol/m2/s", "nmol/g/s")
     } else {
-      Amax <- param[id, 2] / SLA
+      amax_mass <- param[id, 2] # [nmol/g/s]
+      Amax <- PEcAn.utils::ud_convert(amax_mass / SLA_g, "nmol/g/s", "umol/m2/s")
     }
+    
     # Daily fraction of maximum photosynthesis
     if ("AmaxFrac" %in% pft.names) {
       param[which(param[, 1] == "aMaxFrac"), 2] <- pft.traits[which(pft.names == "AmaxFrac")]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Two small bug fixes in `write.configs.SIPNET.R`. Both were parameter translations involving `SLA`. 

1. The forward and inverse conversions between `leafCSpWt` and `leafC` were inconsistent. This was likely due to a unit conversion error. 
2. The forward and inverse conversions between `amax` (SIPNET) and `Amax` (PEcAn) were inconsistent. This was a simple arithmetic error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [x] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
