### PR TITLE
use actor when PR

### DIFF
--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           echo "image_name=$(echo ${{ inputs.image-name }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
           # if pr then actor not repository owner otherwise we can not push to ghcr.io
-          if [ "{{ github.event_name }}" == "pull_request" ]; then
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
             echo "repository=$(echo ${{ github.actor }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
           else
             echo "repository=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -50,7 +50,12 @@ jobs:
         id: name
         run: |
           echo "image_name=$(echo ${{ inputs.image-name }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
-          echo "repository=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+          # if pr then actor not repository owner otherwise we can not push to ghcr.io
+          if [ "{{ github.event_name }}" == "pull_request" ]; then
+            echo "repository=$(echo ${{ github.actor }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+          else
+            echo "repository=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+          fi
 
       - name: set PARENT_IMAGE only if specified
         id: parent

--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           echo "image_name=$(echo ${{ inputs.image-name }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
           # if pr then actor not repository owner otherwise we can not push to ghcr.io
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
+          if [ "{{ github.event_name }}" == "pull_request" ]; then
             echo "repository=$(echo ${{ github.actor }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
           else
             echo "repository=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
@@ -130,7 +130,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ steps.name.outputs.repository }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # build the docker images

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -206,6 +206,7 @@ jobs:
       build-context: ${{ matrix.CONTEXT }}
       dockerfile: ${{ matrix.DOCKERFILE }}
       r-version: ${{ needs.rversion.outputs.R_VERSION }}
+      parent-image: "base"
       platforms: ${{ matrix.PLATFORM }}
     secrets: inherit
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,6 +67,41 @@ jobs:
       # If seeing weird results here, check that all steps above have an id set.
       R_VERSION: ${{ join(steps.*.outputs.R_VERSION, '') }}
 
+  push_test:
+    permissions:
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: lowercase image name
+        id: name
+        run: |
+          echo "image_name=$(echo ${{ inputs.image-name }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+          # if pr then actor not repository owner otherwise we can not push to ghcr.io
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "repository=$(echo ${{ github.actor }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+          else
+            echo "repository=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+          fi
+      # setup docker build
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ steps.name.outputs.repository }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test GHCR push permissions
+        run: |
+          echo "FROM alpine" | docker build -t ghcr.io/${{ steps.name.outputs.repository }}/test:${{ github.sha }} -
+          docker push ghcr.io/${{ steps.name.outputs.repository }}/test:${{ github.sha }}   
+
   # ----------------------------------------------------------------------
   # depends image has all the dependencies installed
   # ----------------------------------------------------------------------


### PR DESCRIPTION
when creating PR from a fork, the default is for `repository_owner` to be the repository where the PR is targetting. This will fail, in this case we want to use the actor.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] My name is in the list of CITATION.cff
- [x] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
