### PR TITLE
Handle null status in SIPNET download script For DEMO 1 Notebook

### DIFF
--- a/documentation/tutorials/Demo_1_Basic_Run/download_sipnet.R
+++ b/documentation/tutorials/Demo_1_Basic_Run/download_sipnet.R
@@ -39,23 +39,30 @@ download.file(
 Sys.chmod(dest_path, mode = "0755")
 
 ## Now we are run, lets just check that `sipnet -h` works
-
-status <- suppressWarnings(
-    system2(dest_path, "-h", stderr = TRUE, stdout = TRUE) |>
-        attr("status")
-)
-
-if (is.null(status)) {
+tryCatch(
+  {
+    # This block runs if system2 succeeds with exit code 0 (status attribute is NULL).
+    # This is unexpected for `sipnet -h`, so we warn but assume it's OK.
+    system2(dest_path, "-h", stderr = TRUE, stdout = TRUE)
+    PEcAn.logger::logger.warn("SIPNET ran with exit code 0, but expected 1. Assuming installation is OK.")
+  },
+  warning = function(w) {
+    # This block runs if system2 returns a non-zero exit code, which is expected.
+    # We check the warning message for the expected status of 1.
+    if (grepl("had status 1", w$message, fixed = TRUE)) {
+      PEcAn.logger::logger.info("SIPNET has been installed!")
+    } else {
+      PEcAn.logger::logger.error("SIPNET ran but failed with an unexpected status.", "Details:", w$message)
+    }
+  },
+  error = function(e) {
+    # This block runs if system2 fails to execute the command at all.
     PEcAn.logger::logger.error(
-        "SIPNET command failed to execute. ",
-        "The binary may be incompatible with your system or have missing dependencies."
+      "SIPNET command failed to execute. The binary may be incompatible with your system.",
+      "Details:", e$message
     )
-} else if(status == 1){
-    # 1 is expected for `sipnet -h`
-    PEcAn.logger::logger.info("SIPNET has been installed!")
-} else {
-    PEcAn.logger::logger.error("SIPNET installation has failed with status:", status)
-}
+  }
+)
 
 dir.create("dbfiles", showWarnings = FALSE)
 # Download demo .clim file

--- a/documentation/tutorials/Demo_1_Basic_Run/download_sipnet.R
+++ b/documentation/tutorials/Demo_1_Basic_Run/download_sipnet.R
@@ -45,7 +45,12 @@ status <- suppressWarnings(
         attr("status")
 )
 
-if(status == 1){
+if (is.null(status)) {
+    PEcAn.logger::logger.error(
+        "SIPNET command failed to execute. ",
+        "The binary may be incompatible with your system or have missing dependencies."
+    )
+} else if(status == 1){
     # 1 is expected for `sipnet -h`
     PEcAn.logger::logger.info("SIPNET has been installed!")
 } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
The `download_sipnet.R` script, used in the `Demo 1: Basic Run` tutorial, would crash with an argument is of length zero error if the downloaded sipnet binary failed to execute.The resulting output looks like this:
```
downloaded 146 KB

Error in `if (status == 1) ...`:
! argument is of length zero

Quitting from run_pecan.qmd:98-105 [download-sipnet]
Execution halted
```


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
