### PR TITLE
feat(db): Re-enable PFT cultivar query test

### DIFF
--- a/base/db/tests/testthat/test-query.pft.R
+++ b/base/db/tests/testthat/test-query.pft.R
@@ -36,7 +36,6 @@ test_that("nonexistant PFTs and modeltypes return empty dataframes", {
 
 
 test_that("query.pft_cultivars finds cultivars for a PFT", {
-  skip("Disabled until Travis bety contains Pavi_alamo and Pavi_all (#1958)")
   one_cv <- query.pft_cultivars(pft = "Pavi_alamo", modeltype = NULL, con)
   expect_is(one_cv, "data.frame")
   expect_equal(nrow(one_cv), 1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
This pull request re-enables the `query.pft_cultivars` test in `base/db/tests/testthat/test-query.pft.R` by removing the `skip()` line.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
