### PR TITLE
Simpler str_ns handling

### DIFF
--- a/modules/data.atmosphere/R/met.process.R
+++ b/modules/data.atmosphere/R/met.process.R
@@ -142,14 +142,14 @@ met.process <- function(site, input_met, start_date, end_date, model,
   
   
   # setup site database number, lat, lon and name and copy for format.vars if new input
-  if(is.null(site$lat) | is.null(site.lon)) {
+  if(is.null(site$lat) | is.null(site$lon)) {
     latlon <- PEcAn.DB::query.site(site$id, con = con)[c("lat", "lon")] 
     new.site <- data.frame(id = as.numeric(site$id), 
                          lat = latlon$lat, 
                          lon = latlon$lon)
     str_ns <- paste0(new.site$lat,'-',new.site$lon)
   } else {
-    str_ns <- paste0(site$lat,'-',site.lon)
+    str_ns <- paste0(site$lat,'-',site$lon)
   }
   
   if (is.null(format.vars$lat)) {

--- a/modules/data.atmosphere/R/met.process.R
+++ b/modules/data.atmosphere/R/met.process.R
@@ -144,7 +144,7 @@ met.process <- function(site, input_met, start_date, end_date, model,
   # setup site database number, lat, lon and name and copy for format.vars if new input
   # TODO why are this and the original site object passed around together?
   # Could we mutate `site` instead of assigning `new.site`?
-  new.site <- data.frame(
+  new.site <- list(
     id = site$id,
     lat = site$lat,
     lon = site$lon

--- a/modules/data.atmosphere/R/met.process.R
+++ b/modules/data.atmosphere/R/met.process.R
@@ -139,19 +139,34 @@ met.process <- function(site, input_met, start_date, end_date, model,
   if(is.null(model)){
     stage$model <- FALSE
   }
-  
-  
+
+
   # setup site database number, lat, lon and name and copy for format.vars if new input
-  if(is.null(site$lat) | is.null(site$lon)) {
-    latlon <- PEcAn.DB::query.site(site$id, con = con)[c("lat", "lon")] 
-    new.site <- data.frame(id = as.numeric(site$id), 
-                         lat = latlon$lat, 
-                         lon = latlon$lon)
-    str_ns <- paste0(new.site$lat,'-',new.site$lon)
-  } else {
-    str_ns <- paste0(site$lat,'-',site$lon)
+  # TODO why are this and the original site object passed around together?
+  # Could we mutate `site` instead of assigning `new.site`?
+  new.site <- data.frame(
+    id = site$id,
+    lat = site$lat,
+    lon = site$lon
+  )
+  if (is.null(new.site$id)) {
+    PEcAn.logger::logger.info(
+      "no site ID provided. Generating one from lat and lon"
+    )
+    new.site$id <- paste0("lat", new.site$lat, "_lon", new.site$lon)
   }
-  
+  if (is.null(site$lat) || is.null(new.site$lon)) {
+    latlon <- PEcAn.DB::query.site(site$id, con = con)[c("lat", "lon")]
+    new.site$lat <- latlon$lat
+    new.site$lon <- latlon$lon
+  }
+  if (is.numeric(new.site$id) && new.site$id > 1e9) {
+    # Assume this is a BETY id, format as [server id]-[record number]
+    str_ns <- paste0(new.site$id %/% 1e+09, "-", new.site$id %% 1e+09)
+  } else {
+    str_ns <- as.character(new.site$id)
+  }
+
   if (is.null(format.vars$lat)) {
     format.vars$lat <- new.site$lat
   }

--- a/modules/data.atmosphere/R/met.process.R
+++ b/modules/data.atmosphere/R/met.process.R
@@ -142,11 +142,15 @@ met.process <- function(site, input_met, start_date, end_date, model,
   
   
   # setup site database number, lat, lon and name and copy for format.vars if new input
-  latlon <- PEcAn.DB::query.site(site$id, con = con)[c("lat", "lon")] 
-  new.site <- data.frame(id = as.numeric(site$id), 
+  if(is.null(site$lat) | is.null(site.lon)) {
+    latlon <- PEcAn.DB::query.site(site$id, con = con)[c("lat", "lon")] 
+    new.site <- data.frame(id = as.numeric(site$id), 
                          lat = latlon$lat, 
                          lon = latlon$lon)
-  str_ns <- paste0(new.site$id %/% 1e+09, "-", new.site$id %% 1e+09)
+    str_ns <- paste0(new.site$lat,'-',new.site$lon)
+  } else {
+    str_ns <- paste0(site$lat,'-',site.lon)
+  }
   
   if (is.null(format.vars$lat)) {
     format.vars$lat <- new.site$lat

--- a/modules/data.land/R/ic_process.R
+++ b/modules/data.land/R/ic_process.R
@@ -13,15 +13,16 @@ ic_process <- function(settings, input, dir, overwrite = FALSE){
 
   #--------------------------------------------------------------------------------------------------#
   # Extract info from settings and setup
-  site       <- settings$run$site
-  model <- list()
-    model$type <- settings$model$type
-    model$id <- settings$model$id
-  host       <- settings$host
-  dbparms    <- settings$database
+  site <- settings$run$site
+  model <- list(
+    type = settings$model$type,
+    id = settings$model$id
+  )
+  host <- settings$host
+  dbparms <- settings$database
 
   # Handle IC Workflow locally
-  if(host$name != "localhost"){
+  if (host$name != "localhost") {
     host$name <- "localhost"
     dir       <- settings$database$dbfiles
   }
@@ -48,26 +49,27 @@ ic_process <- function(settings, input, dir, overwrite = FALSE){
   # set up bety connection
   con <- PEcAn.DB::db.open(dbparms$bety)
   on.exit(PEcAn.DB::db.close(con), add = TRUE)
-  
+
   #grab site lat and lon info
 
   # check if site metadata is available in the settings$run$site
-  if (isTRUE(nzchar(settings$run$site$lat)) && isTRUE(nzchar(settings$run$site$lon))) {
+  if (isTRUE(nzchar(site$lat)) && isTRUE(nzchar(site$lon))) {
     # if lat and lon are available, use them directly
-    latlon <- data.frame(lat = settings$run$site$lat, lon = settings$run$site$lon)
+    latlon <- data.frame(lat = site$lat, lon = site$lon)
   } else {
     # otherwise, query the site information from the database
     latlon <- PEcAn.DB::query.site(site$id, con = con)[c("lat", "lon")]
   }
 
   # setup site database number, lat, lon and name and copy for format.vars if new input
-  new.site <- data.frame(id = as.numeric(site$id),
-                         lat = latlon$lat,
-                         lon = latlon$lon)
+  new.site <- data.frame(
+    id = site$id,
+    lat = latlon$lat,
+    lon = latlon$lon,
+    name = site$name
+  )
 
-  new.site$name <- settings$run$site$name
-
-  if (isTRUE(new.site$id > 1e9)) {
+  if (is.numeric(new.site$id) && isTRUE(new.site$id > 1e9)) {
     # Assume this is a BETYdb id, condense for readability
     str_ns <- paste0(new.site$id %/% 1e+09, "-", new.site$id %% 1e+09)
   } else {

--- a/modules/data.land/R/ic_process.R
+++ b/modules/data.land/R/ic_process.R
@@ -62,7 +62,7 @@ ic_process <- function(settings, input, dir, overwrite = FALSE){
   }
 
   # setup site database number, lat, lon and name and copy for format.vars if new input
-  new.site <- data.frame(
+  new.site <- list(
     id = site$id,
     lat = latlon$lat,
     lon = latlon$lon,

--- a/modules/data.land/R/soil_params_ensemble.R
+++ b/modules/data.land/R/soil_params_ensemble.R
@@ -159,9 +159,13 @@ soil_params_ensemble_soilgrids <- function(settings,sand,clay,silt,outdir,write_
   PATH <- foreach::foreach(i = seq_along(dat), .packages = c("Kendall", "purrr", "PEcAn.data.land"), .options.snow=opts) %dopar% {
     samples_ens <- list()
     paths <- c()
-    siteid <- as.numeric(unique(dat[[i]]$siteid))
+    siteid <- unique(dat[[i]]$siteid)
     soil_depth <- unique(dat[[i]]$soil_depth)
-    str_ns <- paste0(siteid %/% 1e+09, "-", siteid %% 1e+09)
+    if (is.numeric(siteid) && siteid > 1e9) {
+      str_ns <- paste0(siteid %/% 1e+09, "-", siteid %% 1e+09)
+    } else {
+      str_ns <- as.character(siteid)
+    }
     temp_outdir <- file.path(outdir, siteid)
     dir.create(temp_outdir)
     # Estimate Dirichlet parameters for each depth at each site

--- a/modules/data.land/R/soil_process.R
+++ b/modules/data.land/R/soil_process.R
@@ -31,12 +31,16 @@ soil_process <- function(settings, input, dbfiles, overwrite = FALSE,run.local=T
   con <- PEcAn.DB::db.open(dbparms$bety)
   on.exit(PEcAn.DB::db.close(con), add = TRUE)
   # get site info
-  latlon <- PEcAn.DB::query.site(site$id, con = con)[c("lat", "lon")]
-  new.site <- data.frame(id = as.numeric(site$id),
+  if (isTRUE(nzchar(site$lat)) && isTRUE(nzchar(site$lon))) {
+    latlon <- data.frame(lat = site$lat, lon = site$lon)
+  } else {
+    latlon <- PEcAn.DB::query.site(site$id, con = con)[c("lat", "lon")]
+  }
+  new.site <- data.frame(id = site$id,
                          lat = latlon$lat,
                          lon = latlon$lon)
 
-  if (isTRUE(new.site$id > 1e9)) {
+  if (is.numeric(new.site$id) && isTRUE(new.site$id > 1e9)) {
     # Assume this is a BETYdb id, condense for readability
     str_ns <- paste0(new.site$id %/% 1e+09, "-", new.site$id %% 1e+09)
   } else {
@@ -45,7 +49,7 @@ soil_process <- function(settings, input, dbfiles, overwrite = FALSE,run.local=T
 
   outfolder <- file.path(dbfiles, paste0(input$source, "_site_", str_ns))
 
-  if(!dir.exists(outfolder)) dir.create(outfolder)
+  if (!dir.exists(outfolder)) dir.create(outfolder)
   #--------------------------------------------------------------------------------------------------#
   # if we are reading from gSSURGO
   if (input$source=="gSSURGO"){

--- a/modules/data.land/R/soil_process.R
+++ b/modules/data.land/R/soil_process.R
@@ -36,9 +36,7 @@ soil_process <- function(settings, input, dbfiles, overwrite = FALSE,run.local=T
   } else {
     latlon <- PEcAn.DB::query.site(site$id, con = con)[c("lat", "lon")]
   }
-  new.site <- data.frame(id = site$id,
-                         lat = latlon$lat,
-                         lon = latlon$lon)
+  new.site <- list(id = site$id, lat = latlon$lat, lon = latlon$lon)
 
   if (is.numeric(new.site$id) && isTRUE(new.site$id > 1e9)) {
     # Assume this is a BETYdb id, condense for readability


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description

This is a condensed implementation of the core ideas from #3324: 
- If site settings already contain lat and lon, use those and do not attempt to look site location up from the db
- For met.process only, allow site id to be missing. If so, create an ID by pasting lat & lon together
- Always treat site id as character not numeric, but continue condensing Bety IDs (`1000000772` => `1-772`)  as before

@Sweetdevil144 please review -- if you agree this is a sufficient replacement, merging this will close #3324.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We learned a lot about DB-free runs since starting work on #3324. It's now clear that for most cases we want to require the user to provide site IDs rather than generate them ourselves, meaning much of the complexity proposed in the existing  PR is unneeded. Rather than try to unwind all the changes there, I've cherry-picked out the core commits here and updated the format of the latlon-based IDs for reduced ambiguity.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
