### PR TITLE
Fix unit error in leafCSpWt calculation

### DIFF
--- a/models/sipnet/DESCRIPTION
+++ b/models/sipnet/DESCRIPTION
@@ -12,6 +12,7 @@ Description: The Predictive Ecosystem Carbon Analyzer (PEcAn) is a scientific
     efficacy of scientific investigation.
 URL: https://pecanproject.github.io
 BugReports: https://github.com/PecanProject/pecan/issues
+Depends: R (>= 4.1.0)
 Imports:
     dplyr,
     jsonlite,

--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -201,28 +201,27 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
     pft.trait.names <- pft.trait.names[pft.traits != "NA" & !is.na(pft.traits)]
     pft.traits <- pft.traits[pft.traits != "NA" & !is.na(pft.traits)]
     pft.traits <- as.numeric(pft.traits)
-    
+
     # Leaf carbon concentration
-    leafC <- NA
     if ("leafC" %in% pft.trait.names) {
-      leafC <- pft.traits[which(pft.trait.names == "leafC")]
+      leafC <- pft.traits[pft.trait.names == "leafC"] |>
+        PEcAn.utils::ud_convert("percent", "1") # percentage to fraction
       id <- which(param[, 1] == "cFracLeaf")
-      param[id, 2] <- PEcAn.utils::ud_convert(leafC, "percent", "1") # Convert from percentage to fraction
+      param[id, 2] <- leafC
     } else {
       leafC <- 0.48 # Fixed value if not available, because it is used in downstream calculations
     }
-    
+
     # Specific leaf area converted to SLW
-    # leafCSpWt [gC/m2 leaf], SLA [m2 leaf/kg C], leafC [percentage C]
-    SLA <- NA
+    # leafCSpWt [gC/m2 leaf], SLA [m2 leaf/kg leaf], leafC [g C / g leaf]
     id <- which(param[, 1] == "leafCSpWt")
     if ("SLA" %in% pft.trait.names) {
       SLA <- pft.traits[which(pft.trait.names == "SLA")]
       param[id, 2] <- PEcAn.utils::ud_convert(leafC / SLA, "kg/m2", "g/m2")
     } else {
-      SLA <- PEcAn.utils::ud_convert(leafC / param[id, 2], "kg", "g")
+      SLA <- PEcAn.utils::ud_convert(leafC / param[id, 2], "m2/g", "m2/kg")
     }
-    
+
     # Maximum photosynthesis
     # SIPNET: aMax [nmol CO2 / g   leaf / sec]
     # PEcAn:  Amax [umol CO2 / m^2 leaf / sec]

--- a/models/sipnet/tests/testthat/test-write.config.SIPNET.R
+++ b/models/sipnet/tests/testthat/test-write.config.SIPNET.R
@@ -31,7 +31,7 @@ test_that("write.config.SIPNET", {
 
   res <- write.config.SIPNET(
     defaults = list(pft1 = list(constants = list(SLA = 2.0))),
-    trait.values = list(pft1 = list(Amax = 5, AmaxFrac = 0.99)),
+    trait.values = list(pft1 = list(Amax = 5, AmaxFrac = 0.99, leafC = 47)),
     settings = s,
     run.id = "run1"
   )
@@ -58,4 +58,12 @@ test_that("write.config.SIPNET", {
     fixed = TRUE,
     all = FALSE
   )
+  # leaf C specific weight is leafC / SLA, with units converted to g C/m2 leaf
+  expect_match(
+    param_result,
+    "leafCSpWt 235 ", # space at end to catch unit errors (eg fail on 23500)
+    fixed = TRUE,
+    all = FALSE
+  )
+
 })

--- a/modules/assim.sequential/DESCRIPTION
+++ b/modules/assim.sequential/DESCRIPTION
@@ -11,6 +11,7 @@ Description: The Predictive Ecosystem Carbon Analyzer (PEcAn) is a scientific
     efficacy of scientific investigation.
 URL: https://pecanproject.github.io
 BugReports: https://github.com/PecanProject/pecan/issues
+Depends: R (>= 4.1.0)
 Imports:
     coda,
     dplyr,


### PR DESCRIPTION
Fixes a regression introduced in #3608: leafC comes in as a percentage and we were correctly converting it to a fraction in the assignment to `cFracLeaf`, but `leafC` itself stayed a percentage and caused a factor of 100 error when we treated it as a fraction in the calculation of `leafCSpWt`. 

Thanks @Qianyuxuan for reporting the issue and proposing the fix.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
