### PR TITLE
test(db): fix fancy_scientific test by comparing deparsed expressions

### DIFF
--- a/base/db/tests/testthat/test.query.dplyr.R
+++ b/base/db/tests/testthat/test.query.dplyr.R
@@ -1,12 +1,15 @@
 test_that("`fancy_scientific()` converts numbers to scientific expressions with proper formatting", {
   result <- fancy_scientific(1234567890)
-  expect_equal(result, expression("1.234568" %*% 10^+9))
+  expected <- expression("1.234568" %*% 10^+9)
+  expect_equal(deparse(result[[1]]), deparse(expected[[1]]))
 
   result <- fancy_scientific(0.00000123)
-  expect_equal(result, expression("1.23" %*% 10^-6))
+  expected <- expression("1.23" %*% 10^-6)
+  expect_equal(deparse(result[[1]]), deparse(expected[[1]]))
 
   result <- fancy_scientific(1e-20)
-  expect_equal(result, expression("1" %*% 10^-20))
+  expected <- expression("1" %*% 10^-20)
+  expect_equal(deparse(result[[1]]), deparse(expected[[1]]))
 })
 
 test_that("`dplyr.count()` returns the correct count of rows in a dataframe", {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Fix `fancy_scientific() ` Test Failures in `test.query.dplyr.R`
```
Failure (test.query.dplyr.R:9:3): `fancy_scientific()` converts numbers to scientific expressions with proper formatting
`result` not equal to expression("1" %*% 10^-20).
Attributes: < Modes: list, NULL >
Attributes: < Lengths: 3, 0 >
Attributes: < names for target but not for current >
Attributes: < current is not list-like >
target is not list-like
```
The tests were failing because `expect_equal()` checks every attribute of the parsed expressions, and those attributes can differ even when the expressions themselves mean the same thing.
To avoid these false failures, the tests now compare the `deparsed` string versions of the expressions using `deparse()`, instead of comparing the full expression objects.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
