### PR TITLE
R bugfixes across dbfiles, remote helpers, and met alignment

### DIFF
--- a/base/db/R/dbfiles.R
+++ b/base/db/R/dbfiles.R
@@ -447,13 +447,13 @@ dbfile.posterior.check <- function(pft, mimetype, formatname, con, hostname = PE
   hostname <- default_hostname(hostname)
 
   # find appropriate pft
-  pftid <- get.id(table = "pfts", values = "name", colnames = pft, con = con)
+  pftid <- get.id(table = "pfts", colnames = "name", values = pft, con = con)
   if (is.null(pftid)) {
     return (invisible(data.frame()))
   }
 
   # find appropriate format
-  mimetypeid <- get.id(table = "mimetypes", values = "type_string", colnames = mimetype, con = con)
+  mimetypeid <- get.id(table = "mimetypes", colnames = "type_string", values = mimetype, con = con)
   if (is.null(mimetypeid)) {
     PEcAn.logger::logger.error("mimetype ", mimetype, "does not exist")
   }
@@ -728,7 +728,7 @@ dbfile.move <- function(old.dir, new.dir, file.type, siteid = NULL, register = F
   files.indb <- 0
 
   # check for file type and update to make it *.file type
-  if (file.type != "clim" | file.type != "nc") {
+  if (!(file.type %in% c("clim", "nc"))) {
     PEcAn.logger::logger.error("File type not supported by move at this time. Currently only supports NC and CLIM files")
     error <- 1
   }

--- a/base/db/R/insert.format.vars.R
+++ b/base/db/R/insert.format.vars.R
@@ -48,18 +48,20 @@ insert.format.vars <- function(con, format_name, mimetype_id, notes = NULL, head
   }
 
   # Test if format name already exists
-  name_test <- dplyr::tbl(con, "formats") %>% dplyr::select("id", "name") %>% dplyr::filter(.data$name %in% !!format_name) %>% dplyr::collect()
-  name_test_df <- as.data.frame(name_test)
-  if(!is.null(name_test_df[1,1])){
+  name_test <- dplyr::tbl(con, "formats") %>%
+    dplyr::select(.data$id, .data$name) %>%
+    dplyr::filter(.data$name %in% !!format_name) %>%
+    dplyr::collect()
+  if(nrow(name_test) > 0){
     PEcAn.logger::logger.error(
       "Name already exists"
     )
   }
 
-   #Test if skip is an integer
-  if(!is.character(skip)){
-  PEcAn.logger::logger.error(
-    "Skip must be of type character"
+   # Test if skip is numeric
+  if(!is.numeric(skip)){
+    PEcAn.logger::logger.error(
+      "Skip must be of type numeric"
     )
   }
 
@@ -71,7 +73,7 @@ insert.format.vars <- function(con, format_name, mimetype_id, notes = NULL, head
   }
 
   # Test if notes are a character string
-  if(!is.character(notes)&!is.null(notes)){
+  if(!is.character(notes) & !is.null(notes)){
     PEcAn.logger::logger.error(
       "Notes must be of type character"
     )
@@ -79,39 +81,43 @@ insert.format.vars <- function(con, format_name, mimetype_id, notes = NULL, head
 
   ######## Formats-Variables tests ###############
   if(!is.null(formats_variables)){
-    for(i in 1:nrow(formats_variables)){
-      if(!is.numeric(formats_variables[[i,"variable_id"]])){
+    for(i in seq_len(nrow(formats_variables))){
+      row_i <- formats_variables[i, ]
+      if(!is.numeric(row_i[["variable_id"]])){
         PEcAn.logger::logger.error(
           "variable_id must be an integer"
         )
       }
 
-      if(suppress == FALSE){
-        ## Test if variable_id already exists ##
-        var_id_test <- dplyr::tbl(con, "variables") %>% dplyr::select("id") %>% dplyr::filter(.data$id %in% !!formats_variables[[i, "variable_id"]]) %>% dplyr::collect(.data$id)
-        if(!is.null(var_id_test[1,1])){
+      if(identical(suppress, FALSE)){
+        ## Test if variable_id exists in variables table ##
+        var_id_test <- dplyr::tbl(con, "variables") %>%
+          dplyr::select(.data$id) %>%
+          dplyr::filter(.data$id %in% !!row_i[["variable_id"]]) %>%
+          dplyr::collect()
+        if(nrow(var_id_test) == 0){
           PEcAn.logger::logger.error(
-            "variable_id already exists"
+            "variable_id does not exist in 'variables' table"
           )
         }
       }
 
-      if(!is.character(formats_variables[[i, "name"]])&!is.na(formats_variables[[i, "name"]])){
+      if(!is.na(row_i[["name"]]) && !is.character(row_i[["name"]])){
         PEcAn.logger::logger.error(
           "Variable name must be of type character or NA"
         )
       }
-      if(!is.character(formats_variables[[i, "unit"]])&!is.na(formats_variables[[i, "unit"]])){
+      if(!is.na(row_i[["unit"]]) && !is.character(row_i[["unit"]])){
         PEcAn.logger::logger.error(
           "Units must be of type character or NA"
         )
       }
-      if(!is.character(formats_variables[[i, "storage_type"]])&!is.na(formats_variables[[i, "storage_type"]])){
+      if(!is.na(row_i[["storage_type"]]) && !is.character(row_i[["storage_type"]])){
         PEcAn.logger::logger.error(
           "storage_type must be of type character or NA"
         )
       }
-      if(!is.numeric(formats_variables[[i, "column_number"]])&!is.na(formats_variables[[i, "column_number"]])){
+      if(!is.na(row_i[["column_number"]]) && !is.numeric(row_i[["column_number"]])){
         PEcAn.logger::logger.error(
           "column_number must be of type numeric or NA"
         )
@@ -122,32 +128,39 @@ insert.format.vars <- function(con, format_name, mimetype_id, notes = NULL, head
     formats_variables[is.na(formats_variables)] <- ""
 
     ###  udunit tests ###
-    for(i in 1:nrow(formats_variables)){
-      u1 <- formats_variables[1,"unit"]
-      u2 <- dplyr::tbl(con, "variables") %>% dplyr::select("id", units) %>% dplyr::filter(.data$id %in% !!formats_variables[[1, "variable_id"]]) %>% dplyr::pull("units")
+    for(i in seq_len(nrow(formats_variables))){
+      u1 <- formats_variables[["unit"]][i]
+      vid <- formats_variables[["variable_id"]][i]
+      if(!is.na(u1) && u1 != ""){
+        u2 <- dplyr::tbl(con, "variables") %>%
+          dplyr::select(.data$id, .data$units) %>%
+          dplyr::filter(.data$id %in% !!vid) %>%
+          dplyr::pull(.data$units)
 
-      if(!PEcAn.utils::unit_is_parseable(u1)){
-        PEcAn.logger::logger.error(
-          "Units '", u1,  "' not parseable.",
-          "Please provide a unit that is parseable by the udunits library."
-        )
-      }
-      # Grab the bety units and
-      if(!units::ud_are_convertible(u1, u2)){
-        PEcAn.logger::logger.error(
-          "Units are not convertable."
-        )
+        if(!PEcAn.utils::unit_is_parseable(u1)){
+          PEcAn.logger::logger.error(
+            "Units '", u1,  "' not parseable.",
+            "Please provide a unit that is parseable by the udunits library."
+          )
+        }
+        # Grab the bety units and compare only if we have both units
+        if(length(u2) > 0 && !is.na(u2)){
+          if(!units::ud_are_convertible(u1, u2)){
+            PEcAn.logger::logger.error(
+              "Units are not convertible."
+            )
+          }
+        }
       }
     }
   }
 
     formats_df <- tibble::tibble(
-      header = as.character(header),
+      header = header,
       skip = skip,
       mimetype_id = mimetype_id,
       notes = notes,
-      name = format_name,
-      stringsAsFactors = FALSE
+      name = format_name
     )
 
     ## Insert format record

--- a/base/remote/R/merge_job_files.R
+++ b/base/remote/R/merge_job_files.R
@@ -15,7 +15,7 @@ merge_job_files <- function(settings, jobs_per_file = 10, outdir = NULL){
   }
   # create folder or delete previous job files.
   if(dir.exists(outdir)){
-    unlink(list.files(outdir, recursive = T, full.names = T))
+    unlink(list.files(outdir, recursive = TRUE, full.names = TRUE))
   }else{
     dir.create(outdir)
   }

--- a/base/remote/R/qsub_parallel.R
+++ b/base/remote/R/qsub_parallel.R
@@ -15,7 +15,7 @@
 #' @importFrom foreach %dopar%
 #' @importFrom dplyr %>%
 qsub_parallel <- function(settings, files = NULL, prefix = "sipnet.out", sleep = 10, hybrid = TRUE) {
-  if("try-error" %in% class(try(find.package("doSNOW"), silent = T))){
+  if("try-error" %in% class(try(find.package("doSNOW"), silent = TRUE))){
     PEcAn.logger::logger.info("Package doSNOW is not installed! Please install it and rerun the function!")
     return(0)
   }
@@ -71,7 +71,7 @@ qsub_parallel <- function(settings, files = NULL, prefix = "sipnet.out", sleep =
     if(!dir.exists(std_out)){
       dir.create(std_out)
     }else{
-      unlink(list.files(std_out, recursive = T, full.names = T))
+      unlink(list.files(std_out, recursive = TRUE, full.names = TRUE))
     }
     jobids <- foreach::foreach(file = files, .packages="Kendall", .options.snow=opts, settings = rep(settings, length(files))) %dopar% {
       qsub <- settings$host$qsub

--- a/modules/data.atmosphere/R/align_met.R
+++ b/modules/data.atmosphere/R/align_met.R
@@ -428,7 +428,7 @@ align.met <- function(train.path, source.path, yrs.train=NULL, yrs.source=NULL, 
           dat.tem <- ncdf4::ncvar_get(ncT, v)
           
           if(align=="repeat"){ # if we need to coerce the time step to be repeated to match temporal resolution, do it here
-            dat.tem <- rep(dat.tem, each=stamps.hr)
+            dat.tem <- rep(dat.tem, each=length(stamps.hr))
           }
           df.tem <- matrix(rep(dat.tem, n.src), ncol=1, byrow=F)
           

--- a/modules/data.atmosphere/R/debias_met_regression.R
+++ b/modules/data.atmosphere/R/debias_met_regression.R
@@ -108,22 +108,22 @@ debias.met.regression <- function(train.data, source.data, n.ens, vars.debias=NU
 
   # If we have more columns than we need, randomly subset
   if(ncol(train.data[[2]]) > n.ens) {
-    ens.train <- sample(1:ncol(train.data[[2]]), ncol(train.data[[2]]),replace=T)
+    ens.train <- sample(1:ncol(train.data[[2]]), n.ens, replace = TRUE)
   }
 
   # Setting up cases for dealing with an ensemble of source data to be biased
-  if(pair.ens==T & ncol(train.data[[2]]!=ncol(source.data[[2]]))){
+  if(isTRUE(pair.ens) && (ncol(train.data[[2]]) != ncol(source.data[[2]]))){
     stop("Cannot pair ensembles of different size")
-  } else if(pair.ens==T) {
+  } else if(isTRUE(pair.ens)) {
     ens.src <- ens.train
   }
 
-  if(pair.ens==F & ncol(source.data[[2]])==1){
-    ens.src=1
-  } else if(pair.ens==F & ncol(source.data[[2]]) > n.ens) {
-    ens.src <- sample(1:ncol(source.data[[2]]), ncol(source.data[[2]]),replace=T)
-  } else if(pair.ens==F & ncol(source.data[[2]]) < n.ens){
-    ens.src <- c(1:ncol(source.data[[2]]), sample(1:ncol(source.data[[2]]), n.ens-ncol(source.data[[2]]),replace=T))
+  if(!isTRUE(pair.ens) && ncol(source.data[[2]])==1){
+    ens.src <- 1
+  } else if(!isTRUE(pair.ens) && ncol(source.data[[2]]) > n.ens) {
+    ens.src <- sample(1:ncol(source.data[[2]]), n.ens, replace = TRUE)
+  } else if(!isTRUE(pair.ens) && ncol(source.data[[2]]) < n.ens){
+    ens.src <- c(1:ncol(source.data[[2]]), sample(1:ncol(source.data[[2]]), n.ens-ncol(source.data[[2]]), replace = TRUE))
   }
   # ---------
 
@@ -1020,7 +1020,7 @@ debias.met.regression <- function(train.data, source.data, n.ens, vars.debias=NU
         )
       }
 
-      dir.create(path.diagnostics, recursive=T, showWarnings=F)
+      dir.create(path.diagnostics, recursive = TRUE, showWarnings = FALSE)
 
       dat.pred <- source.data$time
       dat.pred$Date <- as.POSIXct(dat.pred$Date)
@@ -1038,7 +1038,7 @@ debias.met.regression <- function(train.data, source.data, n.ens, vars.debias=NU
           ggplot2::geom_line(ggplot2::aes(x=.data$Date, y=.data$obs, color="original"), size=0.5) +
           ggplot2::scale_color_manual(values=c("corrected" = "red", "original"="black")) +
           ggplot2::scale_fill_manual(values=c("corrected" = "red", "original"="black")) +
-          ggplot2::guides(fill=F) +
+          ggplot2::guides(fill = FALSE) +
           ggplot2::ggtitle(paste0(v, " - ensemble mean & 95% CI (daily slice)")) +
           ggplot2::theme_bw()
       )


### PR DESCRIPTION
## What
Small, targeted fixes to prevent runtime errors and subtle misbehavior in DB utilities, remote job helpers, and meteorology alignment/debiasing routines. No new features, no API changes.

## Why
- dbfiles: wrong get.id argument order prevented lookups; file-type guard always evaluated TRUE.
- align_met: incorrect `rep(..., each=stamps.hr)` used a vector as a scalar, leading to length mismatch.
- debias_met_regression: ensemble-size checks and sampling counts were incorrect; could error or oversample.
- insert.format.vars: invalid indexing and collect() usage, wrong type check for `skip`, and unsafe unit checks could raise errors.

## Scope/Risk
- Changes are confined to the listed functions; default behavior is preserved except to correct the bugs.
- No interfaces or schemas changed; CI and existing callers should remain unaffected.

## Testing hints
- Run existing R tests for affected packages (PEcAn.DB, PEcAn.data.atmosphere, PEcAn.remote) if available.
- Smoke test `align.met()` with coarse source and finer training data.
- Call `insert.format.vars()` with a tibble for `formats_variables` and confirm validations and DB writes.
- Exercise `dbfile.move()` with supported types ("nc"/"clim").