### PR TITLE
Update phenological parameters when there are NAs for specific site-years using across-year means

### DIFF
--- a/models/sipnet/R/write.configs.SIPNET.R
+++ b/models/sipnet/R/write.configs.SIPNET.R
@@ -487,18 +487,42 @@ write.config.SIPNET <- function(defaults, trait.values, settings, run.id, inputs
       leaf_pheno_path <- settings$run$inputs$leaf_phenology$path
       if (!is.null(leaf_pheno_path)) {
         ##read data
-        leafphdata <- utils::read.csv(leaf_pheno_path)
+        leafphdata <- utils::read.csv(leaf_pheno_path) #leaf phenology data starting from 2001-01-01 to current
         leafOnDay <- leafphdata$leafonday[leafphdata$year == obs_year_start
                                           & leafphdata$site_id == settings$run$site$id]
         leafOffDay <- leafphdata$leafoffday[leafphdata$year == obs_year_start
                                             & leafphdata$site_id == settings$run$site$id]
-        # when we have NAs for phenology.
-        if (is.na(leafOnDay)) {
-          leafOnDay <- param[which(param[, 1] == "leafOnDay"), 2]
+        # when we have NAs for phenology (or missing years)
+        if (length(leafOnDay) == 0 || is.na(leafOnDay)) {
+          # 1. Try to calculate the mean across all available years for this site
+          site_phenology_on <- leafphdata$leafonday[leafphdata$site_id == settings$run$site$id]
+          mean_on <- mean(site_phenology_on, na.rm = TRUE)
+          
+          if (!is.nan(mean_on) && !is.na(mean_on)) {
+            leafOnDay <- round(mean_on)
+            PEcAn.logger::logger.info(paste("Missing leafOnDay for current year. Using site mean:", leafOnDay))
+          } else {
+            # 2. If no site history exists, fall back to parameter file
+            leafOnDay <- param[which(param[, 1] == "leafOnDay"), 2]
+            PEcAn.logger::logger.warn("Missing leafOnDay and no site history. Using parameter file default.")
+          }
         }
-        if (is.na(leafOffDay)) {
-          leafOffDay <- param[which(param[, 1] == "leafOffDay"), 2]
+        
+        if (length(leafOffDay) == 0 || is.na(leafOffDay)) {
+          # 1. Try to calculate the mean across all available years for this site
+          site_phenology_off <- leafphdata$leafoffday[leafphdata$site_id == settings$run$site$id]
+          mean_off <- mean(site_phenology_off, na.rm = TRUE)
+          
+          if (!is.nan(mean_off) && !is.na(mean_off)) {
+            leafOffDay <- round(mean_off)
+            PEcAn.logger::logger.info(paste("Missing leafOffDay for current year. Using site mean:", leafOffDay))
+          } else {
+            # 2. If no site history exists, fall back to parameter file
+            leafOffDay <- param[which(param[, 1] == "leafOffDay"), 2]
+            PEcAn.logger::logger.warn("Missing leafOffDay and no site history. Using parameter file default.")
+          }
         }
+        
         # when we have Leaf off date larger than leaf on date.
         # Otherwise the phenology will not be used.
         if (leafOffDay > leafOnDay) {


### PR DESCRIPTION
Update phenological parameters when there are NAs for specific site-years using across-year means
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
Update phenological parameters when there are NAs for specific site-years using across-year means.

## Motivation and Context
Resolve the issue that default leaf-on date of 144 and leaf-off date of 285 were used when missing or poor quality phenological data were presented in the parameter file derived from MODIS Land Cover Dynamics (MCD12Q2) Version 6.1 data product. There is also a need to rerun "PEcAn.data.remote::extract_phenology_MODIS" with start date as "2001-01-01" to calculate the site-specific across-year means.
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
