### PR TITLE
ensure_version_bump: Default to most recent tag by date

### DIFF
--- a/scripts/ensure_version_bump.sh
+++ b/scripts/ensure_version_bump.sh
@@ -25,7 +25,7 @@ set -e
 
 # Git tag (or hash or other ref) to compare against.
 # If not given as an argument, defaults to the most recently created tag.
-git_ref=${1:-$(git describe --tags --abbrev=0)}
+git_ref=${1:-$(git tag --sort=-creatordate | head -n1)}
 
 # Directory inside which to check every R package.
 # If not given as an argument, defaults to the current working directory.


### PR DESCRIPTION
## Description

Previous default used `git describe --tags`, which walks back through history to find the closest tagged ancestor commit.  New version finds the tag with the newest creatordate. This works better in shallow clones (e.g. on CI) because you only need the tag commits (`git fetch --tags --depth=1`); previous `git describe` default needed the full history from HEAD to tag.

Note that neither of these is guaranteed to be the tag with the semantically largest version number; for that we'd want --sort="v:refname" along with being sure our tags stick to one parseable versioning system.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I started looking into this because of an odd-looking [CI failure](https://github.com/PecanProject/pecan/pull/3680#issuecomment-3583410610) that was probably mostly a temporary GitHub API failure. The CI job still uses the API call that drove that failure (Because if any of these definitions of "most recent tag" ever conflict with each other, the latest release is the one we'll want to use), but I'm hoping this change will give it a more robust fallback on CI _and_ arguably make the default more likely to be what users want.
