### PR TITLE
comment dbsync out of compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -363,26 +363,30 @@ services:
   # Shiny Apps
   # ----------------------------------------------------------------------
   # PEcAn DB Sync visualization
-  dbsync:
-    hostname: dbsync
-    platform: linux/amd64
-    image: pecan/shiny-dbsync:${PECAN_VERSION:-latest}
-    restart: unless-stopped
-    networks:
-      - pecan
-    depends_on:
-      postgres:
-        condition: service_healthy
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.dbsync.rule=Host(`${TRAEFIK_HOST:-pecan.localhost}`) && PathPrefix(`/dbsync/`)"
-      - "traefik.http.routers.dbsync.middlewares=dbsync-stripprefix"
-      - "traefik.http.middlewares.dbsync-stripprefix.stripprefix.prefixes=/dbsync"
-    healthcheck:
-      test: "curl --silent --fail http://localhost:3838 > /dev/null || exit 1"
-      interval: 10s
-      timeout: 5s
-      retries: 5
+  #  Note: We no longer recommend enabling sync by default.
+  #   Only turn this on if you're sure you need it, and only if you know
+  #   which servers you want to sync with. dbsync's built-in server list
+  #   is out of date.
+  # dbsync:
+  #   hostname: dbsync
+  #   platform: linux/amd64
+  #   image: pecan/shiny-dbsync:${PECAN_VERSION:-latest}
+  #   restart: unless-stopped
+  #   networks:
+  #     - pecan
+  #   depends_on:
+  #     postgres:
+  #       condition: service_healthy
+  #   labels:
+  #     - "traefik.enable=true"
+  #     - "traefik.http.routers.dbsync.rule=Host(`${TRAEFIK_HOST:-pecan.localhost}`) && PathPrefix(`/dbsync/`)"
+  #     - "traefik.http.routers.dbsync.middlewares=dbsync-stripprefix"
+  #     - "traefik.http.middlewares.dbsync-stripprefix.stripprefix.prefixes=/dbsync"
+  #   healthcheck:
+  #     test: "curl --silent --fail http://localhost:3838 > /dev/null || exit 1"
+  #     interval: 10s
+  #     timeout: 5s
+  #     retries: 5
 
   # ----------------------------------------------------------------------
   # PEcAn API


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Removes dbsync Shiny app from the default Docker stack. Given few servers are still participating in Bety sync and how many new PEcAn users come asking about dbsync failing to launch as their first experience running the Docker stack, I think it's time to turn it off.

For now I've just commented it out of docker-compose.yml; I'm open to suggestions on whether to instead delete the yml entry or even remove the app entirely.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
