### PR TITLE
Quarto: remove manual outdir creation and fix pft outdir

### DIFF
--- a/documentation/tutorials/Demo_1_Basic_Run/pecan.xml
+++ b/documentation/tutorials/Demo_1_Basic_Run/pecan.xml
@@ -11,7 +11,7 @@
   <pft>
    <name>temperate.coniferous</name>
    <posterior.files>pft/temperate.coniferous/prior.distns.Rdata</posterior.files>
-   <outdir>pft/temperate.coniferous/pft/temperate.coniferous</outdir>
+   <outdir>pft/temperate.coniferous</outdir>
   </pft>
  </pfts> 
  <ensemble>

--- a/documentation/tutorials/Demo_1_Basic_Run/run_pecan.qmd
+++ b/documentation/tutorials/Demo_1_Basic_Run/run_pecan.qmd
@@ -167,17 +167,6 @@ settings$info <- list(
 
 Editing the more interesting settings to change the PFT (`settings$pfts`) or extend the run (`settings$run$end.date`) is beyond the scope of this demo. You _could_ change the pft or the end date, but you would need a new file containing parameters for that PFT (`settings$pfts$pft$posterior.files`), or a climate file (`settings$run$met$path$path1`) that extends to the desired simulation period.
 
-# Create Output Directory
-
-Before running the workflow, we need to ensure that the output directory specified in the settings exists. This directory will store all the model outputs, configuration files, and results from the simulation.
-
-> **Note:** All outputs will be written to `settings$outdir`. You can change this directory in your `pecan.xml` file or by modifying `settings$outdir` in the notebook before running the workflow. You can also put the `sipnet` executable anywhere you prefer, as long as you update `settings$model$binary`.
-
-```{r create-outdir}
-dir.create(settings$outdir, recursive = TRUE, showWarnings = FALSE)
-```
-
-
 The directory structure created by PEcAn for this demo run will look like this:
 
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Currently, we don’t need to create the output directory in the demo notebook. This part is leftover from the Demo 1 notebook and has already been removed from Demo 2, since output directory creation is handled by `prepare.settings`, as mentioned here https://github.com/PecanProject/pecan/pull/3570#discussion_r2433535723. 

And also PFT outdir has also been fixed in the settings file, as noted here https://github.com/PecanProject/pecan/pull/3570#discussion_r2512154447.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
