### PR TITLE
Ensure settings$database defaults to NULL when absent

### DIFF
--- a/base/settings/R/check.all.settings.R
+++ b/base/settings/R/check.all.settings.R
@@ -450,25 +450,27 @@ check.settings <- function(settings, force = FALSE) {
   }
 
   # Check folder where outputs are written before adding to dbfiles
-  if (is.null(settings$database$dbfiles)) {
-    settings$database$dbfiles <- PEcAn.utils::full.path("~/.pecan/dbfiles")
-  } else {
-    if (substr(settings$database$dbfiles, 1, 1) != "/") {
-      PEcAn.logger::logger.warn(
-        "settings$database$dbfiles pathname", settings$database$dbfiles,
-        "is invalid\n",
-        "placing it in the home directory ",
-        Sys.getenv("HOME"))
-      settings$database$dbfiles <- file.path(
-        Sys.getenv("HOME"),
-        settings$database$dbfiles)
-    }
+  if (!is.null(settings$database)) {
+    if (is.null(settings$database$dbfiles)) {
+      settings$database$dbfiles <- PEcAn.utils::full.path("~/.pecan/dbfiles")
+    } else {
+      if (substr(settings$database$dbfiles, 1, 1) != "/") {
+        PEcAn.logger::logger.warn(
+          "settings$database$dbfiles pathname", settings$database$dbfiles,
+          "is invalid\n",
+          "placing it in the home directory ",
+          Sys.getenv("HOME"))
+        settings$database$dbfiles <- file.path(
+          Sys.getenv("HOME"),
+          settings$database$dbfiles)
+      }
 
-    settings$database$dbfiles <- normalizePath(
-      settings$database$dbfiles,
-      mustWork = FALSE)
+      settings$database$dbfiles <- normalizePath(
+        settings$database$dbfiles,
+        mustWork = FALSE)
+    }
+    dir.create(settings$database$dbfiles, showWarnings = FALSE, recursive = TRUE)
   }
-  dir.create(settings$database$dbfiles, showWarnings = FALSE, recursive = TRUE)
 
   # check all inputs exist
   settings <- papply(settings, check.inputs)

--- a/documentation/tutorials/Demo_02_Uncertainty_Analysis/uncertainty.qmd
+++ b/documentation/tutorials/Demo_02_Uncertainty_Analysis/uncertainty.qmd
@@ -120,10 +120,6 @@ See Demo 1 Section 6 for details on what these functions do. Briefly, they read 
 
 This step generates the model-specific configuration files that will be used to run the ecosystem model. The process involves:
 
-1. Disabling database write operations because we are not using a database
-```{r disable-db-write}
-settings$database <- NULL # Disable database operations for this demo
-```
 2. Generating SIPNET configuration files using the `runModule.run.write.configs()` function.
 ```{r write-configs}
 settings <- PEcAn.workflow::runModule.run.write.configs(settings)

--- a/documentation/tutorials/Demo_1_Basic_Run/run_pecan.qmd
+++ b/documentation/tutorials/Demo_1_Basic_Run/run_pecan.qmd
@@ -187,13 +187,9 @@ Additional outputs include logs, a `STATUS` file that records the steps of the w
 
 # Write Model Configuration Files
 
-This step generates the model-specific configuration files and scripts that will be used to run the ecosystem model. The process involves:
-
-1. Disabling database write operations because we are not using a database
-2. Generating SIPNET configuration files using the `runModule.run.write.configs()` function.
+This step generates the model-specific configuration files and scripts that will be used to run the ecosystem model. The process involves generating SIPNET configuration files using the `runModule.run.write.configs()` function.
 
 ```{r write-configs}
-settings$database <- NULL # Disable database operations for this demo
 settings <- PEcAn.workflow::runModule.run.write.configs(settings)
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Currently, both Demo notebooks use a workaround to set settings$database to NULL, even though the <database> configuration is absent in the settings file.

https://github.com/PecanProject/pecan/blob/381c450d92f0921c3f3391bf6c10786ed7f35c16/documentation/tutorials/Demo_02_Uncertainty_Analysis/uncertainty.qmd#L123-L125

The issue arises because `prepare.settings` automatically adds `settings$database$dbfiles` even if `settings$database` is initially absent. (see https://github.com/PecanProject/pecan/issues/3701#issuecomment-3618966494).

This PR fixes the issue by modifying `check.settings` to only set `settings$database$dbfiles` if `settings$database` is already present (i.e., not NULL). This ensures that `settings$database` remains `NULL` when no database configuration is provided.
Also, after the fix, inspecting the `settings` object confirms that there is NO `settings$database` present.
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3701

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
