### PR TITLE
Remove hardcoded assumption that model output lives in outdir/out

### DIFF
--- a/modules/assim.sequential/R/sda.enkf_refactored.R
+++ b/modules/assim.sequential/R/sda.enkf_refactored.R
@@ -379,7 +379,7 @@ sda.enkf <- function(settings,
     
     #----chaning the extension of nc files to a more specific date related name
    files <-  list.files(
-      path = file.path(settings$outdir, "out"),
+      path = settings$modeloutdir,
       "*.nc$",
       recursive = TRUE,
       full.names = TRUE)

--- a/modules/uncertainty/R/run.ensemble.analysis.R
+++ b/modules/uncertainty/R/run.ensemble.analysis.R
@@ -241,7 +241,7 @@ read.ensemble.ts <- function(settings, ensemble.id = NULL, variable = NULL,
     for(var in seq_along(variables)){
       out.tmp <- PEcAn.utils::read.output(
         run.id,
-        file.path(settings$outdir, "out", run.id),
+        file.path(settings$modeloutdir, run.id),
         start.year,
         end.year,
         variables[var])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
This PR removes hardcoded assumptions in workflow modules that model output
always lives in `file.path(settings$outdir, "out")`. The affected modules now
consistently use `settings$modeloutdir`, which respects user-defined output
locations provided via XML configuration.

A repository-wide search was performed to ensure no additional workflow 
code relied on this assumption.

## Motivation and Context
PEcAn already supports a configurable `<modeloutdir>` setting that defaults to
`file.path(outdir, "out")` when not explicitly provided. However, some workflow
modules were still hardcoding `outdir/"out"`, causing user-specified
`<modeloutdir>` values to be ignored.


This change aligns workflow code with existing settings logic and documented
behavior, ensuring consistent handling of model output directories.

Fixes #3439

## Review Time Estimate
- [x] When possible

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) — Fixes #3439
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [x] I agree that PEcAn Project may distribute my contribution under any or all of
  - the same license as the existing code,
  - and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
