### PR TITLE
Run Docker stack test on set schedule instead of each PR

### DIFF
--- a/.github/workflows/docker-stack-sipnet.yml
+++ b/.github/workflows/docker-stack-sipnet.yml
@@ -5,7 +5,7 @@ on :
 
   schedule:
     # run Thursday 4:30 AM UTC
-  - cron: '30 4 * * */3'
+  - cron: '30 4 * * 1,3,5'
 jobs:
   sipnet:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-stack-sipnet.yml
+++ b/.github/workflows/docker-stack-sipnet.yml
@@ -1,13 +1,11 @@
 name : Docker Stack Model Test
 on :
-  pull_request:
-
   # allow manual triggering
   workflow_dispatch:
 
   schedule:
     # run Thursday 4:30 AM UTC
-  - cron: '30 4 * * 4'    
+  - cron: '30 4 * * */3'
 jobs:
   sipnet:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-stack-sipnet.yml
+++ b/.github/workflows/docker-stack-sipnet.yml
@@ -4,7 +4,7 @@ on :
   workflow_dispatch:
 
   schedule:
-    # run Thursday 4:30 AM UTC
+   # run at 4:30 AM UTC on Mon, Wed, Fri
   - cron: '30 4 * * 1,3,5'
 jobs:
   sipnet:


### PR DESCRIPTION
This job pulls its Docker containers from `develop` and does not rebuild them from the PR branch, so running it for each push implied a closer connection between test output and the changes in the PR than is actually there. 

This patch stops running the job on pull requests and instead bumps up the frequency of scheduled runs -- currently to once every 3 days, but I could see moving it all the way to daily if we find that's still too much lag between introducing changes and being alerted to problems.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
