### PR TITLE
db: fix convert_input and missing site.id 

### DIFF
--- a/base/db/R/convert_input.R
+++ b/base/db/R/convert_input.R
@@ -112,6 +112,9 @@ convert_input <-
   # Forecast data sets require their own set of database checking operations, making the following else if and else irrelevant
   # for such data.  Forecast data are different if their start date (and if they are part of an ensemble, their ensemble id) are 
   # different.
+  existing.input <- NULL
+  existing.dbfile <- NULL
+  PEcAn.logger::logger.info("DEBUG: Initialized existing.input/dbfile to NULL")
   if (forecast) {
     #if the data is an ensemble, ensemble will be set equal to the number of ensemble members.
     #However, if the data is not an ensemble, ensemble will be equal to FALSE.  In order to treat ensemble and 
@@ -497,6 +500,9 @@ convert_input <-
   input <- machine.info$input
   dbfile <- machine.info$dbfile
   
+  if (is.data.frame(input)) {
+    input <- list(input)
+  }
   #--------------------------------------------------------------------------------------------------#
   # Perform Conversion
  
@@ -574,7 +580,7 @@ convert_input <-
                                machine, mimetype, formatname,
                                allow.conflicting.dates, ensemble,
                                ensemble_name, existing.input,
-                               existing.dbfile, input)
+                               existing.dbfile, input, site.id)
       )
     }
     # if we got here, nothing left to do

--- a/base/db/R/convert_input.R
+++ b/base/db/R/convert_input.R
@@ -114,7 +114,6 @@ convert_input <-
   # different.
   existing.input <- NULL
   existing.dbfile <- NULL
-  PEcAn.logger::logger.info("DEBUG: Initialized existing.input/dbfile to NULL")
   if (forecast) {
     #if the data is an ensemble, ensemble will be set equal to the number of ensemble members.
     #However, if the data is not an ensemble, ensemble will be equal to FALSE.  In order to treat ensemble and 

--- a/base/db/R/update_ensemble_writes.R
+++ b/base/db/R/update_ensemble_writes.R
@@ -33,7 +33,7 @@ update_ensemble_writes <- function(
     machine, mimetype, formatname,
     allow.conflicting.dates, ensemble,
     ensemble_name, existing.input,
-    existing.dbfile, input) {
+    existing.dbfile, input, site.id) {
     # Setup newinput. This list will contain two variables: a vector of input IDs and a vector of DB IDs for each entry in result.
     # This list will be returned.
     newinput <- list(input.id = NULL, dbfile.id = NULL) # Blank vectors are null.

--- a/base/db/R/update_ensemble_writes.R
+++ b/base/db/R/update_ensemble_writes.R
@@ -19,6 +19,7 @@
 #' @param existing.input data.frame. Possibly zero rows representing the current record(s) in the `inputs` table that match (or partially match) the data being added. If no matching record exists, an empty data frame is supplied.
 #' @param existing.dbfile data.frame. Possibly zero rows representing the current record(s) in the `dbfiles` table that match (or partially match) the data being added. If no matching record exists, an empty data frame is supplied.
 #' @param input data.frame. Single row with the parent input record from BETYdb, typically including columns like `id`, `start_date`, `end_date`, etc. If the new data are derived from an existing input, this links them in the `parent_id` column of the new entries.
+#' @param site.id integer. The ID of the site associated with the input data.
 #' 
 #' @return list with two elements: \describe{ \item{input.id}{A numeric vector of new (or updated) input record IDs.} \item{dbfile.id}{A numeric vector of new (or updated) dbfile record IDs.} }
 #' 

--- a/base/db/man/update_ensemble_writes.Rd
+++ b/base/db/man/update_ensemble_writes.Rd
@@ -20,7 +20,8 @@ update_ensemble_writes(
   ensemble_name,
   existing.input,
   existing.dbfile,
-  input
+  input,
+  site.id
 )
 }
 \arguments{
@@ -55,6 +56,8 @@ update_ensemble_writes(
 \item{existing.dbfile}{data.frame. Possibly zero rows representing the current record(s) in the `dbfiles` table that match (or partially match) the data being added. If no matching record exists, an empty data frame is supplied.}
 
 \item{input}{data.frame. Single row with the parent input record from BETYdb, typically including columns like `id`, `start_date`, `end_date`, etc. If the new data are derived from an existing input, this links them in the `parent_id` column of the new entries.}
+
+\item{site.id}{integer. The ID of the site associated with the input data.}
 }
 \value{
 list with two elements: \describe{ \item{input.id}{A numeric vector of new (or updated) input record IDs.} \item{dbfile.id}{A numeric vector of new (or updated) dbfile record IDs.} }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Encountered a few issues while running the workflow using a database connection. Below are the error logs:

```
Error in PEcAn.DB::convert_input(...) : object 'existing.input' not found
```

and 

```
Error in h(simpleError(msg, call)) : 
  error in evaluating the argument 'statement' in selecting a method for function 'dbGetQuery': object 'site.id' not found
Calls: <Anonymous> ... db.query -> <Anonymous> -> paste0 -> .handleSimpleError -> h
```
I will try to explain these issues with the fixes in more detail below.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
