### PR TITLE
input.ens.gen: Complain if input doesn't exist

### DIFF
--- a/modules/uncertainty/R/ensemble.R
+++ b/modules/uncertainty/R/ensemble.R
@@ -552,20 +552,25 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
 #'
 input.ens.gen <- function(settings, ensemble_size, input, method = "sampling", parent_ids = NULL) {
 
-  #-- reading the dots and exposing them to the inside of the function
   samples <- list()
   samples$ids <- c()
-  #
+
   if (is.null(method)) return(NULL)
   # parameter is exceptional it needs to be handled spearatly
   if (input == "parameters") return(NULL)
 
-  #-- assing the sample ids based on different scenarios
   input_path <- settings$run$inputs[[tolower(input)]]$path
+  if (is.null(input_path)) {
+    PEcAn.logger::logger.error(
+      "No paths found for input", sQuote(input), "in settings$run$inputs"
+    )
+  }
+
   if (!is.null(parent_ids)) {
     samples$ids <- parent_ids$ids
     out.of.sample.size <- length(samples$ids[samples$ids > length(input_path)])
-    #sample for those that our outside the param size - forexample, parent id may send id number 200 but we have only100 sample for param
+    # sample for those that our outside the param size -
+    # for example, parent id may send id number 200 but we have only 100 sample for param
     samples$ids[samples$ids %in% out.of.sample.size] <- sample(
       seq_along(input_path),
       out.of.sample.size,
@@ -578,11 +583,10 @@ input.ens.gen <- function(settings, ensemble_size, input, method = "sampling", p
   } else if (tolower(method) == "looping") {
     samples$ids <- rep_len(
       seq_along(input_path),
-      length.out = ensemble_size )
+      length.out = ensemble_size)
   }
   #using the sample ids
   samples$samples <- input_path[samples$ids]
 
   return(samples)
 }
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
I had a typo in my `settings$ensemble$samplingspace` that turned out to be making `input.ens.gen` look for a nonexistent block of `settings$run$inputs`, but it took me a while to dig down to that when the only message I had to start from was `Error in sample.int(length(x), size, replace, prob) :  invalid first argument`. Hopefully the new wording here will be easier to interpret and fix.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
