### PR TITLE
docs: update master branch references to main

### DIFF
--- a/scripts/install_pecan.sh
+++ b/scripts/install_pecan.sh
@@ -410,7 +410,7 @@ sudo cp sipnet /usr/local/bin/sipnet.r136
 make clean
 
 cd ${HOME}/sipnet/
-git checkout master
+git checkout main
 make clean
 make
 sudo cp sipnet /usr/local/bin/sipnet.git

--- a/scripts/syncgit.sh
+++ b/scripts/syncgit.sh
@@ -7,9 +7,9 @@ git stash -u
 # update all remotes
 git fetch --all
 
-# update master
-git checkout master
-git merge upstream/master
+# update main
+git checkout main
+git merge upstream/main
 git push
 
 # update develop


### PR DESCRIPTION
Updated all references from the old master branch to the new main branch across the PEcAn repository

syncgit.sh  Changed git checkout and merge commands to use main instead of master
install_pecan.sh Updated the Sipnet build section to checkout main instead of master

### fixes #3726 