### PR TITLE
soil2netcdf: Do not drop depth dimension from one-layer files

### DIFF
--- a/modules/data.land/R/soil2netcdf.R
+++ b/modules/data.land/R/soil2netcdf.R
@@ -2,7 +2,7 @@
 #'
 #' A table of standard names and units can be displayed by running
 #'  soil.units() without any arguements
-#' 
+#'
 #' soil_params is called internally to estimate additional soil physical
 #' parameters from sand/silt/clay & bulk density. Will not overwrite any
 #' provided values
@@ -28,7 +28,15 @@
 #'
 #' soil2netcdf(soil.data,"soil.nc") }
 soil2netcdf <- function(soil.data, new.file) {
-  soil.data <- as.list(soil.data)
+  if (any(lengths(soil.data) != length(soil.data[[1]]))) {
+    PEcAn.logger::logger.warn(
+      "Soil2netcdf: input lengths differ.",
+      "Will make them equal by recycling shorter variables.",
+      "If this is not expected, please  fix inputs and rerun."
+    )
+  }
+  soil.data <- as.data.frame(soil.data)
+
 
   ## convert soil type to parameters via look-up-table / equations
   mysoil <- PEcAn.data.land::soil_params(sand = soil.data$fraction_of_sand_in_soil,
@@ -49,42 +57,33 @@ soil2netcdf <- function(soil.data, new.file) {
   soil.data$soil_n <- NULL
 
   ## create depth dimension
-  depth <- ncdf4::ncdim_def(name = "depth", units = "meters", vals = soil.data$soil_depth, create_dimvar = TRUE)  
+  depth <- ncdf4::ncdim_def(name = "depth",
+                            units = "meters",
+                            vals = soil.data$soil_depth,
+                            create_dimvar = TRUE)
   soil.data$soil_depth <- NULL ## deleting so don't ALSO write as a variable
-  
-  ## create netCDF variables
-  ncvar <- list()
-  good_vars <- 0
-  for(n in seq_along(soil.data)){
-    if(all(is.null(soil.data[[n]])) || all(is.na(soil.data[[n]]))) next
-    varname <- names(soil.data)[n]
-    if(length(soil.data[[n]])>1){
-      ## if vector, save by depth
-      good_vars <- c(good_vars,n)
-      ncvar[[n]] <- ncdf4::ncvar_def(name = varname, 
-                                     units = soil.units(varname), 
-                                     dim = depth)
-    }else {
-      ## else save as scalar
-      good_vars <- c(good_vars,n)
-      ncvar[[n]] <- ncdf4::ncvar_def(name = varname, 
-                                     units = soil.units(varname), 
-                                     dim=list())
-    }
+
+  ## Drop empty/missing data
+  good_vars <- sapply(soil.data, \(x) !all(is.na(x)))
+  if (sum(good_vars) < 1) {
+    PEcAn.logger::logger.error("All variables missing")
+    return()
   }
-  if(length(good_vars)>1) {
-  good_vars <- good_vars[2:length(good_vars)]
-  ncvar <- ncvar[good_vars]
-  soil.data <- soil.data[good_vars]
+
+  ## create netCDF variables
+  def_dim <- function(vn) {
+    ncdf4::ncvar_def(name = vn,
+                     units = soil.units(vn),
+                     dim = depth)
+  }
+  ncvar <- sapply(names(soil.data), def_dim, simplify = FALSE)
+
   ## create new file
   nc <- ncdf4::nc_create(new.file, vars = ncvar)
-  
+  on.exit(ncdf4::nc_close(nc), add = TRUE)
+
   ## add data
-  for (i in seq_along(ncvar)) {
-    if(is.null(soil.data[[i]]) || all(is.na(soil.data[[i]]))) next
-    ncdf4::ncvar_put(nc, ncvar[[i]], soil.data[[i]]) 
-  }
-  
-  ncdf4::nc_close(nc)
+  for (vn in names(soil.data)) {
+    ncdf4::ncvar_put(nc, ncvar[[vn]], soil.data[[vn]])
   }
 }

--- a/modules/data.land/tests/testthat/test-soil2netcdf.R
+++ b/modules/data.land/tests/testthat/test-soil2netcdf.R
@@ -1,0 +1,37 @@
+list2nc2list <- function(depth,
+                         sand = 0, clay = 0, silt = NULL,
+                         ...) {
+  if (is.null(silt)) {
+    silt <- 1 - (sand + clay)
+  }
+  nc <- withr::local_tempfile()
+  data.frame(
+    fraction_of_sand_in_soil = sand,
+    fraction_of_silt_in_soil = silt,
+    fraction_of_clay_in_soil = clay,
+    soil_depth = depth,
+    ...
+  ) |>
+    soil2netcdf(nc)
+
+  pool_ic_netcdf2list(nc)
+}
+
+test_that("retains depth dimension even when only one layer", {
+  expect_equal(
+    list2nc2list(depth = 0.1)$dims$depth,
+    array(0.1)
+  )
+  expect_equal(
+    list2nc2list(1:2, c(0.5, 0.8), c(0.4, 0.1))$dims$depth,
+    array(c(1, 2))
+  )
+})
+
+test_that("parameters estimated if missing, but not overwritten", {
+  expect_equal(list2nc2list(0.15, 0.3, 0.6)$vals$thcond0, array(0.7636137604))
+  expect_equal(
+    list2nc2list(0.15, 0.3, 0.6, thcond0 = 1.0)$vals$thcond0,
+    array(1.0)
+  )
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
As discussed in Slack. Our best guess is the original motivation for dropping the dimension was probably to avoid extra dimensions in the netcdf, but it means we lose information about the depth of the layer as well, causing trouble for `soil_ic_list2netcdf` (which always needs depth information)

While I was refactoring I also:
* did more whitespace cleanup;
* Added a warning if not all inputs have the same length, and made it recycle short ones if needed by coercing input to a dataframe 
* Simplified the code for removing variables with all values missing

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
