### PR TITLE
Use explicit boolean mask to filter all-NA carbon pool rows

### DIFF
--- a/modules/data.land/R/IC_BADM_Utilities.R
+++ b/modules/data.land/R/IC_BADM_Utilities.R
@@ -163,7 +163,7 @@ Read.IC.info.BADM <-function(lat, long){
   
  #cleaning
 ind <- apply(entries[,5:8], 1, function(x) all(is.na(x)))
-entries <- entries[-which(ind),]
+entries <- entries[!ind, , drop = FALSE]
 
   return(entries)
 }


### PR DESCRIPTION
## Description
This PR updates the row-filtering logic in `IC_BADM_Utilities.R` to remove rows where
all carbon pool values are `NA` using an explicit boolean mask instead of relying on
`-which(ind)`.

The filtering logic has been changed to:

```r
entries <- entries[!ind, , drop = FALSE]
```



## Motivation and Context
Previously, rows with all-NA carbon pool values were filtered using `-which(ind)`.
While this approach works, it relies on implicit behavior in R subsetting,
particularly in edge cases such as:

- when all rows match the condition (all values are `NA`),
- when no rows match the condition, or
- when the input data frame is empty.

Using a boolean mask (`!ind`) makes the logic explicit, improves readability, and
ensures robust handling of all edge cases without changing the resulting output.
This is particularly relevant when BADM returns all-NA values for a site.

## Related Issues
- [x] #739

---

## Review Time Estimate
- [x] Immediately
- [ ] Within one week
- [ ] When possible

---

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [x] I agree that PEcAn Project may distribute my contribution under any or all of
  - the same license as the existing code,
  - and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

