### PR TITLE
Remove skip from read.settings test

### DIFF
--- a/base/settings/tests/testthat/test.read.settings.R
+++ b/base/settings/tests/testthat/test.read.settings.R
@@ -74,8 +74,7 @@ skip_if_not(
 )
 
 test_that("read.settings returned correctly", {
-  s <- .get.test.settings()
-  skip("Tests failing due to multisite?")
+  s <- .get.test.settings(testdir)
   expect_true(file.exists(s$outdir))
   expect_true(file.info(s$outdir)$isdir)
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Removes a skip() call from the "read.settings returned correctly" test,After digging into git history , it was added as a temporary workaround in 2017 ([ac060fde9](https://github.com/PecanProject/pecan/commit/ac060fde9)) during the multisite/MultiSettings feature development (PR #1325).

The underlying issue has long been resolved and the test now passes. This unskips 1 previously disabled test.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
