### PR TITLE
docs(benchmark): changes to documentation of load_csv

### DIFF
--- a/modules/benchmark/DESCRIPTION
+++ b/modules/benchmark/DESCRIPTION
@@ -52,5 +52,5 @@ Copyright: Authors
 LazyLoad: yes
 LazyData: FALSE
 Encoding: UTF-8
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 X-schema.org-keywords: model-evaluation, model-data-comparison, PEcAn

--- a/modules/benchmark/DESCRIPTION
+++ b/modules/benchmark/DESCRIPTION
@@ -52,5 +52,5 @@ Copyright: Authors
 LazyLoad: yes
 LazyData: FALSE
 Encoding: UTF-8
-RoxygenNote: 7.3.3
+RoxygenNote: 7.3.2.9000
 X-schema.org-keywords: model-evaluation, model-data-comparison, PEcAn

--- a/modules/benchmark/DESCRIPTION
+++ b/modules/benchmark/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PEcAn.benchmark
 Type: Package
 Title: PEcAn Functions Used for Benchmarking
-Version: 1.7.5
+Version: 1.7.5.9000
 Authors@R: c(person("Mike", "Dietze", role = c("aut", "cre"),
                      email = "dietze@bu.edu"),
              person("Betsy", "Cowdery", role = c("aut"),

--- a/modules/benchmark/DESCRIPTION
+++ b/modules/benchmark/DESCRIPTION
@@ -52,5 +52,5 @@ Copyright: Authors
 LazyLoad: yes
 LazyData: FALSE
 Encoding: UTF-8
-RoxygenNote: 7.3.2.9000
+RoxygenNote: 7.3.2
 X-schema.org-keywords: model-evaluation, model-data-comparison, PEcAn

--- a/modules/benchmark/NEWS.md
+++ b/modules/benchmark/NEWS.md
@@ -1,3 +1,8 @@
+# PEcAn.benchmark 1.7.5.9000
+
+* Improved clarity of code examples that are not run at check time.
+
+
 # PEcAn.benchmark 1.7.5
 
 * Added keywords and bug reporting URL to DESCRIPTION.

--- a/modules/benchmark/R/load_csv.R
+++ b/modules/benchmark/R/load_csv.R
@@ -1,9 +1,17 @@
 ##' load_csv
 ##'
-##' @param data.path character
-##' @param format list
+##' @param data.path character, file path to the .csv file
+##' @param format list, config list containing 
+##' \itemize{
+##'   \item \code{header},    numeric for number of header rows in file
+##'   \item \code{skip}       numeric for skip argument of utils::read.csv 
+##'   \item \code{na.strings} character vector for na.strings argument
+##'                           of utils::read.csv
+##'   }
 ##' @param site list
 ##' @param vars column names to return. If NULL, returns all columns
+##' 
+##' @return dat, a data.frame with the processed data of the .csv file
 ##' 
 ##' @author Betsy Cowdery
 ##' @export

--- a/modules/benchmark/R/load_csv.R
+++ b/modules/benchmark/R/load_csv.R
@@ -8,7 +8,7 @@
 ##'   \item \code{na.strings}, character vector for na.strings argument
 ##'                           of utils::read.csv
 ##'   }
-##' @param site list
+##' @param site list, currently ignored
 ##' @param vars column names to return. If NULL, returns all columns
 ##' 
 ##' @return a data frame with the processed data of the .csv file

--- a/modules/benchmark/R/load_csv.R
+++ b/modules/benchmark/R/load_csv.R
@@ -4,8 +4,8 @@
 ##' @param format list, config list containing 
 ##' \itemize{
 ##'   \item \code{header},    numeric for number of header rows in file
-##'   \item \code{skip}       numeric for skip argument of utils::read.csv 
-##'   \item \code{na.strings} character vector for na.strings argument
+##'   \item \code{skip},       numeric for skip argument of utils::read.csv 
+##'   \item \code{na.strings}, character vector for na.strings argument
 ##'                           of utils::read.csv
 ##'   }
 ##' @param site list

--- a/modules/benchmark/R/load_csv.R
+++ b/modules/benchmark/R/load_csv.R
@@ -11,7 +11,9 @@
 ##' @param site list, currently ignored
 ##' @param vars column names to return. If NULL, returns all columns
 ##' 
+
 ##' @return a data frame with the processed data of the .csv file
+
 ##' 
 ##' @author Betsy Cowdery
 ##' @export

--- a/modules/benchmark/R/load_csv.R
+++ b/modules/benchmark/R/load_csv.R
@@ -11,7 +11,7 @@
 ##' @param site list
 ##' @param vars column names to return. If NULL, returns all columns
 ##' 
-##' @return dat, a data.frame with the processed data of the .csv file
+##' @return a data frame with the processed data of the .csv file
 ##' 
 ##' @author Betsy Cowdery
 ##' @export

--- a/modules/benchmark/man/load_csv.Rd
+++ b/modules/benchmark/man/load_csv.Rd
@@ -7,13 +7,22 @@
 load_csv(data.path, format, site, vars = NULL)
 }
 \arguments{
-\item{data.path}{character}
+\item{data.path}{character, file path to the .csv file}
 
-\item{format}{list}
+\item{format}{list, config list containing 
+\itemize{
+  \item \code{header},    numeric for number of header rows in file
+  \item \code{skip},       numeric for skip argument of utils::read.csv 
+  \item \code{na.strings}, character vector for na.strings argument
+                          of utils::read.csv
+  }}
 
 \item{site}{list}
 
 \item{vars}{column names to return. If NULL, returns all columns}
+}
+\value{
+\code{dat}, a data.frame with the processed data of the .csv file
 }
 \description{
 load_csv

--- a/modules/benchmark/man/load_csv.Rd
+++ b/modules/benchmark/man/load_csv.Rd
@@ -17,12 +17,12 @@ load_csv(data.path, format, site, vars = NULL)
                           of utils::read.csv
   }}
 
-\item{site}{list}
+\item{site}{list, currently ignored}
 
 \item{vars}{column names to return. If NULL, returns all columns}
 }
 \value{
-\code{dat}, a data.frame with the processed data of the .csv file
+a data frame with the processed data of the .csv file
 }
 \description{
 load_csv


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
I have updated the documentation for the load_csv function in benchmark. It now includes information about the required keys for the format argument and a return tag, stating that the function returns a data.frame (containing the processed .csv data). Also regenerated the corresponding .Rd file. 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I went through the code for the benchmark module, because I am interested in contributing to the proposed project for the GSoC 2026 regarding that module. It is just a minor improvement of the documentation. 

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ x] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [x ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
