### PR TITLE
move {traits} to Suggests

### DIFF
--- a/docker/depends/pecan_package_dependencies.csv
+++ b/docker/depends/pecan_package_dependencies.csv
@@ -665,7 +665,7 @@
 "tidyverse","*","base/db","Suggests",FALSE
 "tools","*","base/remote","Suggests",FALSE
 "tools","*","modules/allometry","Imports",FALSE
-"traits","*","modules/data.land","Imports",FALSE
+"traits","*","modules/data.land","Suggests",FALSE
 "TruncatedNormal",">= 2.2","modules/assim.batch","Imports",FALSE
 "truncnorm","*","modules/data.atmosphere","Imports",FALSE
 "units","*","base/db","Imports",FALSE

--- a/modules/data.land/DESCRIPTION
+++ b/modules/data.land/DESCRIPTION
@@ -58,7 +58,6 @@ Imports:
     terra,
     tidyr,
     tidyselect,
-    traits,
     XML (>= 3.98-1.4)
 Suggests:
     dataone,
@@ -72,6 +71,7 @@ Suggests:
     raster,
     reticulate,
     testthat (>= 3.1.0),
+    traits,
     withr,
     MASS
 Remotes:

--- a/modules/data.land/NEWS.md
+++ b/modules/data.land/NEWS.md
@@ -11,6 +11,11 @@
   *  `landiq_crop_mapping_codes` dataset mapping LandIQ crop classification codes to human-readable crop names.
   *  `bism_kc_by_crop` dataset containing BISm crop coefficient schedules and stage timing references for use in ET estimation, including columns that map to LandIQ class and subclass.
 
+## Changed
+
+* Package `traits`, used by `match_pft()` and `match_species_id()` only when no local database connection is provided, is now suggested rather than required.
+
+
 # PEcAn.data.land 1.9.0
 
 ## Added

--- a/modules/data.land/NEWS.md
+++ b/modules/data.land/NEWS.md
@@ -13,7 +13,7 @@
 
 ## Changed
 
-* Package `traits`, used by `match_pft()` and `match_species_id()` only when no local database connection is provided, is now suggested rather than required.
+* Package `traits`, used by `match_pft()` and `match_species_id()` only when no database connection is provided, is now suggested rather than required.
 
 
 # PEcAn.data.land 1.9.0

--- a/modules/data.land/R/match_pft.R
+++ b/modules/data.land/R/match_pft.R
@@ -33,12 +33,18 @@ match_pft <- function(bety_species_id, pfts, query = NULL, con = NULL, allow_mis
       query <- paste0(query," AND bp.modeltype_id = ",modeltype$id)
     }
     translation <- PEcAn.DB::db.query(query, con = con)
-    
-    
-  }else{ # use traits package
-    
+
+
+  } else { # use traits package
+    if (!requireNamespace("traits", quietly = TRUE)) {
+      PEcAn.logger::logger.severe(
+        "Using match_pft without a Bety connection",
+        "requires the `traits` package, which is not installed."
+      )
+    }
+
     bety_list <- list()
-    
+
     for (pft in pfts) {
       # query pft id
       bety_pft <- traits::betydb_query(name = pft$name, modeltype_id = model$id, table = 'pfts', user = 'bety', pwd = 'bety')

--- a/modules/data.land/R/match_species_id.R
+++ b/modules/data.land/R/match_species_id.R
@@ -87,8 +87,14 @@ match_species_id <- function(input_codes, format_name = 'custom', bety = NULL, t
         translation,
         data.frame(input_code = input_codes, stringsAsFactors = FALSE),
         by = "input_code")
-    }else{
+    } else {
       # use traits package
+      if (!requireNamespace("traits", quietly = TRUE)) {
+        PEcAn.logger::logger.severe(
+          "Using match_species_id without a Bety connection",
+          "requires the `traits` package, which is not installed."
+        )
+      }
 
       # can call traits::betydb_query one at a time?
       # reduce the number of calls

--- a/modules/data.land/tests/Rcheck_reference.log
+++ b/modules/data.land/tests/Rcheck_reference.log
@@ -13,7 +13,7 @@
 * package encoding: UTF-8
 * checking package namespace information ... OK
 * checking package dependencies ... NOTE
-Imports includes 35 non-default packages.
+Imports includes 34 non-default packages.
 Importing from so many packages makes the package vulnerable to any of
 them becoming unavailable.  Move as many as possible to Suggests and
 use conditionally.


### PR DESCRIPTION
Problem: data.land imports {traits}, which imports {taxize}, which was recently [re?]archived on CRAN because it uses the archived {wikidata}. Therefore our CI checks currently fail on R-devel when {traits} fails to install.

Solution: Noting that {traits} is used by only two functions, in both cases as a fallback when no Bety connection is provided, move {traits} to Suggests in data.land and add checks for availability to the code branches that use it.

