### PR TITLE
test(utils): improve test isolation in test-status.R

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,6 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - Fixed a bugs and BADM now process both single-site and multi-site settings, detecting the input structure and processing each site independently to generate the correct number of ensemble members per site.
 - Fixed "external pointer is not valid" error and addressed key bugs in `soilgrids_soilC_extract()` function (#3506)
 - Fixed a bug within the `model2netcdf.SIPNET` function where we assumed the constant calculations of `pecan_start_doy` across years (the calculations should vary depending on the last date from the last loop and the start date of the current loop), which will lead to incorrect calculations of the start `sub_dates` and `sub_dates_cf` if we are jumping between years (e.g., from 2012-12-31 to 2013-01-01). The `sipnet2datetime` function is no longer used anywhere and therefore has been removed.
-- Improved test isolation in base/utils (test-status.R) using withr
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - Fixed a bugs and BADM now process both single-site and multi-site settings, detecting the input structure and processing each site independently to generate the correct number of ensemble members per site.
 - Fixed "external pointer is not valid" error and addressed key bugs in `soilgrids_soilC_extract()` function (#3506)
 - Fixed a bug within the `model2netcdf.SIPNET` function where we assumed the constant calculations of `pecan_start_doy` across years (the calculations should vary depending on the last date from the last loop and the start date of the current loop), which will lead to incorrect calculations of the start `sub_dates` and `sub_dates_cf` if we are jumping between years (e.g., from 2012-12-31 to 2013-01-01). The `sipnet2datetime` function is no longer used anywhere and therefore has been removed.
+- Improved test isolation in base/utils (test-status.R) using withr
 
 ### Changed
 

--- a/base/utils/tests/testthat/test-status.R
+++ b/base/utils/tests/testthat/test-status.R
@@ -1,15 +1,8 @@
 context("status")
 
-make_testdir <- function() {
-	td <- tempfile()
-	dir.create(td)
-	teardown(unlink(td, recursive = TRUE, force = TRUE))
-
-	td
-}
 
 test_that("status functions accept explicit filename", {
-	d <- make_testdir()
+	d <- withr::local_tempdir()
 	f <- file.path(d, "MY_STATUS")
 
 	expect_silent(status.start("TRAITS", f))
@@ -29,14 +22,14 @@ test_that("status functions accept explicit filename", {
 })
 
 test_that("status handles file = dir/", {
-	d <- make_testdir()
+	d <- withr::local_tempdir()
 	status.start("NONE", d)
 	status.end("DONE", d)
 	expect_equal(status.check("NONE", file.path(d, "STATUS")), 1L)
 })
 
 test_that("status functions read from local settings", {
-	settings <- list(outdir = make_testdir())
+	settings <- list(outdir = withr::local_tempdir())
 	expect_silent(status.skip("auto"))
 	expect_match(
 		readLines(file.path(settings$outdir, "STATUS"))[[1]],
@@ -44,7 +37,7 @@ test_that("status functions read from local settings", {
 })
 
 test_that("status finds settings defined outside immediate calling scope", {
-	settings <- list(outdir = make_testdir())
+	settings <- list(outdir = withr::local_tempdir())
 	f <- function(name) {
 		status.start(name)
 		status.end()
@@ -60,11 +53,11 @@ test_that("status finds settings defined outside immediate calling scope", {
 
 test_that("status writes to stdout on bad filename", {
 	expect_output(status.start("NOFILE"), "NOFILE")
-	settings <- list(outdir = file.path(make_testdir(), "fake", "path"))
+	settings <- list(outdir = file.path(withr::local_tempdir(), "fake", "path"))
 	expect_output(status.end(), "\\d{4}-\\d{2}-\\d{2}.*DONE")
 })
 
 test_that("status.check returns 0 on bad filename", {
 	expect_equal(status.check("NOFILE"), 0L)
-	expect_equal(status.check("NOFILE", file.path(make_testdir(), "fake")), 0L)
+	expect_equal(status.check("NOFILE", file.path(withr::local_tempdir(), "fake")), 0L)
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->
## Description
This PR refactors the test suite in `base/utils/tests/testthat/test-status.R` to adopt better test isolation. 
- Removed the custom helper function `make_testdir()`, which relied on manual `dir.create()` and `teardown(unlink())`.
- Replaced all calls to the helper with `withr::local_tempdir()`.
- This change ensures that each `test_that` block operates in a clean, independent temporary directory that is automatically deleted by the operating system hook provided by `withr`, even if the test execution is interrupted or fails.

## Motivation and Context
This change follows the maintainer's suggestion in #3802 and continues the refactoring pattern established in #3803. 

The previous manual directory management was prone to "leaking" files if a test crashed before the `unlink()` command was reached. By using `withr::local_tempdir()`, we align this file with modern R testing best practices and improve the overall robustness of the PEcAn core utility tests.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [x] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- This addresses the "test isolation" technical debt discussed in #3802 -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [x] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
