### PR TITLE
test: improve test isolation in base/utils and data.atmosphere

### DIFF
--- a/base/utils/tests/testthat/test-read.output.R
+++ b/base/utils/tests/testthat/test-read.output.R
@@ -1,8 +1,6 @@
 context("read.output")
 
-testdir = file.path(tempfile(), "readtest")
-dir.create(testdir, recursive = TRUE)
-teardown(unlink(testdir, recursive = TRUE))
+testdir <- withr::local_tempdir()
 
 
 test_that("returns a list or dataframe as requested", {
@@ -74,11 +72,8 @@ test_that("handles arbitrary time offsets", {
 	expect_equal(mixedres$posix, as.POSIXct((0:730)*86400, origin = "2004-01-01", tz = "UTC"))
 })
 
-empty_testdir <- tempfile()
-dir.create(empty_testdir)
-teardown(unlink(empty_testdir, recursive = TRUE))
-
 test_that("Correct behavior when no NetCDF files present", {
+  empty_testdir <- withr::local_tempdir()
   expected <- "no netCDF files of model output present"
   out_log <- capture.output(type = "message", {
     out <- read.output(runid = "", outdir = empty_testdir,
@@ -89,10 +84,8 @@ test_that("Correct behavior when no NetCDF files present", {
   expect_equal(out, list(NA))
 })
 
-custom_testdir <- tempfile()
-dir.create(custom_testdir)
-teardown(unlink(custom_testdir, recursive = TRUE))
 test_that("Correctly read all variables, from custom ncfiles", {
+  custom_testdir <- withr::local_tempdir()
   ncfiles <- file.path(custom_testdir, c("a.nc", "b.nc", "c.nc"))
   zzz <- lapply(ncfiles, example_netcdf, varnames = c("x", "y", "z"))
   out_log <- capture.output(type = "message", {

--- a/modules/data.atmosphere/tests/testthat/test.upscale_met.R
+++ b/modules/data.atmosphere/tests/testthat/test.upscale_met.R
@@ -4,9 +4,7 @@ orig <- ncdf4::nc_open("data/urbana_subdaily_test.nc")
 otime <- orig$dim$time
 ncdf4::nc_close(orig)
 
-tmpdir <- tempfile()
-setup(dir.create(tmpdir, showWarnings = FALSE))
-teardown(unlink(tmpdir, recursive = TRUE))
+tmpdir <- withr::local_tempdir()
 
 sc_result <- upscale_met(outfolder = tmpdir,
                          input_met = "data/urbana_subdaily_test.nc",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
This PR continues the refactoring effort to improve test isolation across the PEcAn codebase, following the pattern in #3814. 


The changes ensure that temporary directories are automatically cleaned up by the R session/hook even if tests fail mid-execution, preventing "orphaned" files in the environment.

## Motivation and Context
The motivation for this change is to eliminate technical debt in the testing infrastructure. As discussed in #3802 and #3803, manual directory management in tests can lead to "flaky" test runs and environmental pollution.

By standardizing on `withr`, we align these modules with modern R testing practices and the standards recently adopted in the `base/utils` package.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [x] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- Technical debt/Test stability -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [x] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

---