### PR TITLE
 prevent db connection when `bety` details missing

### DIFF
--- a/base/workflow/R/run.write.configs.R
+++ b/base/workflow/R/run.write.configs.R
@@ -39,10 +39,10 @@ run.write.configs <- function(settings, ensemble.size, input_design, write = TRU
   }
                               
   ## Skip database connection if settings$database is NULL or write is False
-  if (!isTRUE(write) && is.null(settings$database)) {
+  if (!isTRUE(write) && (is.null(settings$database) || is.null(settings$database$bety))) {
     PEcAn.logger::logger.info("Not writing this run to database, so database connection skipped")
     con <- NULL # Set con to NULL to avoid errors in subsequent code
-  } else if (is.null(settings$database)) {
+  } else if (is.null(settings$database) || is.null(settings$database$bety)) {
     PEcAn.logger::logger.error(
       "Database is NULL but writing is enabled. Provide valid database settings in pecan.xml."
     )

--- a/base/workflow/R/run.write.configs.R
+++ b/base/workflow/R/run.write.configs.R
@@ -45,10 +45,10 @@ run.write.configs <- function(settings, ensemble.size, input_design, write = TRU
   # settings$database$dbfiles into.
   # Checking only for Bety parameters prevents the dbfiles entry from causing
   # undesired connection attempts. 
-  if (!isTRUE(write) && (is.null(settings$database) || is.null(settings$database$bety))) {
+  if (!isTRUE(write) && is.null(settings$database$bety)) {
     PEcAn.logger::logger.info("Not writing this run to database, so database connection skipped")
     con <- NULL # Set con to NULL to avoid errors in subsequent code
-  } else if (is.null(settings$database) || is.null(settings$database$bety)) {
+  } else if (is.null(settings$database$bety)) {
     PEcAn.logger::logger.error(
       "Database is NULL but writing is enabled. Provide valid database settings in pecan.xml."
     )

--- a/base/workflow/R/run.write.configs.R
+++ b/base/workflow/R/run.write.configs.R
@@ -38,7 +38,13 @@ run.write.configs <- function(settings, ensemble.size, input_design, write = TRU
     )
   }
                               
-  ## Skip database connection if settings$database is NULL or write is False
+  ## Skip database connection if no Bety params given or write is False
+  # Historical note: Conceptually it'd be cleaner to skip when all of
+  # settings$database is NULL. But many scripts in the wild call
+  # prepare.settings(), which insists on creating a database section to put
+  # settings$database$dbfiles into.
+  # Checking only for Bety parameters prevents the dbfiles entry from causing
+  # undesired connection attempts. 
   if (!isTRUE(write) && (is.null(settings$database) || is.null(settings$database$bety))) {
     PEcAn.logger::logger.info("Not writing this run to database, so database connection skipped")
     con <- NULL # Set con to NULL to avoid errors in subsequent code

--- a/base/workflow/tests/testthat/test.run.write.configs.R
+++ b/base/workflow/tests/testthat/test.run.write.configs.R
@@ -39,16 +39,17 @@ test_that("run.write.configs correctly skips database connection when bety is mi
   # When write is FALSE and bety is missing, the code should skip opening a DB connection
   # and not throw an error from attempting to pass NULL to db.open()
   
-  # By using expect_output or capturing logs, we could check the "Not writing this run to database"
-  # but simply ensuring it does not throw an error is enough to verify the regression
-  expect_error(
-    PEcAn.workflow::run.write.configs(
-      settings,
-      write = FALSE,
-      input_design = data.frame(param = 1),
-      ensemble.size = 1,
-      overwrite = FALSE
-    ),
-    NA # NA means we expect no error
-  )
+  expect_no_error({
+    runwrite_log <- capture.output(
+      PEcAn.workflow::run.write.configs(
+        settings,
+        write = FALSE,
+        input_design = data.frame(param = 1),
+        ensemble.size = 1,
+        overwrite = FALSE
+      ),
+      type = "message"
+    )
+  })
+  expect_match(runwrite_log, "Not writing this run to database", all = FALSE)
 })

--- a/base/workflow/tests/testthat/test.run.write.configs.R
+++ b/base/workflow/tests/testthat/test.run.write.configs.R
@@ -1,0 +1,54 @@
+context("run.write.configs")
+
+test_that("run.write.configs correctly skips database connection when bety is missing", {
+  # Mock settings with a database section but missing 'bety' details
+  # This mimics the issue where dbfiles triggers the database presence check, but no connection details exist.
+  settings <- list(
+    database = list(
+      dbfiles = tempdir()
+    ),
+    outdir = tempdir(),
+    run = list(
+      host = list(
+        name = "localhost"
+      )
+    ),
+    model = list(
+      type = "ALMA"
+    )
+  )
+  
+  # create a dummy samples.Rdata so it does not crash saying it requires it
+  samples.file <- file.path(settings$outdir, "samples.Rdata")
+  # Mock the internal elements expected by run.write.configs
+  trait.samples <- list()
+  sa.samples <- list()
+  runs.samples <- list()
+  env.samples <- list()
+  ensemble.samples <- list()
+  
+  save(
+    trait.samples, 
+    ensemble.samples,
+    sa.samples, 
+    runs.samples, 
+    env.samples, 
+    file = samples.file
+  )
+  
+  # When write is FALSE and bety is missing, the code should skip opening a DB connection
+  # and not throw an error from attempting to pass NULL to db.open()
+  
+  # By using expect_output or capturing logs, we could check the "Not writing this run to database"
+  # but simply ensuring it does not throw an error is enough to verify the regression
+  expect_error(
+    PEcAn.workflow::run.write.configs(
+      settings,
+      write = FALSE,
+      input_design = data.frame(param = 1),
+      ensemble.size = 1,
+      overwrite = FALSE
+    ),
+    NA # NA means we expect no error
+  )
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
Issue reported in slack(https://pecanproject.slack.com/archives/C8RD9BRLK/p1771538693295529) 
In the given pecan_2.xml used 
```
This XML file does not appear to have any style information associated with it. The document tree is shown below.
<pecan>
<info>
<notes/>
<userid>-1</userid>
<username/>
<date>2025-06-19-15-34-01</date>
</info>
<outdir>/Users/jamesholmquist/GitHub/pecan/documentation/tutorials/Demo_1_Basic_Run/demo_outdir</outdir>
<pfts>
<pft>
<name>temperate.coniferous</name>
<posterior.files>pft/temperate.coniferous/prior.distns.Rdata</posterior.files>
<outdir>pft/temperate.coniferous</outdir>
</pft>
</pfts>
<ensemble>
<variable>NPP</variable>
<size>1</size>
<start.year>2004</start.year>
<end.year>2004</end.year>
<samplingspace>
<parameters>
<method>uniform</method>
</parameters>
<met>
<method>sampling</method>
</met>
</samplingspace>
</ensemble>
<model>
<type>SIPNET</type>
<revision>git</revision>
<delete.raw>FALSE</delete.raw>
<binary>demo_outdir/sipnet</binary>
<id>-1</id>
</model>
<run>
<site>
<met.start>2004/01/01</met.start>
<met.end>2004/12/31</met.end>
<name>Niwot Ridge Forest/LTER NWT1 (US-NR1)</name>
<lat>40.0329</lat>
<lon>-105.546</lon>
<id>-1</id>
</site>
<inputs>
<met>
<source>AmerifluxLBL</source>
<output>SIPNET</output>
<username>Aritra_2004</username>
<path>
<path1>dbfiles/AMF_US-NR1_BASE_HH_23-5.2004-01-01.2004-12-31.clim</path1>
</path>
</met>
</inputs>
<start.date>2004/01/01</start.date>
<end.date>2004/12/31</end.date>
</run>
<host>
<name>localhost</name>
<rundir>/Users/jamesholmquist/GitHub/pecan/documentation/tutorials/Demo_1_Basic_Run/demo_outdir/run</rundir>
<outdir>/Users/jamesholmquist/GitHub/pecan/documentation/tutorials/Demo_1_Basic_Run/demo_outdir/out</outdir>
</host>
<settings.info>
<deprecated.settings.fixed>TRUE</deprecated.settings.fixed>
<settings.updated>TRUE</settings.updated>
<checked>TRUE</checked>
</settings.info>
<database>
<dbfiles>/Users/jamesholmquist/.pecan/dbfiles</dbfiles>
</database>
<workflow>
<id>2026-02-19-15-06-41</id>
</workflow>
<rundir>/Users/jamesholmquist/GitHub/pecan/documentation/tutorials/Demo_1_Basic_Run/demo_outdir/run</rundir>
<modeloutdir>/Users/jamesholmquist/GitHub/pecan/documentation/tutorials/Demo_1_Basic_Run/demo_outdir/out</modeloutdir>
</pecan>
```

In this case the pecan.xml used,in this there is already a `database` section so according to this condition 

```
if (!isTRUE(write) && is.null(settings$database)) {
```
Since settings$database is a populated list, `is.null(settings$database)` evaluates to FALSE! it can incorrectly thinks "the user provided a database configuration, I must connect to it".

It bypasses the safety skip and drops directly into the else block, trying to connect to a database using `settings$database$bety`. Since <bety> wasn't provided, it passes NULL flags to the PostgreSQL driver, which tries to fall back on his local username ("jamesholmquist"), fails, and triggers the logger.severe() fatal crash.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
