### PR TITLE
get.parameter.samples: skip DB connection attempt if no params given

### DIFF
--- a/modules/uncertainty/R/get.parameter.samples.R
+++ b/modules/uncertainty/R/get.parameter.samples.R
@@ -25,8 +25,15 @@ get.parameter.samples <- function(settings,
   }
 
   ## Open database connection
-  con <- try(PEcAn.DB::db.open(settings$database$bety))
-  on.exit(try(PEcAn.DB::db.close(con), silent = TRUE), add = TRUE)
+  if (!is.null(settings$database$bety)) {
+    con <- try(PEcAn.DB::db.open(settings$database$bety))
+    on.exit(try(PEcAn.DB::db.close(con), silent = TRUE), add = TRUE)
+  } else {
+    PEcAn.logger::logger.info(
+      "No database connection parameters provided. Will not use Bety for parameter lookup."
+    )
+    con <- NULL
+  }
 
   # If we fail to connect to DB then we set to NULL
   if (inherits(con, "try-error")) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
The existing `try` kept connection failures from killing the run, but let a scary-looking Postgres connection failure bubble up. This patch replaces that with a more reassuring "will not use Bety" when `settings$database$bety` doesn't exist.

I retained the `try` for runs that do have Bety params, partly to handle other kinds of error and partly out of laziness.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Continues from #3824 in trying to eliminate unwanted DB connection attempts in workflows that didn't request them.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
