### PR TITLE
refactor: standardize GitHub labels to category:name scheme

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,7 +2,7 @@
 # Add project labels to PRs
 # Invocation is done by .github/workflows/prlabeler.yml
 
-'type:docs':
+'documentation':
 - changed-files:
   - any-glob-to-any-file: 'book_source/**'
   - any-glob-to-any-file: 'documentation/**'
@@ -11,34 +11,37 @@
   - any-glob-to-any-file: 'DEV-INTRO.md'
   - any-glob-to-any-file: 'README.md'
 
-'area:infrastructure':
+'GitHub Actions':
 - changed-files:
-  - any-glob-to-any-file: 'docker/**'
   - any-glob-to-any-file: '.github/workflows/**'
 
-'area:ui':
+'infrastructure':
+- changed-files:
+  - any-glob-to-any-file: 'docker/**'
+
+'ui':
 - changed-files:
   - any-glob-to-any-file: 'web/**'
 
-'area:core':
+'core':
 - changed-files:
   - any-glob-to-any-file: 'base/**'
 
-'area:models':
+'models':
 - changed-files:
   - any-glob-to-any-file: 'models/**'
 
-'area:modules':
+'modules':
 - changed-files:
   - any-glob-to-any-file: 'modules/**'
 
 # TODO: scripts folder is due for a reorganization by theme;
 # update these tags when that is done
-'area:scripts':
+'scripts':
 - changed-files:
   - any-glob-to-any-file: 'scripts/**'
 
-'type:test':
+'testing':
 - all:
   - changed-files:
     - any-glob-to-any-file: ['tests/**', '**/tests/**']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,19 +11,19 @@
   - any-glob-to-any-file: 'DEV-INTRO.md'
   - any-glob-to-any-file: 'README.md'
 
-'GitHub Actions':
+'github-actions':
 - changed-files:
   - any-glob-to-any-file: '.github/workflows/**'
 
-'infrastructure':
+'dockerfile':
 - changed-files:
   - any-glob-to-any-file: 'docker/**'
 
-'ui':
+'web-frontend':
 - changed-files:
   - any-glob-to-any-file: 'web/**'
 
-'core':
+'base':
 - changed-files:
   - any-glob-to-any-file: 'base/**'
 
@@ -41,7 +41,7 @@
 - changed-files:
   - any-glob-to-any-file: 'scripts/**'
 
-'testing':
+'tests':
 - all:
   - changed-files:
     - any-glob-to-any-file: ['tests/**', '**/tests/**']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,7 +2,7 @@
 # Add project labels to PRs
 # Invocation is done by .github/workflows/prlabeler.yml
 
-'Documentation':
+'type:docs':
 - changed-files:
   - any-glob-to-any-file: 'book_source/**'
   - any-glob-to-any-file: 'documentation/**'
@@ -11,37 +11,34 @@
   - any-glob-to-any-file: 'DEV-INTRO.md'
   - any-glob-to-any-file: 'README.md'
 
-'Dockerfile':
+'area:infrastructure':
 - changed-files:
   - any-glob-to-any-file: 'docker/**'
+  - any-glob-to-any-file: '.github/workflows/**'
 
-'Web Frontend':
+'area:ui':
 - changed-files:
   - any-glob-to-any-file: 'web/**'
 
-'Base':
+'area:core':
 - changed-files:
   - any-glob-to-any-file: 'base/**'
 
-'Models':
+'area:models':
 - changed-files:
   - any-glob-to-any-file: 'models/**'
 
-'Modules':
+'area:modules':
 - changed-files:
   - any-glob-to-any-file: 'modules/**'
 
-'GitHub Actions':
-- changed-files:
-  - any-glob-to-any-file: '.github/workflows/**'
-
 # TODO: scripts folder is due for a reorganization by theme;
 # update these tags when that is done
-'Scripts':
+'area:scripts':
 - changed-files:
   - any-glob-to-any-file: 'scripts/**'
 
-'Tests':
+'type:test':
 - all:
   - changed-files:
     - any-glob-to-any-file: ['tests/**', '**/tests/**']

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,27 +117,12 @@ git push -u origin GH-issuenumber-title-of-issue
   - The license listed at PR opening time for the code you are contributing to,
   - and/or the BSD 3-clause license.
 
-## Repository Labeling Scheme
+## Repository Labels
 
-PEcAn uses a standardized `category:name` label scheme to keep issues and pull requests organized. This improves discoverability, contributor onboarding, workflow clarity, and automation reliability.
+PEcAn uses plain, self-explanatory labels to keep issues and pull requests organized.
+The [labels page](https://github.com/PecanProject/pecan/labels) is the authoritative reference — label names are intentionally kept simple enough to be understood at a glance without consulting external documentation.
 
-### Categories
-* **`type:`** Indicates the nature of the issue/PR (e.g., `type:bug`, `type:feature`, `type:docs`, `type:refactor`, `type:chore`). Color: red/blue shades.
-* **`status:`** Indicates where in the lifecycle the issue/PR is (e.g., `status:blocked`, `status:in-progress`, `status:ready-for-review`). Color: yellow/orange shades.
-* **`priority:`** Indicates urgency (e.g., `priority:low`, `priority:medium`, `priority:high`, `priority:critical`). Color: red intensity.
-* **`area:`** Indicates the component or domain of the project affected (e.g., `area:core`, `area:models`, `area:modules`, `area:infrastructure`, `area:ui`). Color: green/purple shades.
-* **`meta`**: Labels related to the issue tracker itself, meetings, or general project management. Color: gray.
-
-### Naming Rules
-* All labels are in lowercase.
-* No spaces; use hyphens (e.g., `good-first-issue`).
-* Use the clear prefix categories defined above.
-
-### Applying Labels
-* Apply a `type:` label to all issues and PRs.
-* Apply an `area:` label if the scope is limited to specific components.
-* Apply `status:` and `priority:` labels as needed to help project maintainers triage and track progress.
-* The `.github/labeler.yml` action automatically applies `area:` and `type:` labels to PRs based on the files modified.
+The `.github/labeler.yml` action automatically applies labels to PRs based on the files modified.
 
 ## Additional Resources
 - [Adding models to PEcAn](https://pecanproject.github.io/pecan-documentation/develop/adding-model.html)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,10 +119,9 @@ git push -u origin GH-issuenumber-title-of-issue
 
 ## Repository Labels
 
-PEcAn uses plain, self-explanatory labels to keep issues and pull requests organized.
-The [labels page](https://github.com/PecanProject/pecan/labels) is the authoritative reference — label names are intentionally kept simple enough to be understood at a glance without consulting external documentation.
+PEcAn uses [labels](https://github.com/PecanProject/pecan/labels) to keep issues and pull requests organized. We aim to keep label names simple and have few enough of them for the tag system to be understood by reading the list without consulting external documentation.
 
-The `.github/labeler.yml` action automatically applies labels to PRs based on the files modified.
+The `.github/labeler.yml` action automatically applies labels to PRs based on the files modified. If additional labels beyond these are applicable they can be added manually as needed, but this is not mandatory; we do _not_ expect every issue to need a label.
 
 ## Additional Resources
 - [Adding models to PEcAn](https://pecanproject.github.io/pecan-documentation/develop/adding-model.html)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,8 +117,29 @@ git push -u origin GH-issuenumber-title-of-issue
   - The license listed at PR opening time for the code you are contributing to,
   - and/or the BSD 3-clause license.
 
-## Additional Resources
+## Repository Labeling Scheme
 
+PEcAn uses a standardized `category:name` label scheme to keep issues and pull requests organized. This improves discoverability, contributor onboarding, workflow clarity, and automation reliability.
+
+### Categories
+* **`type:`** Indicates the nature of the issue/PR (e.g., `type:bug`, `type:feature`, `type:docs`, `type:refactor`, `type:chore`). Color: red/blue shades.
+* **`status:`** Indicates where in the lifecycle the issue/PR is (e.g., `status:blocked`, `status:in-progress`, `status:ready-for-review`). Color: yellow/orange shades.
+* **`priority:`** Indicates urgency (e.g., `priority:low`, `priority:medium`, `priority:high`, `priority:critical`). Color: red intensity.
+* **`area:`** Indicates the component or domain of the project affected (e.g., `area:core`, `area:models`, `area:modules`, `area:infrastructure`, `area:ui`). Color: green/purple shades.
+* **`meta`**: Labels related to the issue tracker itself, meetings, or general project management. Color: gray.
+
+### Naming Rules
+* All labels are in lowercase.
+* No spaces; use hyphens (e.g., `good-first-issue`).
+* Use the clear prefix categories defined above.
+
+### Applying Labels
+* Apply a `type:` label to all issues and PRs.
+* Apply an `area:` label if the scope is limited to specific components.
+* Apply `status:` and `priority:` labels as needed to help project maintainers triage and track progress.
+* The `.github/labeler.yml` action automatically applies `area:` and `type:` labels to PRs based on the files modified.
+
+## Additional Resources
 - [Adding models to PEcAn](https://pecanproject.github.io/pecan-documentation/develop/adding-model.html)
 - [PEcAn configuration files](https://pecanproject.github.io/pecan-documentation/develop/pecanXML.html)
 - [Development help](https://pecanproject.github.io/pecan-documentation/latest/developer-guide.html)


### PR DESCRIPTION
# Standardize Repository Labels & Document Labeling Scheme
Part of the repository label cleanup effort (#3696). 

## Description

This PR updates the automated label configuration and documents the new standardized labeling scheme.

### Updates to `.github/labeler.yml`

The following label mappings have been standardized:

- `Documentation` → `type:docs`
- `Dockerfile + GitHub Actions` → `area:infrastructure`
- `Web Frontend` → `area:ui`
- `Base` → `area:core`
- `Models` → `area:models`
- `Modules` → `area:modules`
- `Scripts` → `area:scripts`
- `Tests` → `type:test`

### Documentation Added

A new **"Repository Labeling Scheme"** section has been added to `CONTRIBUTING.md` that documents:

- The `category:name` naming convention  
- Definitions for each label category (`area`, `type`, etc.)  
- Color rationale for visual grouping  
- Guidelines on when and how to apply labels  

The full label rename/delete/create script for maintainers is included in the PR description for transparency and reproducibility.

## Motivation and Context

The repository previously contained duplicate, inconsistent, and obsolete labels, making issue triage and automation harder to manage.

This change:

- Reduces ambiguity in label naming  
- Aligns labeler automation with standardized labels  
- Improves long-term maintainability  
- Documents the labeling policy for contributors  

Part of the broader repository label cleanup effort.

## Review Time Estimate

- [x] Within one week  

## Types of Changes

- [x] Documentation update  
- [x] Repository maintenance / refactor  
- [ ] Bug fix  
- [ ] New feature  
- [ ] Breaking change  

## Checklist

- [x] My change requires a change to the documentation.  
- [x] I have updated the documentation accordingly.  
- [x] I have read the **CONTRIBUTING** document.  
- [x] My name is in the list of `CITATION.cff`.  
- [x] I agree that PEcAn Project may distribute my contribution under:
  - the same license as the existing code, and/or  
  - the BSD 3-clause license.  
- [ ] I have updated the `CHANGELOG.md`.  
- [ ] I have added tests to cover my changes.  
- [ ] All new and existing tests passed.  