### PR TITLE
fix: remove duplicate code blocks in InventoryGrowthFusionDiagnostics

### DIFF
--- a/modules/data.land/R/InventoryGrowthFusionDiagnostics.R
+++ b/modules/data.land/R/InventoryGrowthFusionDiagnostics.R
@@ -77,21 +77,6 @@ InventoryGrowthFusionDiagnostics <- function(jags.out, combined=NULL) {
     vars <- c(vars,which(colnames(out)=="deviance"))
   }
   
-  
-  ## rebuild coda for just vars
-  var.out <- coda::as.mcmc.list(lapply(jags.out,function(x){ x[,vars]}))
-  
-  ## convergence
-  coda::gelman.diag(var.out)
-  
-  #### Diagnostic plots
-  plot(var.out)
-  
-  if("deviance" %in% colnames(out)){
-    graphics::hist(out[,"deviance"])
-    vars <- c(vars,which(colnames(out)=="deviance"))
-  }
-  
   ## rebuild coda for just vars
   var.out <- coda::as.mcmc.list(lapply(jags.out,function(x){ x[,vars]}))
   
@@ -113,19 +98,6 @@ InventoryGrowthFusionDiagnostics <- function(jags.out, combined=NULL) {
   
   ### alpha
   graphics::par(mfrow = c(1, 1))
-  alpha.cols <- grep("alpha", colnames(out))
-  if (length(alpha.cols) > 0) {
-    alpha.ord <- 1:length(alpha.cols)
-    ci.alpha <- apply(out[, alpha.cols], 2, stats::quantile, c(0.025, 0.5, 0.975))
-    plot(alpha.ord, ci.alpha[2, ], type = "n", 
-         ylim = range(ci.alpha, na.rm = TRUE), ylab = "Random Effects")
-    PEcAn.visualization::ciEnvelope(alpha.ord, ci.alpha[1, ], ci.alpha[3, ], col = "lightBlue")
-    graphics::lines(alpha.ord, ci.alpha[2, ], lty = 1, lwd = 2)
-    graphics::abline(h = 0, lty = 2)
-  }
-  
-  graphics::par(mfrow = c(1, 1))
-  ### alpha
   alpha.cols <- grep("alpha", colnames(out))
   if (length(alpha.cols) > 0) {
     alpha.ord <- 1:length(alpha.cols)


### PR DESCRIPTION
## Summary
Removed duplicate code blocks in `InventoryGrowthFusionDiagnostics.R` 
that were introduced in a recent PR.

## Changes
- Removed duplicate `deviance` histogram + `coda.samples` diagnostic block
- Removed duplicate `alpha.cols` random effects plot block

## Impact
No functionality affected — these were exact duplicate blocks 
that ran the same code twice unnecessarily.