### PR TITLE
Add regression tests for get.trait.data.pft() before modularity refactor

### DIFF
--- a/base/db/tests/testthat/test-get.trait.data.pft.R
+++ b/base/db/tests/testthat/test-get.trait.data.pft.R
@@ -7,6 +7,17 @@
 #
 # Tests requiring a live BETYdb connection skip cleanly when unavailable.
 # ── Fixtures ──────────────────────────────────────────────────────────────────
+# Helper needed for the restored cultivar test
+dbdir <- file.path(tempdir(), "dbfiles")
+
+get_pft <- function(pftname) {
+  get.trait.data.pft(
+    pft         = list(name = pftname, outdir = withr::local_tempdir()),
+    trait.names = "SLA",
+    dbfiles     = dbdir,
+    modeltype   = NULL,
+    dbcon       = test_dbcon)
+}
 
 make_test_pft <- function(outdir) {
   list(
@@ -58,19 +69,6 @@ test_dbcon <- tryCatch(
   error = function(e) NULL
 )
 
-# ── Block 0: Tests that work WITHOUT a database ──────────────────────────────
-
-test_that("make_test_pft returns correctly structured list", {
-  outdir <- withr::local_tempdir()
-  pft <- make_test_pft(outdir)
-  
-  expect_true(is.list(pft))
-  expect_equal(pft$name, "temperate.Early_Hardwood")
-  expect_equal(pft$outdir, outdir)
-  expect_null(pft$posteriorid)
-  expect_true(is.list(pft$constants))
-})
-
 test_that("get.trait.data.pft fails gracefully with NULL dbcon", {
   outdir <- withr::local_tempdir()
   
@@ -99,46 +97,10 @@ test_that("get.trait.data.pft fails with invalid modeltype and NULL dbcon", {
   )
 })
 
-test_that("get.trait.data.pft accepts trait.names parameter", {
-  expect_true(
-    "trait.names" %in% names(formals(get.trait.data.pft))
-  )
-})
-
-test_that("make_empty_pft returns correctly structured list", {
-  outdir <- withr::local_tempdir()
-  pft <- make_empty_pft(outdir)
-  
-  expect_true(is.list(pft))
-  expect_equal(pft$name, "soil.ALL")
-  expect_equal(pft$outdir, outdir)
-  expect_null(pft$posteriorid)
-  expect_true(is.list(pft$constants))
-})
-
-test_that("get.trait.data.pft function exists and is callable", {
-  expect_true(is.function(get.trait.data.pft))
-})
-
-test_that("get.trait.data.pft has expected parameters", {
-  params <- names(formals(get.trait.data.pft))
-  
-  expect_true("pft"         %in% params)
-  expect_true("modeltype"   %in% params)
-  expect_true("dbfiles"     %in% params)
-  expect_true("dbcon"       %in% params)
-  expect_true("trait.names" %in% params)
-})
-
 test_that("get.trait.data.pft errors with no arguments", {
   expect_error(get.trait.data.pft())
 })
 
-test_that("std_traits contains expected trait names", {
-  expect_true("SLA"    %in% std_traits)
-  expect_true("Vcmax"  %in% std_traits)
-  expect_equal(length(std_traits), 3)
-})
 
 # ── Block 1: Files are written to disk ────────────────────────────────────────
 
@@ -312,35 +274,67 @@ test_that("prior.distns.Rdata contains a data frame with expected columns", {
 test_that("get.trait.data.pft() does not error for a PFT with no observations", {
   skip_if_no_db(test_dbcon)
   outdir <- withr::local_tempdir()
-
+  
   soil_exists <- tryCatch({
-    nrow(DBI::dbGetQuery(test_dbcon, "SELECT 1 FROM pfts WHERE name = 'soil.ALL' LIMIT 1")) > 0
+    nrow(DBI::dbGetQuery(test_dbcon, 
+      "SELECT 1 FROM pfts WHERE name = 'soil.ALL' LIMIT 1")) > 0
   }, error = function(e) FALSE)
   skip_if_not(soil_exists, "soil.ALL PFT not present in test BETY")
-
-  expect_error(
-    get.trait.data.pft(
-      pft         = make_empty_pft(outdir),
-      modeltype   = std_modeltype,
-      dbfiles     = outdir,
-      dbcon       = test_dbcon,
-      trait.names = std_traits
-    ),
-    regexp = NA  # NA means "no error expected"
-  )
-})
-
-test_that("get.trait.data.pft() writes prior.distns.Rdata even when trait data is empty", {
-  skip_if_no_db(test_dbcon)
-  outdir <- withr::local_tempdir()
-
-  get.trait.data.pft(
+  
+  result <- get.trait.data.pft(
     pft         = make_empty_pft(outdir),
     modeltype   = std_modeltype,
     dbfiles     = outdir,
     dbcon       = test_dbcon,
     trait.names = std_traits
   )
+  
+  # Clean up any DB records created during test
+  if (!is.null(result$posteriorid)) {
+    posteriorid <- result$posteriorid
+    withr::defer({
+      try(DBI::dbExecute(test_dbcon,
+        paste0("DELETE FROM dbfiles WHERE container_type = 'Posterior' AND container_id = ",
+               posteriorid)), silent = TRUE)
+      try(DBI::dbExecute(test_dbcon,
+        paste0("DELETE FROM posteriors WHERE id = ",
+               posteriorid)), silent = TRUE)
+    })
+  }
+  
+  expect_true(is.list(result))
+})
+
+test_that("get.trait.data.pft() writes prior.distns.Rdata even when trait data is empty", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+
+  soil_exists <- tryCatch({
+    nrow(DBI::dbGetQuery(test_dbcon, 
+      "SELECT 1 FROM pfts WHERE name = 'soil.ALL' LIMIT 1")) > 0
+  }, error = function(e) FALSE)
+  skip_if_not(soil_exists, "soil.ALL PFT not present in test BETY")
+
+  result <- get.trait.data.pft(
+    pft         = make_empty_pft(outdir),
+    modeltype   = std_modeltype,
+    dbfiles     = outdir,
+    dbcon       = test_dbcon,
+    trait.names = std_traits
+  )
+
+    # Clean up any DB records created during test
+  if (!is.null(result$posteriorid)) {
+    posteriorid <- result$posteriorid
+    withr::defer({
+      try(DBI::dbExecute(test_dbcon,
+        paste0("DELETE FROM dbfiles WHERE container_type = 'Posterior' AND container_id = ",
+               posteriorid)), silent = TRUE)
+      try(DBI::dbExecute(test_dbcon,
+        paste0("DELETE FROM posteriors WHERE id = ",
+               posteriorid)), silent = TRUE)
+    })
+  }
 
   expect_true(file.exists(file.path(outdir, "prior.distns.Rdata")))
 })
@@ -436,13 +430,6 @@ test_that("end-to-end: written files are consistent with returned pft", {
   expect_equal(result$outdir, outdir)
 })
 
-if (!is.null(test_dbcon)) {
-  withr::defer(
-    try(PEcAn.DB::db.close(test_dbcon), silent = TRUE),
-    envir = testthat::teardown_env()
-  )
-}
-
 # ── Block 7: Error cases ─────────────────────────────────────────────────────
 
 test_that("get.trait.data.pft() errors for non-existent PFT name", {
@@ -485,3 +472,45 @@ test_that("get.trait.data.pft() errors when multiple PFTs share a name", {
     "Multiple PFTs"
   )
 })
+
+# ── Restored: Skipped cultivar test (see #1958) ──────────────────────────────
+test_that("reference species and cultivar PFTs write traits properly", {
+  skip("Disabled until Travis bety contains Pavi_alamo and Pavi_all (#1958)")
+
+  pavi_sp <- get_pft("pavi")
+  expect_equal(pavi_sp$name, "pavi")
+  sp_csv <- file.path(dbdir, "posterior", pavi_sp$posteriorid, "species.csv")
+  sp_trt <- file.path(dbdir, "posterior", pavi_sp$posteriorid, "trait.data.csv")
+  expect_true(file.exists(sp_csv))
+  expect_true(file.exists(sp_trt))
+  expect_gt(file.info(sp_csv)$size, 40)
+  expect_gt(file.info(sp_trt)$size, 215)
+
+  pavi_cv <- get_pft("Pavi_alamo")
+  expect_equal(pavi_cv$name, "Pavi_alamo")
+  cv_csv <- file.path(dbdir, "posterior", pavi_cv$posteriorid, "cultivars.csv")
+  cv_trt <- file.path(dbdir, "posterior", pavi_cv$posteriorid, "trait.data.csv")
+  expect_true(file.exists(cv_csv))
+  expect_true(file.exists(cv_trt))
+  expect_gt(file.info(cv_csv)$size, 63)
+  expect_gt(file.info(cv_trt)$size, 215)
+
+  pavi_allcv <- get_pft("Pavi_all")
+  expect_equal(pavi_allcv$name, "Pavi_all")
+  allcv_csv <- file.path(dbdir, "posterior", pavi_allcv$posteriorid, "cultivars.csv")
+  allcv_trt <- file.path(dbdir, "posterior", pavi_allcv$posteriorid, "trait.data.csv")
+  expect_true(file.exists(allcv_csv))
+  expect_true(file.exists(allcv_trt))
+  expect_gt(file.info(allcv_csv)$size, 63)
+  expect_gt(file.info(allcv_trt)$size, 215)
+
+  expect_gt(file.info(allcv_csv)$size, file.info(cv_csv)$size)
+  expect_gt(file.info(allcv_trt)$size, file.info(cv_trt)$size)
+})
+
+if (!is.null(test_dbcon)) {
+  withr::defer(
+    try(PEcAn.DB::db.close(test_dbcon), silent = TRUE),
+    envir = testthat::teardown_env()
+  )
+}

--- a/base/db/tests/testthat/test-get.trait.data.pft.R
+++ b/base/db/tests/testthat/test-get.trait.data.pft.R
@@ -1,81 +1,443 @@
-context("get.trait.data.pft")
+# Tests for get.trait.data.pft()
+# Package: PEcAn.DB
+#
+# Purpose: Lock down the current behavior of get.trait.data.pft() before
+# refactoring. These act as a regression safety net — if refactoring changes
+# any observable behavior, these tests will catch it.
+#
+# Tests requiring a live BETYdb connection skip cleanly when unavailable.
+# ── Fixtures ──────────────────────────────────────────────────────────────────
 
-con <- check_db_test()
-
-dbdir <- file.path(tempdir(), "dbfiles")
-outdir <- file.path(tempdir(), "outfiles")
-loglevel <- PEcAn.logger::logger.getLevel()
-PEcAn.logger::logger.setLevel("OFF")
-
-teardown({
-  db.close(con)
-  unlink(c(dbdir, outdir), recursive = TRUE)
-  PEcAn.logger::logger.setLevel(loglevel)
-})
-
-get_pft <- function(pftname) {
-  get.trait.data.pft(
-      pft = list(name = pftname, outdir = outdir),
-      trait.names = "SLA",
-      dbfiles = dbdir,
-      modeltype = NULL,
-      dbcon = con)
+make_test_pft <- function(outdir) {
+  list(
+    name        = "temperate.Early_Hardwood",
+    outdir      = outdir,
+    posteriorid = NULL,
+    constants   = list()
+  )
 }
 
-test_that("reference species and cultivar PFTs write traits properly",{
-  skip("Disabled until Travis bety contains Pavi_alamo and Pavi_all (#1958)")
-  pavi_sp <- get_pft("pavi")
-  expect_equal(pavi_sp$name, "pavi")
-  sp_csv = file.path(dbdir, "posterior", pavi_sp$posteriorid, "species.csv")
-  sp_trt = file.path(dbdir, "posterior", pavi_sp$posteriorid, "trait.data.csv")
-  expect_true(file.exists(sp_csv))
-  expect_true(file.exists(sp_trt))
-  expect_gt(file.info(sp_csv)$size, 40) # i.e. longer than the 40-char header
-  expect_gt(file.info(sp_trt)$size, 215) # ditto 215-char header
+make_empty_pft <- function(outdir) {
+  # Uses a deliberately nonexistent PFT name to test empty-data behavior
+  list(
+    name        = "test.EmptyPFT.NoSpecies",
+    outdir      = outdir,
+    posteriorid = NULL,
+    constants   = list()
+  )
+}
 
-  pavi_cv <- get_pft("Pavi_alamo")
-  expect_equal(pavi_cv$name, "Pavi_alamo")
-  cv_csv = file.path(dbdir, "posterior", pavi_cv$posteriorid, "cultivars.csv")
-  cv_trt = file.path(dbdir, "posterior", pavi_cv$posteriorid, "trait.data.csv")
-  expect_true(file.exists(cv_csv))
-  expect_true(file.exists(cv_trt))
-  expect_gt(file.info(cv_csv)$size, 63) # cultivar.csv headers are longer
-  expect_gt(file.info(cv_trt)$size, 215)
+std_modeltype <- "SIPNET"
+std_traits    <- c("SLA", "Vcmax", "leaf_respiration_rate_m2")
 
-  pavi_allcv <- get_pft("Pavi_all")
-  expect_equal(pavi_allcv$name, "Pavi_all")
-  allcv_csv = file.path(dbdir, "posterior", pavi_allcv$posteriorid, "cultivars.csv")
-  allcv_trt = file.path(dbdir, "posterior", pavi_allcv$posteriorid, "trait.data.csv")
-  expect_true(file.exists(allcv_csv))
-  expect_true(file.exists(allcv_trt))
-  expect_gt(file.info(allcv_csv)$size, 63)
-  expect_gt(file.info(allcv_trt)$size, 215)
+skip_if_no_db <- function(dbcon) {
+  if (is.null(dbcon) || inherits(dbcon, "try-error")) {
+    skip("No test database connection available — skipping live DB test")
+  }
+  # Also skip if BETYdb schema hasn't been loaded (empty database)
+  has_schema <- tryCatch({
+    DBI::dbExistsTable(dbcon, "pfts")
+  }, error = function(e) FALSE)
+  if (!has_schema) {
+    skip("No test database connection available — skipping live DB test")
+  }
+}
 
+# Try to open a DB connection — tests skip gracefully if unavailable
+test_dbcon <- tryCatch(
+  PEcAn.DB::db.open(
+    params = list(
+      driver   = "PostgreSQL",
+      user     = Sys.getenv("PECAN_TEST_DB_USER", "bety"),
+      password = Sys.getenv("PECAN_TEST_DB_PASS", "bety"),
+      host     = Sys.getenv("PECAN_TEST_DB_HOST", "localhost"),
+      dbname   = Sys.getenv("PECAN_TEST_DB_NAME", "bety"),
+      port     = as.integer(Sys.getenv("PECAN_TEST_DB_PORT", "5432"))
+    )
+  ),
+  error = function(e) NULL
+)
 
-  expect_gt(file.info(allcv_csv)$size, file.info(cv_csv)$size)
-  expect_gt(file.info(allcv_trt)$size, file.info(cv_trt)$size)
+# ── Block 0: Tests that work WITHOUT a database ──────────────────────────────
+
+test_that("make_test_pft returns correctly structured list", {
+  outdir <- withr::local_tempdir()
+  pft <- make_test_pft(outdir)
+  
+  expect_true(is.list(pft))
+  expect_equal(pft$name, "temperate.Early_Hardwood")
+  expect_equal(pft$outdir, outdir)
+  expect_null(pft$posteriorid)
+  expect_true(is.list(pft$constants))
 })
 
-test_that("error cases complain",{
-  expect_error(get_pft("NOTAPFT"), "Could not find pft")
-  expect_error(get_pft("soil"), "Multiple PFTs named soil")
+test_that("get.trait.data.pft fails gracefully with NULL dbcon", {
+  outdir <- withr::local_tempdir()
+  
+  expect_error(
+    get.trait.data.pft(
+      pft         = make_test_pft(outdir),
+      modeltype   = std_modeltype,
+      dbfiles     = outdir,
+      dbcon       = NULL,
+      trait.names = std_traits
+    )
+  )
 })
 
-test_that("PFT with no trait data (SIPNET soil) works.", {
-  soil_pft <- dplyr::tbl(con, "pfts") %>%
-    dplyr::filter(name == "soil.ALL") %>%
-    dplyr::count() %>%
-    dplyr::pull()
-  skip_if_not(soil_pft == 1, "`soil.ALL` PFT not present in BETY.")
-  sipnet_soil <- get.trait.data(list(pft = list(name = "soil.ALL",
-                                                outdir = outdir)),
-                                modeltype = "SIPNET",
-                                dbfiles = dbdir,
-                                database = get_db_params(),
-                                forceupdate = FALSE)
-  # Remove new record
-  DBI::dbExecute(con, "DELETE FROM dbfiles WHERE container_type = 'Posterior' AND container_id = $1",
-                 list(sipnet_soil[[1]][["posteriorid"]]))
-  DBI::dbExecute(con, "DELETE FROM posteriors WHERE id = $1",
-                 list(sipnet_soil[[1]][["posteriorid"]]))
+test_that("get.trait.data.pft fails with invalid modeltype and NULL dbcon", {
+  outdir <- withr::local_tempdir()
+  
+  expect_error(
+    get.trait.data.pft(
+      pft         = make_test_pft(outdir),
+      modeltype   = "NONEXISTENT_MODEL",
+      dbfiles     = outdir,
+      dbcon       = NULL,
+      trait.names = std_traits
+    )
+  )
 })
+
+test_that("get.trait.data.pft accepts trait.names parameter", {
+  expect_true(
+    "trait.names" %in% names(formals(get.trait.data.pft))
+  )
+})
+
+test_that("make_empty_pft returns correctly structured list", {
+  outdir <- withr::local_tempdir()
+  pft <- make_empty_pft(outdir)
+  
+  expect_true(is.list(pft))
+  expect_equal(pft$name, "test.EmptyPFT.NoSpecies")
+  expect_equal(pft$outdir, outdir)
+  expect_null(pft$posteriorid)
+  expect_true(is.list(pft$constants))
+})
+
+test_that("get.trait.data.pft function exists and is callable", {
+  expect_true(is.function(get.trait.data.pft))
+})
+
+test_that("get.trait.data.pft has expected parameters", {
+  params <- names(formals(get.trait.data.pft))
+  
+  expect_true("pft"         %in% params)
+  expect_true("modeltype"   %in% params)
+  expect_true("dbfiles"     %in% params)
+  expect_true("dbcon"       %in% params)
+  expect_true("trait.names" %in% params)
+})
+
+test_that("get.trait.data.pft errors with no arguments", {
+  expect_error(get.trait.data.pft())
+})
+
+test_that("std_traits contains expected trait names", {
+  expect_true("SLA"    %in% std_traits)
+  expect_true("Vcmax"  %in% std_traits)
+  expect_equal(length(std_traits), 3)
+})
+
+# ── Block 1: Files are written to disk ────────────────────────────────────────
+
+test_that("get.trait.data.pft() writes trait.data.Rdata to pft$outdir", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+
+  get.trait.data.pft(
+    pft         = make_test_pft(outdir),
+    modeltype   = std_modeltype,
+    dbfiles     = outdir,
+    dbcon       = test_dbcon,
+    trait.names = std_traits
+  )
+
+  expect_true(file.exists(file.path(outdir, "trait.data.Rdata")))
+})
+
+test_that("get.trait.data.pft() writes prior.distns.Rdata to pft$outdir", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+
+  get.trait.data.pft(
+    pft         = make_test_pft(outdir),
+    modeltype   = std_modeltype,
+    dbfiles     = outdir,
+    dbcon       = test_dbcon,
+    trait.names = std_traits
+  )
+
+  expect_true(file.exists(file.path(outdir, "prior.distns.Rdata")))
+})
+
+test_that("get.trait.data.pft() writes both expected files in one call", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+
+  get.trait.data.pft(
+    pft         = make_test_pft(outdir),
+    modeltype   = std_modeltype,
+    dbfiles     = outdir,
+    dbcon       = test_dbcon,
+    trait.names = std_traits
+  )
+
+  rdata_files <- list.files(outdir, pattern = "\\.Rdata$")
+  expect_true("trait.data.Rdata"   %in% rdata_files)
+  expect_true("prior.distns.Rdata" %in% rdata_files)
+})
+
+
+# ── Block 2: Return value shape ───────────────────────────────────────────────
+
+test_that("get.trait.data.pft() returns a list with field 'name'", {
+  skip_if_no_db(test_dbcon)
+  outdir   <- withr::local_tempdir()
+  test_pft <- make_test_pft(outdir)
+
+  result <- get.trait.data.pft(
+    pft         = test_pft,
+    modeltype   = std_modeltype,
+    dbfiles     = outdir,
+    dbcon       = test_dbcon,
+    trait.names = std_traits
+  )
+
+  expect_true("name" %in% names(result))
+  expect_equal(result$name, test_pft$name)
+})
+
+test_that("get.trait.data.pft() returns a list with field 'posteriorid'", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+
+  result <- get.trait.data.pft(
+    pft         = make_test_pft(outdir),
+    modeltype   = std_modeltype,
+    dbfiles     = outdir,
+    dbcon       = test_dbcon,
+    trait.names = std_traits
+  )
+
+  expect_true("posteriorid" %in% names(result))
+})
+
+test_that("get.trait.data.pft() returns a list with field 'outdir'", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+
+  result <- get.trait.data.pft(
+    pft         = make_test_pft(outdir),
+    modeltype   = std_modeltype,
+    dbfiles     = outdir,
+    dbcon       = test_dbcon,
+    trait.names = std_traits
+  )
+
+  expect_true("outdir" %in% names(result))
+  expect_equal(result$outdir, outdir)
+})
+
+test_that("CURRENT BEHAVIOR: get.trait.data.pft() discards computed data", {
+  # NOTE: This test documents the CURRENT behavior where trait_data and
+  # prior_distns are saved to disk but NOT returned to the caller.
+  # After the modularity refactor, this test should be UPDATED (not deleted)
+  # to verify that the new pure function DOES return these objects.
+
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+
+  result <- get.trait.data.pft(
+    pft         = make_test_pft(outdir),
+    modeltype   = std_modeltype,
+    dbfiles     = outdir,
+    dbcon       = test_dbcon,
+    trait.names = std_traits
+  )
+
+  expect_false("trait_data"   %in% names(result))
+  expect_false("prior_distns" %in% names(result))
+})
+
+
+# ── Block 3: Contents of written files ───────────────────────────────────────
+
+test_that("trait.data.Rdata contains a named list", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+
+  get.trait.data.pft(
+    pft         = make_test_pft(outdir),
+    modeltype   = std_modeltype,
+    dbfiles     = outdir,
+    dbcon       = test_dbcon,
+    trait.names = std_traits
+  )
+
+  env <- new.env(parent = emptyenv())
+  load(file.path(outdir, "trait.data.Rdata"), envir = env)
+
+  expect_true(exists("trait.data", envir = env))
+  expect_true(is.list(env$trait.data))
+})
+
+test_that("prior.distns.Rdata contains a data frame with expected columns", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+
+  get.trait.data.pft(
+    pft         = make_test_pft(outdir),
+    modeltype   = std_modeltype,
+    dbfiles     = outdir,
+    dbcon       = test_dbcon,
+    trait.names = std_traits
+  )
+
+  env <- new.env(parent = emptyenv())
+  load(file.path(outdir, "prior.distns.Rdata"), envir = env)
+
+  expect_true(exists("prior.distns", envir = env))
+  expect_true(is.data.frame(env$prior.distns))
+
+  missing_cols <- setdiff(c("distn", "parama", "paramb"), colnames(env$prior.distns))
+  expect_equal(length(missing_cols), 0L,
+    label = paste("prior.distns missing columns:", paste(missing_cols, collapse = ", ")))
+})
+
+
+# ── Block 4: PFT with no observations ────────────────────────────────────────
+
+test_that("get.trait.data.pft() does not error for a PFT with no observations", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+
+  expect_no_error(
+    get.trait.data.pft(
+      pft         = make_empty_pft(outdir),
+      modeltype   = std_modeltype,
+      dbfiles     = outdir,
+      dbcon       = test_dbcon,
+      trait.names = std_traits
+    )
+  )
+})
+
+test_that("get.trait.data.pft() writes prior.distns.Rdata even when trait data is empty", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+
+  get.trait.data.pft(
+    pft         = make_empty_pft(outdir),
+    modeltype   = std_modeltype,
+    dbfiles     = outdir,
+    dbcon       = test_dbcon,
+    trait.names = std_traits
+  )
+
+  expect_true(file.exists(file.path(outdir, "prior.distns.Rdata")))
+})
+
+
+# ── Block 5: Caching behavior ─────────────────────────────────────────────────
+
+test_that("second call uses cache — files are not rewritten", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+
+  args <- list(
+    pft         = make_test_pft(outdir),
+    modeltype   = std_modeltype,
+    dbfiles     = outdir,
+    dbcon       = test_dbcon,
+    trait.names = std_traits
+  )
+
+  # First call — creates files
+  do.call(get.trait.data.pft, args)
+  
+  trait_file <- file.path(outdir, "trait.data.Rdata")
+  prior_file <- file.path(outdir, "prior.distns.Rdata")
+  
+  expect_true(file.exists(trait_file))
+  expect_true(file.exists(prior_file))
+  
+  # Record file sizes (not timestamps — more reliable)
+  size_before_trait <- file.size(trait_file)
+  size_before_prior <- file.size(prior_file)
+  
+  # Second call — should use cache
+  result2 <- do.call(get.trait.data.pft, args)
+  
+  # Files should still exist and be the same size
+  expect_equal(file.size(trait_file), size_before_trait)
+  expect_equal(file.size(prior_file), size_before_prior)
+  
+  # Return value should still be valid
+  expect_true("name" %in% names(result2))
+})
+
+test_that("second call still returns a valid pft list when using cache", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+
+  args <- list(
+    pft         = make_test_pft(outdir),
+    modeltype   = std_modeltype,
+    dbfiles     = outdir,
+    dbcon       = test_dbcon,
+    trait.names = std_traits
+  )
+
+  do.call(get.trait.data.pft, args)
+  result <- do.call(get.trait.data.pft, args)
+
+  expect_true("name"        %in% names(result))
+  expect_true("posteriorid" %in% names(result))
+  expect_true("outdir"      %in% names(result))
+})
+
+
+# ── Block 6: End-to-end check ─────────────────────────────────────────────────
+# This test requires a real DB connection to verify the full
+# query → save → return cycle works correctly.
+
+test_that("end-to-end: written files are consistent with returned pft", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+
+  result <- get.trait.data.pft(
+    pft         = make_test_pft(outdir),
+    modeltype   = std_modeltype,
+    dbfiles     = outdir,
+    dbcon       = test_dbcon,
+    trait.names = std_traits
+  )
+
+  # Load what was written to disk
+  trait_env <- new.env(parent = emptyenv())
+  prior_env <- new.env(parent = emptyenv())
+  load(file.path(outdir, "trait.data.Rdata"), envir = trait_env)
+  load(file.path(outdir, "prior.distns.Rdata"), envir = prior_env)
+
+  # Verify files contain actual data structures
+  expect_true(is.list(trait_env$trait.data))
+  expect_true(is.data.frame(prior_env$prior.distns))
+
+  # Verify return value is consistent
+  expect_equal(result$name, "temperate.Early_Hardwood")
+  expect_equal(result$outdir, outdir)
+})
+
+if (!is.null(test_dbcon)) {
+  if (exists("teardown_env", where = asNamespace("testthat"))) {
+    withr::defer(
+      try(PEcAn.DB::db.close(test_dbcon), silent = TRUE),
+      envir = testthat::teardown_env()
+    )
+  } else {
+    # Fallback for testthat < 3.0.0
+    on.exit(try(PEcAn.DB::db.close(test_dbcon), silent = TRUE), add = TRUE)
+  }
+}

--- a/base/db/tests/testthat/test-get.trait.data.pft.R
+++ b/base/db/tests/testthat/test-get.trait.data.pft.R
@@ -1,27 +1,15 @@
 # Tests for get.trait.data.pft()
-# Package: PEcAn.DB
 #
-# Purpose: Lock down the current behavior of get.trait.data.pft() before
-# refactoring. These act as a regression safety net — if refactoring changes
-# any observable behavior, these tests will catch it.
-#
-# Tests requiring a live BETYdb connection skip cleanly when unavailable.
-# ── Fixtures ──────────────────────────────────────────────────────────────────
-# Helper needed for the restored cultivar test
-dbdir <- file.path(tempdir(), "dbfiles")
+# Regression safety net to lock down current behavior before the modularity
+# refactor. DB-dependent tests skip cleanly when no connection is available.
 
-get_pft <- function(pftname) {
-  get.trait.data.pft(
-    pft         = list(name = pftname, outdir = withr::local_tempdir()),
-    trait.names = "SLA",
-    dbfiles     = dbdir,
-    modeltype   = NULL,
-    dbcon       = test_dbcon)
-}
+# Helpers
+
+dbdir <- file.path(tempdir(), "dbfiles")
 
 make_test_pft <- function(outdir) {
   list(
-    name        = "temperate.Early_Hardwood",
+    name        = "temperate.deciduous",
     outdir      = outdir,
     posteriorid = NULL,
     constants   = list()
@@ -29,7 +17,6 @@ make_test_pft <- function(outdir) {
 }
 
 make_empty_pft <- function(outdir) {
-  # PFT that exists in BETY but has no observations for the requested traits
   list(
     name        = "soil.ALL",
     outdir      = outdir,
@@ -43,18 +30,39 @@ std_traits    <- c("SLA", "Vcmax", "leaf_respiration_rate_m2")
 
 skip_if_no_db <- function(dbcon) {
   if (is.null(dbcon) || inherits(dbcon, "try-error")) {
-    skip("No test database connection available — skipping live DB test")
+    skip("No test database connection available")
   }
-  # Also skip if BETYdb schema hasn't been loaded (empty database)
-  has_schema <- tryCatch({
-    DBI::dbExistsTable(dbcon, "pfts")
-  }, error = function(e) FALSE)
+  has_schema <- tryCatch(
+    DBI::dbExistsTable(dbcon, "pfts"),
+    error = function(e) FALSE
+  )
   if (!has_schema) {
-    skip("No test database connection available — skipping live DB test")
+    skip("Test database has no pfts table")
   }
 }
 
-# Try to open a DB connection — tests skip gracefully if unavailable
+# Every call that reaches the INSERT creates a posteriors row.
+# With write = FALSE (default), no dbfiles rows are created.
+cleanup_posterior <- function(dbcon, posteriorid) {
+  if (!is.null(posteriorid)) {
+    try(DBI::dbExecute(dbcon,
+      "DELETE FROM posteriors WHERE id = $1",
+      list(posteriorid)), silent = TRUE)
+  }
+}
+
+# Helper for the restored cultivar test (see #1958)
+get_pft <- function(pftname) {
+  get.trait.data.pft(
+    pft         = list(name = pftname, outdir = withr::local_tempdir()),
+    trait.names = "SLA",
+    dbfiles     = dbdir,
+    modeltype   = NULL,
+    dbcon       = test_dbcon)
+}
+
+# DB connection and teardown
+
 test_dbcon <- tryCatch(
   PEcAn.DB::db.open(
     params = list(
@@ -69,9 +77,29 @@ test_dbcon <- tryCatch(
   error = function(e) NULL
 )
 
-test_that("get.trait.data.pft fails gracefully with NULL dbcon", {
+old_log_level <- PEcAn.logger::logger.getLevel()
+PEcAn.logger::logger.setLevel("WARN")
+
+withr::defer({
+  unlink(dbdir, recursive = TRUE)
+  PEcAn.logger::logger.setLevel(old_log_level)
+}, envir = testthat::teardown_env())
+
+if (!is.null(test_dbcon)) {
+  withr::defer(
+    try(PEcAn.DB::db.close(test_dbcon), silent = TRUE),
+    envir = testthat::teardown_env()
+  )
+}
+
+# Input validation (no DB required)
+
+test_that("errors with no arguments", {
+  expect_error(get.trait.data.pft())
+})
+
+test_that("errors with NULL dbcon", {
   outdir <- withr::local_tempdir()
-  
   expect_error(
     get.trait.data.pft(
       pft         = make_test_pft(outdir),
@@ -83,363 +111,15 @@ test_that("get.trait.data.pft fails gracefully with NULL dbcon", {
   )
 })
 
-test_that("get.trait.data.pft fails with invalid modeltype and NULL dbcon", {
-  outdir <- withr::local_tempdir()
-  
-  expect_error(
-    get.trait.data.pft(
-      pft         = make_test_pft(outdir),
-      modeltype   = "NONEXISTENT_MODEL",
-      dbfiles     = outdir,
-      dbcon       = NULL,
-      trait.names = std_traits
-    )
-  )
-})
+# Error cases
 
-test_that("get.trait.data.pft errors with no arguments", {
-  expect_error(get.trait.data.pft())
-})
-
-
-# ── Block 1: Files are written to disk ────────────────────────────────────────
-
-test_that("get.trait.data.pft() writes trait.data.Rdata to pft$outdir", {
+test_that("errors for non-existent PFT name", {
   skip_if_no_db(test_dbcon)
   outdir <- withr::local_tempdir()
-
-  get.trait.data.pft(
-    pft         = make_test_pft(outdir),
-    modeltype   = std_modeltype,
-    dbfiles     = outdir,
-    dbcon       = test_dbcon,
-    trait.names = std_traits
-  )
-
-  expect_true(file.exists(file.path(outdir, "trait.data.Rdata")))
-})
-
-test_that("get.trait.data.pft() writes prior.distns.Rdata to pft$outdir", {
-  skip_if_no_db(test_dbcon)
-  outdir <- withr::local_tempdir()
-
-  get.trait.data.pft(
-    pft         = make_test_pft(outdir),
-    modeltype   = std_modeltype,
-    dbfiles     = outdir,
-    dbcon       = test_dbcon,
-    trait.names = std_traits
-  )
-
-  expect_true(file.exists(file.path(outdir, "prior.distns.Rdata")))
-})
-
-test_that("get.trait.data.pft() writes both expected files in one call", {
-  skip_if_no_db(test_dbcon)
-  outdir <- withr::local_tempdir()
-
-  get.trait.data.pft(
-    pft         = make_test_pft(outdir),
-    modeltype   = std_modeltype,
-    dbfiles     = outdir,
-    dbcon       = test_dbcon,
-    trait.names = std_traits
-  )
-
-  rdata_files <- list.files(outdir, pattern = "\\.Rdata$")
-  expect_true("trait.data.Rdata"   %in% rdata_files)
-  expect_true("prior.distns.Rdata" %in% rdata_files)
-})
-
-
-# ── Block 2: Return value shape ───────────────────────────────────────────────
-
-test_that("get.trait.data.pft() returns a list with field 'name'", {
-  skip_if_no_db(test_dbcon)
-  outdir   <- withr::local_tempdir()
-  test_pft <- make_test_pft(outdir)
-
-  result <- get.trait.data.pft(
-    pft         = test_pft,
-    modeltype   = std_modeltype,
-    dbfiles     = outdir,
-    dbcon       = test_dbcon,
-    trait.names = std_traits
-  )
-
-  expect_true("name" %in% names(result))
-  expect_equal(result$name, test_pft$name)
-})
-
-test_that("get.trait.data.pft() returns a list with field 'posteriorid'", {
-  skip_if_no_db(test_dbcon)
-  outdir <- withr::local_tempdir()
-
-  result <- get.trait.data.pft(
-    pft         = make_test_pft(outdir),
-    modeltype   = std_modeltype,
-    dbfiles     = outdir,
-    dbcon       = test_dbcon,
-    trait.names = std_traits
-  )
-
-  expect_true("posteriorid" %in% names(result))
-})
-
-test_that("get.trait.data.pft() returns a list with field 'outdir'", {
-  skip_if_no_db(test_dbcon)
-  outdir <- withr::local_tempdir()
-
-  result <- get.trait.data.pft(
-    pft         = make_test_pft(outdir),
-    modeltype   = std_modeltype,
-    dbfiles     = outdir,
-    dbcon       = test_dbcon,
-    trait.names = std_traits
-  )
-
-  expect_true("outdir" %in% names(result))
-  expect_equal(result$outdir, outdir)
-})
-
-test_that("CURRENT BEHAVIOR: get.trait.data.pft() discards computed data", {
-  # NOTE: This test documents the CURRENT behavior where trait_data and
-  # prior_distns are saved to disk but NOT returned to the caller.
-  # After the modularity refactor, this test should be UPDATED (not deleted)
-  # to verify that the new pure function DOES return these objects.
-
-  skip_if_no_db(test_dbcon)
-  outdir <- withr::local_tempdir()
-
-  result <- get.trait.data.pft(
-    pft         = make_test_pft(outdir),
-    modeltype   = std_modeltype,
-    dbfiles     = outdir,
-    dbcon       = test_dbcon,
-    trait.names = std_traits
-  )
-
-  expect_false("trait_data"   %in% names(result))
-  expect_false("prior_distns" %in% names(result))
-})
-
-
-# ── Block 3: Contents of written files ───────────────────────────────────────
-
-test_that("trait.data.Rdata contains a named list", {
-  skip_if_no_db(test_dbcon)
-  outdir <- withr::local_tempdir()
-
-  get.trait.data.pft(
-    pft         = make_test_pft(outdir),
-    modeltype   = std_modeltype,
-    dbfiles     = outdir,
-    dbcon       = test_dbcon,
-    trait.names = std_traits
-  )
-
-  env <- new.env(parent = emptyenv())
-  load(file.path(outdir, "trait.data.Rdata"), envir = env)
-
-  expect_true(exists("trait.data", envir = env))
-  expect_true(is.list(env$trait.data))
-})
-
-test_that("prior.distns.Rdata contains a data frame with expected columns", {
-  skip_if_no_db(test_dbcon)
-  outdir <- withr::local_tempdir()
-
-  get.trait.data.pft(
-    pft         = make_test_pft(outdir),
-    modeltype   = std_modeltype,
-    dbfiles     = outdir,
-    dbcon       = test_dbcon,
-    trait.names = std_traits
-  )
-
-  env <- new.env(parent = emptyenv())
-  load(file.path(outdir, "prior.distns.Rdata"), envir = env)
-
-  expect_true(exists("prior.distns", envir = env))
-  expect_true(is.data.frame(env$prior.distns))
-
-  missing_cols <- setdiff(c("distn", "parama", "paramb"), colnames(env$prior.distns))
-  expect_equal(length(missing_cols), 0L,
-    label = paste("prior.distns missing columns:", paste(missing_cols, collapse = ", ")))
-})
-
-
-# ── Block 4: PFT with no observations ────────────────────────────────────────
-
-test_that("get.trait.data.pft() does not error for a PFT with no observations", {
-  skip_if_no_db(test_dbcon)
-  outdir <- withr::local_tempdir()
-  
-  soil_exists <- tryCatch({
-    nrow(DBI::dbGetQuery(test_dbcon, 
-      "SELECT 1 FROM pfts WHERE name = 'soil.ALL' LIMIT 1")) > 0
-  }, error = function(e) FALSE)
-  skip_if_not(soil_exists, "soil.ALL PFT not present in test BETY")
-  
-  result <- get.trait.data.pft(
-    pft         = make_empty_pft(outdir),
-    modeltype   = std_modeltype,
-    dbfiles     = outdir,
-    dbcon       = test_dbcon,
-    trait.names = std_traits
-  )
-  
-  # Clean up any DB records created during test
-  if (!is.null(result$posteriorid)) {
-    posteriorid <- result$posteriorid
-    withr::defer({
-      try(DBI::dbExecute(test_dbcon,
-        paste0("DELETE FROM dbfiles WHERE container_type = 'Posterior' AND container_id = ",
-               posteriorid)), silent = TRUE)
-      try(DBI::dbExecute(test_dbcon,
-        paste0("DELETE FROM posteriors WHERE id = ",
-               posteriorid)), silent = TRUE)
-    })
-  }
-  
-  expect_true(is.list(result))
-})
-
-test_that("get.trait.data.pft() writes prior.distns.Rdata even when trait data is empty", {
-  skip_if_no_db(test_dbcon)
-  outdir <- withr::local_tempdir()
-
-  soil_exists <- tryCatch({
-    nrow(DBI::dbGetQuery(test_dbcon, 
-      "SELECT 1 FROM pfts WHERE name = 'soil.ALL' LIMIT 1")) > 0
-  }, error = function(e) FALSE)
-  skip_if_not(soil_exists, "soil.ALL PFT not present in test BETY")
-
-  result <- get.trait.data.pft(
-    pft         = make_empty_pft(outdir),
-    modeltype   = std_modeltype,
-    dbfiles     = outdir,
-    dbcon       = test_dbcon,
-    trait.names = std_traits
-  )
-
-    # Clean up any DB records created during test
-  if (!is.null(result$posteriorid)) {
-    posteriorid <- result$posteriorid
-    withr::defer({
-      try(DBI::dbExecute(test_dbcon,
-        paste0("DELETE FROM dbfiles WHERE container_type = 'Posterior' AND container_id = ",
-               posteriorid)), silent = TRUE)
-      try(DBI::dbExecute(test_dbcon,
-        paste0("DELETE FROM posteriors WHERE id = ",
-               posteriorid)), silent = TRUE)
-    })
-  }
-
-  expect_true(file.exists(file.path(outdir, "prior.distns.Rdata")))
-})
-
-
-# ── Block 5: Caching behavior ─────────────────────────────────────────────────
-
-test_that("second call uses cache — files are not rewritten", {
-  skip_if_no_db(test_dbcon)
-  outdir <- withr::local_tempdir()
-
-  args <- list(
-    pft         = make_test_pft(outdir),
-    modeltype   = std_modeltype,
-    dbfiles     = outdir,
-    dbcon       = test_dbcon,
-    trait.names = std_traits
-  )
-
-  # First call — creates files
-  do.call(get.trait.data.pft, args)
-  
-  trait_file <- file.path(outdir, "trait.data.Rdata")
-  prior_file <- file.path(outdir, "prior.distns.Rdata")
-  
-  expect_true(file.exists(trait_file))
-  expect_true(file.exists(prior_file))
-  
-  # Record file sizes (not timestamps — more reliable)
-  size_before_trait <- file.size(trait_file)
-  size_before_prior <- file.size(prior_file)
-  
-  # Second call — should use cache
-  result2 <- do.call(get.trait.data.pft, args)
-  
-  # Files should still exist and be the same size
-  expect_equal(file.size(trait_file), size_before_trait)
-  expect_equal(file.size(prior_file), size_before_prior)
-  
-  # Return value should still be valid
-  expect_true("name" %in% names(result2))
-})
-
-test_that("second call still returns a valid pft list when using cache", {
-  skip_if_no_db(test_dbcon)
-  outdir <- withr::local_tempdir()
-
-  args <- list(
-    pft         = make_test_pft(outdir),
-    modeltype   = std_modeltype,
-    dbfiles     = outdir,
-    dbcon       = test_dbcon,
-    trait.names = std_traits
-  )
-
-  do.call(get.trait.data.pft, args)
-  result <- do.call(get.trait.data.pft, args)
-
-  expect_true("name"        %in% names(result))
-  expect_true("posteriorid" %in% names(result))
-  expect_true("outdir"      %in% names(result))
-})
-
-
-# ── Block 6: End-to-end check ─────────────────────────────────────────────────
-# This test requires a real DB connection to verify the full
-# query → save → return cycle works correctly.
-
-test_that("end-to-end: written files are consistent with returned pft", {
-  skip_if_no_db(test_dbcon)
-  outdir <- withr::local_tempdir()
-
-  result <- get.trait.data.pft(
-    pft         = make_test_pft(outdir),
-    modeltype   = std_modeltype,
-    dbfiles     = outdir,
-    dbcon       = test_dbcon,
-    trait.names = std_traits
-  )
-
-  # Load what was written to disk
-  trait_env <- new.env(parent = emptyenv())
-  prior_env <- new.env(parent = emptyenv())
-  load(file.path(outdir, "trait.data.Rdata"), envir = trait_env)
-  load(file.path(outdir, "prior.distns.Rdata"), envir = prior_env)
-
-  # Verify files contain actual data structures
-  expect_true(is.list(trait_env$trait.data))
-  expect_true(is.data.frame(prior_env$prior.distns))
-
-  # Verify return value is consistent
-  expect_equal(result$name, "temperate.Early_Hardwood")
-  expect_equal(result$outdir, outdir)
-})
-
-# ── Block 7: Error cases ─────────────────────────────────────────────────────
-
-test_that("get.trait.data.pft() errors for non-existent PFT name", {
-  skip_if_no_db(test_dbcon)
-  outdir <- withr::local_tempdir()
-
   expect_error(
     get.trait.data.pft(
       pft       = list(name = "NOTAPFT", outdir = outdir,
-                        posteriorid = NULL, constants = list()),
+                       posteriorid = NULL, constants = list()),
       modeltype = std_modeltype,
       dbfiles   = outdir,
       dbcon     = test_dbcon,
@@ -449,13 +129,13 @@ test_that("get.trait.data.pft() errors for non-existent PFT name", {
   )
 })
 
-test_that("get.trait.data.pft() errors when multiple PFTs share a name", {
+test_that("errors when multiple PFTs share a name", {
   skip_if_no_db(test_dbcon)
   outdir <- withr::local_tempdir()
 
-  # "soil" matches multiple PFTs in standard BETY
   multi_exists <- tryCatch({
-    n <- DBI::dbGetQuery(test_dbcon, "SELECT count(*) AS n FROM pfts WHERE name = 'soil'")$n
+    n <- DBI::dbGetQuery(test_dbcon,
+      "SELECT count(*) AS n FROM pfts WHERE name = 'soil'")$n
     n > 1
   }, error = function(e) FALSE)
   skip_if_not(multi_exists, "Need multiple PFTs named 'soil' to test this case")
@@ -463,7 +143,7 @@ test_that("get.trait.data.pft() errors when multiple PFTs share a name", {
   expect_error(
     get.trait.data.pft(
       pft       = list(name = "soil", outdir = outdir,
-                        posteriorid = NULL, constants = list()),
+                       posteriorid = NULL, constants = list()),
       modeltype = NULL,
       dbfiles   = outdir,
       dbcon     = test_dbcon,
@@ -473,7 +153,132 @@ test_that("get.trait.data.pft() errors when multiple PFTs share a name", {
   )
 })
 
-# ── Restored: Skipped cultivar test (see #1958) ──────────────────────────────
+# File output
+
+test_that("writes expected Rdata files to outdir", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+  result <- get.trait.data.pft(
+    pft = make_test_pft(outdir), modeltype = std_modeltype,
+    dbfiles = outdir, dbcon = test_dbcon, trait.names = std_traits
+  )
+  withr::defer(cleanup_posterior(test_dbcon, result$posteriorid))
+
+  rdata_files <- list.files(outdir, pattern = "\\.Rdata$")
+  expect_true("trait.data.Rdata"   %in% rdata_files)
+  expect_true("prior.distns.Rdata" %in% rdata_files)
+})
+
+test_that("trait.data.Rdata contains a named list", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+  result <- get.trait.data.pft(
+    pft = make_test_pft(outdir), modeltype = std_modeltype,
+    dbfiles = outdir, dbcon = test_dbcon, trait.names = std_traits
+  )
+  withr::defer(cleanup_posterior(test_dbcon, result$posteriorid))
+
+  env <- new.env(parent = emptyenv())
+  load(file.path(outdir, "trait.data.Rdata"), envir = env)
+  expect_true(exists("trait.data", envir = env))
+  expect_true(is.list(env$trait.data))
+})
+
+test_that("prior.distns.Rdata contains a data frame with expected columns", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+  result <- get.trait.data.pft(
+    pft = make_test_pft(outdir), modeltype = std_modeltype,
+    dbfiles = outdir, dbcon = test_dbcon, trait.names = std_traits
+  )
+  withr::defer(cleanup_posterior(test_dbcon, result$posteriorid))
+
+  env <- new.env(parent = emptyenv())
+  load(file.path(outdir, "prior.distns.Rdata"), envir = env)
+  expect_true(exists("prior.distns", envir = env))
+  expect_true(is.data.frame(env$prior.distns))
+  expect_true(all(c("distn", "parama", "paramb") %in% colnames(env$prior.distns)))
+})
+
+# Return value
+
+test_that("returns pft list with name, posteriorid, and outdir", {
+  skip_if_no_db(test_dbcon)
+  outdir   <- withr::local_tempdir()
+  test_pft <- make_test_pft(outdir)
+  result <- get.trait.data.pft(
+    pft = test_pft, modeltype = std_modeltype,
+    dbfiles = outdir, dbcon = test_dbcon, trait.names = std_traits
+  )
+  withr::defer(cleanup_posterior(test_dbcon, result$posteriorid))
+
+  expect_equal(result$name, test_pft$name)
+  expect_equal(result$outdir, outdir)
+  expect_true("posteriorid" %in% names(result))
+})
+
+# Documents the behavior the modularity refactor will change:
+# trait_data and prior_distns are computed and saved to disk but NOT returned.
+# After refactoring, update this test to verify the new function DOES return them.
+test_that("return value does not include trait_data or prior_distns", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+  result <- get.trait.data.pft(
+    pft = make_test_pft(outdir), modeltype = std_modeltype,
+    dbfiles = outdir, dbcon = test_dbcon, trait.names = std_traits
+  )
+  withr::defer(cleanup_posterior(test_dbcon, result$posteriorid))
+
+  expect_false("trait_data"   %in% names(result))
+  expect_false("prior_distns" %in% names(result))
+})
+
+# PFT with no observations
+
+test_that("PFT with no trait observations returns valid result and writes priors", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+
+  soil_exists <- tryCatch({
+    nrow(DBI::dbGetQuery(test_dbcon,
+      "SELECT 1 FROM pfts WHERE name = 'soil.ALL' LIMIT 1")) > 0
+  }, error = function(e) FALSE)
+  skip_if_not(soil_exists, "soil.ALL PFT not present in test BETY")
+
+  result <- get.trait.data.pft(
+    pft = make_empty_pft(outdir), modeltype = std_modeltype,
+    dbfiles = outdir, dbcon = test_dbcon, trait.names = std_traits
+  )
+  withr::defer(cleanup_posterior(test_dbcon, result$posteriorid))
+
+  expect_true(is.list(result))
+  expect_true(file.exists(file.path(outdir, "prior.distns.Rdata")))
+})
+
+# End-to-end
+
+test_that("end-to-end: disk files are consistent with returned pft", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+  result <- get.trait.data.pft(
+    pft = make_test_pft(outdir), modeltype = std_modeltype,
+    dbfiles = outdir, dbcon = test_dbcon, trait.names = std_traits
+  )
+  withr::defer(cleanup_posterior(test_dbcon, result$posteriorid))
+
+  trait_env <- new.env(parent = emptyenv())
+  prior_env <- new.env(parent = emptyenv())
+  load(file.path(outdir, "trait.data.Rdata"), envir = trait_env)
+  load(file.path(outdir, "prior.distns.Rdata"), envir = prior_env)
+
+  expect_true(is.list(trait_env$trait.data))
+  expect_true(is.data.frame(prior_env$prior.distns))
+  expect_equal(result$name, "temperate.deciduous")
+  expect_equal(result$outdir, outdir)
+})
+
+# ── Restored: cultivar test (see #1958) ──────────────────────────────────────
+
 test_that("reference species and cultivar PFTs write traits properly", {
   skip("Disabled until Travis bety contains Pavi_alamo and Pavi_all (#1958)")
 
@@ -507,10 +312,3 @@ test_that("reference species and cultivar PFTs write traits properly", {
   expect_gt(file.info(allcv_csv)$size, file.info(cv_csv)$size)
   expect_gt(file.info(allcv_trt)$size, file.info(cv_trt)$size)
 })
-
-if (!is.null(test_dbcon)) {
-  withr::defer(
-    try(PEcAn.DB::db.close(test_dbcon), silent = TRUE),
-    envir = testthat::teardown_env()
-  )
-}

--- a/base/db/tests/testthat/test-get.trait.data.pft.R
+++ b/base/db/tests/testthat/test-get.trait.data.pft.R
@@ -18,9 +18,9 @@ make_test_pft <- function(outdir) {
 }
 
 make_empty_pft <- function(outdir) {
-  # Uses a deliberately nonexistent PFT name to test empty-data behavior
+  # PFT that exists in BETY but has no observations for the requested traits
   list(
-    name        = "test.EmptyPFT.NoSpecies",
+    name        = "soil.ALL",
     outdir      = outdir,
     posteriorid = NULL,
     constants   = list()
@@ -110,7 +110,7 @@ test_that("make_empty_pft returns correctly structured list", {
   pft <- make_empty_pft(outdir)
   
   expect_true(is.list(pft))
-  expect_equal(pft$name, "test.EmptyPFT.NoSpecies")
+  expect_equal(pft$name, "soil.ALL")
   expect_equal(pft$outdir, outdir)
   expect_null(pft$posteriorid)
   expect_true(is.list(pft$constants))
@@ -313,14 +313,20 @@ test_that("get.trait.data.pft() does not error for a PFT with no observations", 
   skip_if_no_db(test_dbcon)
   outdir <- withr::local_tempdir()
 
-  expect_no_error(
+  soil_exists <- tryCatch({
+    nrow(DBI::dbGetQuery(test_dbcon, "SELECT 1 FROM pfts WHERE name = 'soil.ALL' LIMIT 1")) > 0
+  }, error = function(e) FALSE)
+  skip_if_not(soil_exists, "soil.ALL PFT not present in test BETY")
+
+  expect_error(
     get.trait.data.pft(
       pft         = make_empty_pft(outdir),
       modeltype   = std_modeltype,
       dbfiles     = outdir,
       dbcon       = test_dbcon,
       trait.names = std_traits
-    )
+    ),
+    regexp = NA  # NA means "no error expected"
   )
 })
 
@@ -431,13 +437,51 @@ test_that("end-to-end: written files are consistent with returned pft", {
 })
 
 if (!is.null(test_dbcon)) {
-  if (exists("teardown_env", where = asNamespace("testthat"))) {
-    withr::defer(
-      try(PEcAn.DB::db.close(test_dbcon), silent = TRUE),
-      envir = testthat::teardown_env()
-    )
-  } else {
-    # Fallback for testthat < 3.0.0
-    on.exit(try(PEcAn.DB::db.close(test_dbcon), silent = TRUE), add = TRUE)
-  }
+  withr::defer(
+    try(PEcAn.DB::db.close(test_dbcon), silent = TRUE),
+    envir = testthat::teardown_env()
+  )
 }
+
+# ── Block 7: Error cases ─────────────────────────────────────────────────────
+
+test_that("get.trait.data.pft() errors for non-existent PFT name", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+
+  expect_error(
+    get.trait.data.pft(
+      pft       = list(name = "NOTAPFT", outdir = outdir,
+                        posteriorid = NULL, constants = list()),
+      modeltype = std_modeltype,
+      dbfiles   = outdir,
+      dbcon     = test_dbcon,
+      trait.names = std_traits
+    ),
+    "Could not find pft"
+  )
+})
+
+test_that("get.trait.data.pft() errors when multiple PFTs share a name", {
+  skip_if_no_db(test_dbcon)
+  outdir <- withr::local_tempdir()
+
+  # "soil" matches multiple PFTs in standard BETY
+  multi_exists <- tryCatch({
+    n <- DBI::dbGetQuery(test_dbcon, "SELECT count(*) AS n FROM pfts WHERE name = 'soil'")$n
+    n > 1
+  }, error = function(e) FALSE)
+  skip_if_not(multi_exists, "Need multiple PFTs named 'soil' to test this case")
+
+  expect_error(
+    get.trait.data.pft(
+      pft       = list(name = "soil", outdir = outdir,
+                        posteriorid = NULL, constants = list()),
+      modeltype = NULL,
+      dbfiles   = outdir,
+      dbcon     = test_dbcon,
+      trait.names = "SLA"
+    ),
+    "Multiple PFTs"
+  )
+})

--- a/base/db/tests/testthat/test-get.trait.data.pft.R
+++ b/base/db/tests/testthat/test-get.trait.data.pft.R
@@ -3,9 +3,10 @@
 # Regression safety net to lock down current behavior before the modularity
 # refactor. DB-dependent tests skip cleanly when no connection is available.
 
-# Helpers
+# ── Helpers ──────────────────────────────────────────────────────────────────
 
-dbdir <- file.path(tempdir(), "dbfiles")
+dbdir  <- file.path(tempdir(), "dbfiles")
+outdir <- file.path(tempdir(), "outfiles")
 
 make_test_pft <- function(outdir) {
   list(
@@ -41,8 +42,6 @@ skip_if_no_db <- function(dbcon) {
   }
 }
 
-# Every call that reaches the INSERT creates a posteriors row.
-# With write = FALSE (default), no dbfiles rows are created.
 cleanup_posterior <- function(dbcon, posteriorid) {
   if (!is.null(posteriorid)) {
     try(DBI::dbExecute(dbcon,
@@ -51,17 +50,18 @@ cleanup_posterior <- function(dbcon, posteriorid) {
   }
 }
 
-# Helper for the restored cultivar test (see #1958)
 get_pft <- function(pftname) {
   get.trait.data.pft(
-    pft         = list(name = pftname, outdir = withr::local_tempdir()),
+    pft         = list(name = pftname, outdir = withr::local_tempdir(),
+                       posteriorid = NULL, constants = list()),
     trait.names = "SLA",
     dbfiles     = dbdir,
     modeltype   = NULL,
-    dbcon       = test_dbcon)
+    dbcon       = test_dbcon
+  )
 }
 
-# DB connection and teardown
+# ── DB connection and teardown ───────────────────────────────────────────────
 
 test_dbcon <- tryCatch(
   PEcAn.DB::db.open(
@@ -92,7 +92,7 @@ if (!is.null(test_dbcon)) {
   )
 }
 
-# Input validation (no DB required)
+# ── Input validation (no DB required) ───────────────────────────────────────
 
 test_that("errors with no arguments", {
   expect_error(get.trait.data.pft())
@@ -111,7 +111,7 @@ test_that("errors with NULL dbcon", {
   )
 })
 
-# Error cases
+# ── Error cases ──────────────────────────────────────────────────────────────
 
 test_that("errors for non-existent PFT name", {
   skip_if_no_db(test_dbcon)
@@ -132,14 +132,12 @@ test_that("errors for non-existent PFT name", {
 test_that("errors when multiple PFTs share a name", {
   skip_if_no_db(test_dbcon)
   outdir <- withr::local_tempdir()
-
   multi_exists <- tryCatch({
     n <- DBI::dbGetQuery(test_dbcon,
       "SELECT count(*) AS n FROM pfts WHERE name = 'soil'")$n
     n > 1
   }, error = function(e) FALSE)
   skip_if_not(multi_exists, "Need multiple PFTs named 'soil' to test this case")
-
   expect_error(
     get.trait.data.pft(
       pft       = list(name = "soil", outdir = outdir,
@@ -153,7 +151,7 @@ test_that("errors when multiple PFTs share a name", {
   )
 })
 
-# File output
+# ── File output ──────────────────────────────────────────────────────────────
 
 test_that("writes expected Rdata files to outdir", {
   skip_if_no_db(test_dbcon)
@@ -163,7 +161,6 @@ test_that("writes expected Rdata files to outdir", {
     dbfiles = outdir, dbcon = test_dbcon, trait.names = std_traits
   )
   withr::defer(cleanup_posterior(test_dbcon, result$posteriorid))
-
   rdata_files <- list.files(outdir, pattern = "\\.Rdata$")
   expect_true("trait.data.Rdata"   %in% rdata_files)
   expect_true("prior.distns.Rdata" %in% rdata_files)
@@ -177,7 +174,6 @@ test_that("trait.data.Rdata contains a named list", {
     dbfiles = outdir, dbcon = test_dbcon, trait.names = std_traits
   )
   withr::defer(cleanup_posterior(test_dbcon, result$posteriorid))
-
   env <- new.env(parent = emptyenv())
   load(file.path(outdir, "trait.data.Rdata"), envir = env)
   expect_true(exists("trait.data", envir = env))
@@ -192,7 +188,6 @@ test_that("prior.distns.Rdata contains a data frame with expected columns", {
     dbfiles = outdir, dbcon = test_dbcon, trait.names = std_traits
   )
   withr::defer(cleanup_posterior(test_dbcon, result$posteriorid))
-
   env <- new.env(parent = emptyenv())
   load(file.path(outdir, "prior.distns.Rdata"), envir = env)
   expect_true(exists("prior.distns", envir = env))
@@ -200,7 +195,7 @@ test_that("prior.distns.Rdata contains a data frame with expected columns", {
   expect_true(all(c("distn", "parama", "paramb") %in% colnames(env$prior.distns)))
 })
 
-# Return value
+# ── Return value ─────────────────────────────────────────────────────────────
 
 test_that("returns pft list with name, posteriorid, and outdir", {
   skip_if_no_db(test_dbcon)
@@ -211,15 +206,11 @@ test_that("returns pft list with name, posteriorid, and outdir", {
     dbfiles = outdir, dbcon = test_dbcon, trait.names = std_traits
   )
   withr::defer(cleanup_posterior(test_dbcon, result$posteriorid))
-
   expect_equal(result$name, test_pft$name)
   expect_equal(result$outdir, outdir)
   expect_true("posteriorid" %in% names(result))
 })
 
-# Documents the behavior the modularity refactor will change:
-# trait_data and prior_distns are computed and saved to disk but NOT returned.
-# After refactoring, update this test to verify the new function DOES return them.
 test_that("return value does not include trait_data or prior_distns", {
   skip_if_no_db(test_dbcon)
   outdir <- withr::local_tempdir()
@@ -228,34 +219,30 @@ test_that("return value does not include trait_data or prior_distns", {
     dbfiles = outdir, dbcon = test_dbcon, trait.names = std_traits
   )
   withr::defer(cleanup_posterior(test_dbcon, result$posteriorid))
-
   expect_false("trait_data"   %in% names(result))
   expect_false("prior_distns" %in% names(result))
 })
 
-# PFT with no observations
+# ── PFT with no observations ────────────────────────────────────────────────
 
 test_that("PFT with no trait observations returns valid result and writes priors", {
   skip_if_no_db(test_dbcon)
   outdir <- withr::local_tempdir()
-
   soil_exists <- tryCatch({
     nrow(DBI::dbGetQuery(test_dbcon,
       "SELECT 1 FROM pfts WHERE name = 'soil.ALL' LIMIT 1")) > 0
   }, error = function(e) FALSE)
   skip_if_not(soil_exists, "soil.ALL PFT not present in test BETY")
-
   result <- get.trait.data.pft(
     pft = make_empty_pft(outdir), modeltype = std_modeltype,
     dbfiles = outdir, dbcon = test_dbcon, trait.names = std_traits
   )
   withr::defer(cleanup_posterior(test_dbcon, result$posteriorid))
-
   expect_true(is.list(result))
   expect_true(file.exists(file.path(outdir, "prior.distns.Rdata")))
 })
 
-# End-to-end
+# ── End-to-end ───────────────────────────────────────────────────────────────
 
 test_that("end-to-end: disk files are consistent with returned pft", {
   skip_if_no_db(test_dbcon)
@@ -265,12 +252,10 @@ test_that("end-to-end: disk files are consistent with returned pft", {
     dbfiles = outdir, dbcon = test_dbcon, trait.names = std_traits
   )
   withr::defer(cleanup_posterior(test_dbcon, result$posteriorid))
-
   trait_env <- new.env(parent = emptyenv())
   prior_env <- new.env(parent = emptyenv())
   load(file.path(outdir, "trait.data.Rdata"), envir = trait_env)
   load(file.path(outdir, "prior.distns.Rdata"), envir = prior_env)
-
   expect_true(is.list(trait_env$trait.data))
   expect_true(is.data.frame(prior_env$prior.distns))
   expect_equal(result$name, "temperate.deciduous")
@@ -281,6 +266,7 @@ test_that("end-to-end: disk files are consistent with returned pft", {
 
 test_that("reference species and cultivar PFTs write traits properly", {
   skip("Disabled until Travis bety contains Pavi_alamo and Pavi_all (#1958)")
+  skip_if_no_db(test_dbcon)
 
   pavi_sp <- get_pft("pavi")
   expect_equal(pavi_sp$name, "pavi")

--- a/base/db/tests/testthat/test-get.trait.data.pft.R
+++ b/base/db/tests/testthat/test-get.trait.data.pft.R
@@ -1,12 +1,9 @@
 # Tests for get.trait.data.pft()
 #
-# Regression safety net to lock down current behavior before the modularity
-# refactor. DB-dependent tests skip cleanly when no connection is available.
 
-# ── Helpers ──────────────────────────────────────────────────────────────────
+# Helpers
 
 dbdir  <- file.path(tempdir(), "dbfiles")
-outdir <- file.path(tempdir(), "outfiles")
 
 make_test_pft <- function(outdir) {
   list(
@@ -29,70 +26,38 @@ make_empty_pft <- function(outdir) {
 std_modeltype <- "SIPNET"
 std_traits    <- c("SLA", "Vcmax", "leaf_respiration_rate_m2")
 
-skip_if_no_db <- function(dbcon) {
-  if (is.null(dbcon) || inherits(dbcon, "try-error")) {
-    skip("No test database connection available")
-  }
-  has_schema <- tryCatch(
-    DBI::dbExistsTable(dbcon, "pfts"),
-    error = function(e) FALSE
-  )
-  if (!has_schema) {
-    skip("Test database has no pfts table")
-  }
-}
-
 cleanup_posterior <- function(dbcon, posteriorid) {
   if (!is.null(posteriorid)) {
+    try(DBI::dbExecute(dbcon,
+      "DELETE FROM dbfiles WHERE container_type = 'Posterior' AND container_id = $1",
+      list(posteriorid)), silent = TRUE)
     try(DBI::dbExecute(dbcon,
       "DELETE FROM posteriors WHERE id = $1",
       list(posteriorid)), silent = TRUE)
   }
 }
 
-get_pft <- function(pftname) {
+get_pft <- function(pftname, dbcon) {
   get.trait.data.pft(
     pft         = list(name = pftname, outdir = withr::local_tempdir(),
                        posteriorid = NULL, constants = list()),
     trait.names = "SLA",
     dbfiles     = dbdir,
     modeltype   = NULL,
-    dbcon       = test_dbcon
+    dbcon       = dbcon 
   )
 }
 
-# ── DB connection and teardown ───────────────────────────────────────────────
-
-test_dbcon <- tryCatch(
-  PEcAn.DB::db.open(
-    params = list(
-      driver   = "PostgreSQL",
-      user     = Sys.getenv("PECAN_TEST_DB_USER", "bety"),
-      password = Sys.getenv("PECAN_TEST_DB_PASS", "bety"),
-      host     = Sys.getenv("PECAN_TEST_DB_HOST", "localhost"),
-      dbname   = Sys.getenv("PECAN_TEST_DB_NAME", "bety"),
-      port     = as.integer(Sys.getenv("PECAN_TEST_DB_PORT", "5432"))
-    )
-  ),
-  error = function(e) NULL
-)
+#  Teardown 
 
 old_log_level <- PEcAn.logger::logger.getLevel()
 PEcAn.logger::logger.setLevel("WARN")
-
-withr::defer({
+teardown({
   unlink(dbdir, recursive = TRUE)
   PEcAn.logger::logger.setLevel(old_log_level)
-}, envir = testthat::teardown_env())
+})
 
-if (!is.null(test_dbcon)) {
-  withr::defer(
-    try(PEcAn.DB::db.close(test_dbcon), silent = TRUE),
-    envir = testthat::teardown_env()
-  )
-}
-
-# ── Input validation (no DB required) ───────────────────────────────────────
+# Input validation (no DB required)
 
 test_that("errors with no arguments", {
   expect_error(get.trait.data.pft())
@@ -111,10 +76,11 @@ test_that("errors with NULL dbcon", {
   )
 })
 
-# ── Error cases ──────────────────────────────────────────────────────────────
+# Error cases
 
 test_that("errors for non-existent PFT name", {
-  skip_if_no_db(test_dbcon)
+  test_dbcon <- check_db_test()
+  withr::defer(PEcAn.DB::db.close(test_dbcon))
   outdir <- withr::local_tempdir()
   expect_error(
     get.trait.data.pft(
@@ -130,7 +96,8 @@ test_that("errors for non-existent PFT name", {
 })
 
 test_that("errors when multiple PFTs share a name", {
-  skip_if_no_db(test_dbcon)
+  test_dbcon <- check_db_test()
+  withr::defer(PEcAn.DB::db.close(test_dbcon))
   outdir <- withr::local_tempdir()
   multi_exists <- tryCatch({
     n <- DBI::dbGetQuery(test_dbcon,
@@ -151,10 +118,11 @@ test_that("errors when multiple PFTs share a name", {
   )
 })
 
-# ── File output ──────────────────────────────────────────────────────────────
+# File output
 
 test_that("writes expected Rdata files to outdir", {
-  skip_if_no_db(test_dbcon)
+  test_dbcon <- check_db_test()
+  withr::defer(PEcAn.DB::db.close(test_dbcon))
   outdir <- withr::local_tempdir()
   result <- get.trait.data.pft(
     pft = make_test_pft(outdir), modeltype = std_modeltype,
@@ -167,7 +135,8 @@ test_that("writes expected Rdata files to outdir", {
 })
 
 test_that("trait.data.Rdata contains a named list", {
-  skip_if_no_db(test_dbcon)
+  test_dbcon <- check_db_test()
+  withr::defer(PEcAn.DB::db.close(test_dbcon))
   outdir <- withr::local_tempdir()
   result <- get.trait.data.pft(
     pft = make_test_pft(outdir), modeltype = std_modeltype,
@@ -181,7 +150,8 @@ test_that("trait.data.Rdata contains a named list", {
 })
 
 test_that("prior.distns.Rdata contains a data frame with expected columns", {
-  skip_if_no_db(test_dbcon)
+  test_dbcon <- check_db_test()
+  withr::defer(PEcAn.DB::db.close(test_dbcon))
   outdir <- withr::local_tempdir()
   result <- get.trait.data.pft(
     pft = make_test_pft(outdir), modeltype = std_modeltype,
@@ -195,10 +165,11 @@ test_that("prior.distns.Rdata contains a data frame with expected columns", {
   expect_true(all(c("distn", "parama", "paramb") %in% colnames(env$prior.distns)))
 })
 
-# ── Return value ─────────────────────────────────────────────────────────────
+# Return value 
 
 test_that("returns pft list with name, posteriorid, and outdir", {
-  skip_if_no_db(test_dbcon)
+  test_dbcon <- check_db_test()
+  withr::defer(PEcAn.DB::db.close(test_dbcon))
   outdir   <- withr::local_tempdir()
   test_pft <- make_test_pft(outdir)
   result <- get.trait.data.pft(
@@ -212,7 +183,8 @@ test_that("returns pft list with name, posteriorid, and outdir", {
 })
 
 test_that("return value does not include trait_data or prior_distns", {
-  skip_if_no_db(test_dbcon)
+  test_dbcon <- check_db_test()
+  withr::defer(PEcAn.DB::db.close(test_dbcon))
   outdir <- withr::local_tempdir()
   result <- get.trait.data.pft(
     pft = make_test_pft(outdir), modeltype = std_modeltype,
@@ -223,10 +195,11 @@ test_that("return value does not include trait_data or prior_distns", {
   expect_false("prior_distns" %in% names(result))
 })
 
-# ── PFT with no observations ────────────────────────────────────────────────
+# PFT with no observations
 
 test_that("PFT with no trait observations returns valid result and writes priors", {
-  skip_if_no_db(test_dbcon)
+  test_dbcon <- check_db_test()
+  withr::defer(PEcAn.DB::db.close(test_dbcon))
   outdir <- withr::local_tempdir()
   soil_exists <- tryCatch({
     nrow(DBI::dbGetQuery(test_dbcon,
@@ -242,10 +215,11 @@ test_that("PFT with no trait observations returns valid result and writes priors
   expect_true(file.exists(file.path(outdir, "prior.distns.Rdata")))
 })
 
-# ── End-to-end ───────────────────────────────────────────────────────────────
+# End-to-end
 
 test_that("end-to-end: disk files are consistent with returned pft", {
-  skip_if_no_db(test_dbcon)
+  test_dbcon <- check_db_test()
+  withr::defer(PEcAn.DB::db.close(test_dbcon))
   outdir <- withr::local_tempdir()
   result <- get.trait.data.pft(
     pft = make_test_pft(outdir), modeltype = std_modeltype,
@@ -262,31 +236,32 @@ test_that("end-to-end: disk files are consistent with returned pft", {
   expect_equal(result$outdir, outdir)
 })
 
-# ── Restored: cultivar test (see #1958) ──────────────────────────────────────
+# Restored: cultivar test (see #1958)
 
 test_that("reference species and cultivar PFTs write traits properly", {
   skip("Disabled until Travis bety contains Pavi_alamo and Pavi_all (#1958)")
-  skip_if_no_db(test_dbcon)
+  test_dbcon <- check_db_test()
+  withr::defer(PEcAn.DB::db.close(test_dbcon))
 
-  pavi_sp <- get_pft("pavi")
+  pavi_sp    <- get_pft("pavi", test_dbcon)
   expect_equal(pavi_sp$name, "pavi")
   sp_csv <- file.path(dbdir, "posterior", pavi_sp$posteriorid, "species.csv")
   sp_trt <- file.path(dbdir, "posterior", pavi_sp$posteriorid, "trait.data.csv")
   expect_true(file.exists(sp_csv))
   expect_true(file.exists(sp_trt))
-  expect_gt(file.info(sp_csv)$size, 40)
-  expect_gt(file.info(sp_trt)$size, 215)
+  expect_gt(file.info(sp_csv)$size, 40)  # i.e. longer than the 40-char header
+  expect_gt(file.info(sp_trt)$size, 215) # ditto 215-char header
 
-  pavi_cv <- get_pft("Pavi_alamo")
+  pavi_cv    <- get_pft("Pavi_alamo", test_dbcon)
   expect_equal(pavi_cv$name, "Pavi_alamo")
   cv_csv <- file.path(dbdir, "posterior", pavi_cv$posteriorid, "cultivars.csv")
   cv_trt <- file.path(dbdir, "posterior", pavi_cv$posteriorid, "trait.data.csv")
   expect_true(file.exists(cv_csv))
   expect_true(file.exists(cv_trt))
-  expect_gt(file.info(cv_csv)$size, 63)
+  expect_gt(file.info(cv_csv)$size, 63)  # cultivar.csv headers are longer
   expect_gt(file.info(cv_trt)$size, 215)
 
-  pavi_allcv <- get_pft("Pavi_all")
+  pavi_allcv <- get_pft("Pavi_all", test_dbcon)
   expect_equal(pavi_allcv$name, "Pavi_all")
   allcv_csv <- file.path(dbdir, "posterior", pavi_allcv$posteriorid, "cultivars.csv")
   allcv_trt <- file.path(dbdir, "posterior", pavi_allcv$posteriorid, "trait.data.csv")


### PR DESCRIPTION
Regression tests for get.trait.data.pft()
Added test coverage for get.trait.data.pft() before starting the modularity refactor. No source changes — just tests.

Tests cover: input validation, error paths (bad PFT name, ambiguous name), file output and contents, return value shape, empty PFT handling (soil.ALL), and end-to-end consistency. Original error cases and the skipped cultivar test (#1958) are preserved.

All DB tests clean up via cleanup_posterior() — no orphaned rows.

Removed the old caching tests — traced through the source and the cache never actually hits with write=FALSE and posteriorid=NULL. The function deletes and recreates outdir contents on every call.

Without DB:
<img width="987" height="644" alt="Screenshot 2026-03-27 224821" src="https://github.com/user-attachments/assets/8a6f7ab7-1829-49ce-8a61-c7b4bb21c228" />

[ FAIL 0 | WARN 0 | SKIP 10 | PASS 2 ]

With DB (Codespace + Docker BETY):
<img width="458" height="314" alt="image" src="https://github.com/user-attachments/assets/82eeebd2-cb34-4d81-ab36-8fcaf299cebf" />

[ FAIL 0 | WARN 2 | SKIP 1 | PASS 22 ]

Warnings are upstream (dbplyr interface, soil.ALL no priors). Skip is cultivar test #1958.