### PR TITLE
check.model.settings: Skip binary lookup when no DB connection

### DIFF
--- a/base/settings/NEWS.md
+++ b/base/settings/NEWS.md
@@ -1,3 +1,9 @@
+# PEcAn.settings 1.9.1.9000
+
+* Breaking: `loadPath.SitePFT(path)` now takes only one argument, removing the previously required but ignored `settings` (@Thomas-Sedhom, #3834).
+* `check.model.settings()` now skips lookup of the model binary path if no DB connection is provided (#3863).
+
+
 # PEcAn.settings 1.9.1
 
 ## Fixed

--- a/base/settings/R/check.all.settings.R
+++ b/base/settings/R/check.all.settings.R
@@ -903,7 +903,11 @@ check.model.settings <- function(settings, dbcon = NULL) {
     }
 
     # check on binary for given host
-    if (!is.null(settings$model$id) && (settings$model$id >= 0)) {
+    if (is.null(dbcon)) {
+      PEcAn.logger::logger.warn(
+        "No database connection available, can't check model binary"
+      )
+    } else if (!is.null(settings$model$id) && (settings$model$id >= 0)) {
       binary <- PEcAn.DB::dbfile.file(
         "Model",
         settings$model$id,
@@ -922,7 +926,7 @@ check.model.settings <- function(settings, dbcon = NULL) {
       }
     } else {
       PEcAn.logger::logger.warn(
-        "No model binary sepcified in database for model ", settings$model$type)
+        "No model binary specified in database for model ", settings$model$type)
     }
   }
 


### PR DESCRIPTION
Should help reduce connection errors from inside prepare.settings