### PR TITLE
fix in-place mutation of Tair met2model.SIPNET

### DIFF
--- a/base/utils/DESCRIPTION
+++ b/base/utils/DESCRIPTION
@@ -45,7 +45,7 @@ Imports:
     purrr,
     rlang,
     stringi,
-    units
+    units (>= 0.8.7)
 Suggests:
     coda (>= 0.18),
     data.table,

--- a/base/utils/R/ud_convert.R
+++ b/base/utils/R/ud_convert.R
@@ -19,7 +19,7 @@ ud_convert <- function(x, u1, u2) {
       warning("Units of `x` don't match `u1`, using '", units::deparse_unit(x1), "' instead")
     }
   } else {
-    x1 <- units::set_units(x, value = u1, mode = "standard")
+    x1 <- units::set_units(as.numeric(x), value = u1, mode = "standard")
   }
   x2 <- units::set_units(x1, value = u2, mode = "standard")
   

--- a/docker/depends/pecan_package_dependencies.csv
+++ b/docker/depends/pecan_package_dependencies.csv
@@ -671,9 +671,9 @@
 "TruncatedNormal",">= 2.2","modules/assim.batch","Imports",FALSE
 "truncnorm","*","modules/data.atmosphere","Imports",FALSE
 "units","*","base/db","Imports",FALSE
-"units","*","base/utils","Imports",FALSE
 "units","*","modules/benchmark","Imports",FALSE
 "units","*","modules/data.atmosphere","Imports",FALSE
+"units",">= 0.8.7","base/utils","Imports",FALSE
 "urltools","*","base/remote","Imports",FALSE
 "utils","*","base/all","Imports",FALSE
 "utils","*","base/logger","Imports",FALSE

--- a/models/sipnet/R/met2model.SIPNET.R
+++ b/models/sipnet/R/met2model.SIPNET.R
@@ -188,7 +188,7 @@ met2model.SIPNET <- function(in.path,
       lat <- ncdf4::ncvar_get(nc, "latitude")
       lon <- ncdf4::ncvar_get(nc, "longitude")
       Tair <-ncdf4::ncvar_get(nc, "air_temperature")  ## in Kelvin
-      Tair_C <- PEcAn.utils::ud_convert(Tair, "K", "degC")
+      Tair_C <- PEcAn.utils::ud_convert(as.numeric(Tair), "K", "degC")
       Qair <-ncdf4::ncvar_get(nc, "specific_humidity")  #humidity (kg/kg)
       
       # if we have wind speed.

--- a/models/sipnet/R/met2model.SIPNET.R
+++ b/models/sipnet/R/met2model.SIPNET.R
@@ -188,7 +188,7 @@ met2model.SIPNET <- function(in.path,
       lat <- ncdf4::ncvar_get(nc, "latitude")
       lon <- ncdf4::ncvar_get(nc, "longitude")
       Tair <-ncdf4::ncvar_get(nc, "air_temperature")  ## in Kelvin
-      Tair_C <- PEcAn.utils::ud_convert(as.numeric(Tair), "K", "degC")
+      Tair_C <- PEcAn.utils::ud_convert(Tair, "K", "degC")
       Qair <-ncdf4::ncvar_get(nc, "specific_humidity")  #humidity (kg/kg)
       
       # if we have wind speed.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
PEcAn.utils::ud_convert's internall call units::set_units mutates the input array in place causes `Tair` (K) to silently overwritten with C values after computing `Tair_C`. case when soil_temperature is absent from input netcdf, soil temperature approximation branch uses `stats::convolve(Tair, filt)` expecting K, but receives the mutated C values; later ud_convert(soilT, "K", "degC") then subtracts 273.15 second time, produces soil temperatures approximately -263 C
so soil temperature in .clim output was ~-263C instead of ~10C

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
