### PR TITLE
[chore] bump actions that are now warning about node 20 deprecation

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     # checkout source code
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     # install bookdown
     - name: Install bookdown
       run: |
@@ -41,7 +41,7 @@ jobs:
         cd book_source
         Rscript -e 'bookdown::render_book("index.Rmd", "bookdown::gitbook")'
     # save artifact
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: pecan-documentation
         path: book_source/_book/
@@ -57,7 +57,7 @@ jobs:
     # download documentation repo
     - name: Checkout documentation repo
       if: ${{ github.event_name == 'push' && steps.doc_exists.outputs.exists == 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ github.repository_owner }}/pecan-documentation
         path: pecan-documentation

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,7 +37,7 @@ jobs:
     # checkout source code
     - name: work around https://github.com/actions/checkout/issues/766
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         set-safe-directory: false
 

--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -70,7 +70,7 @@ jobs:
             echo 'MODEL_VERSION=${{ inputs.model-version }}'
             )" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # create metadata for image
       - name: Docker meta
@@ -78,7 +78,7 @@ jobs:
           check_var: ${{ secrets.DOCKERHUB_USERNAME }}
           is_default_R: ${{ inputs.r-version == env.DEFAULT_R_VERSION }}
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -97,11 +97,11 @@ jobs:
 
       # setup docker build
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Inspect Builder
         run: |
@@ -116,13 +116,13 @@ jobs:
         env: 
           check_var: ${{ secrets.DOCKERHUB_USERNAME }}
         if: env.check_var != null
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -130,7 +130,7 @@ jobs:
 
       # build the docker images
       - name: Build and push ${{ steps.name.outputs.image_name }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.build-context }}
           file: ${{ inputs.dockerfile }}

--- a/.github/workflows/docker-stack-sipnet.yml
+++ b/.github/workflows/docker-stack-sipnet.yml
@@ -26,7 +26,7 @@ jobs:
         swap-storage: true
 
     - name: Checkout source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Docker Compose
       run: |

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     # Checkout source code
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     # Install dependencies
     - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
     # Checkout package documentation repo
     - name: Checkout package documentation repo
       if: ${{ github.event_name == 'push' && steps.pkgdoc_exists.outputs.exists == 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ github.repository_owner }}/package-documentation
         path: package-documentation

--- a/.github/workflows/prlabeler.yml
+++ b/.github/workflows/prlabeler.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: ".github/labeler.yml"

--- a/.github/workflows/render-quarto.yml
+++ b/.github/workflows/render-quarto.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build PEcAn base Docker image
         run: |
@@ -69,7 +69,7 @@ jobs:
           done
 
       - name: Upload rendered HTML as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: quarto-html
           path: quarto_html_build/
@@ -86,7 +86,7 @@ jobs:
 
       - name: Checkout documentation repo
         if: ${{ github.event_name == 'push' && steps.doc_exists.outputs.exists == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.repository_owner }}/pecan-documentation
           path: pecan-documentation

--- a/.github/workflows/sipnet.yml
+++ b/.github/workflows/sipnet.yml
@@ -32,7 +32,7 @@ jobs:
     # checkout source code
     - name: work around https://github.com/actions/checkout/issues/766
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         set-safe-directory: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     # checkout source code
     - name: work around https://github.com/actions/checkout/issues/766
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         set-safe-directory: false
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
GHA now issues a deprecation warning for actions that run on Node 20;  I went through and bumped the ones I saw complaining in recent build logs that have newer versions available. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
