### PR TITLE
Log INFO not WARN when checking settings with no DB block

### DIFF
--- a/base/settings/NEWS.md
+++ b/base/settings/NEWS.md
@@ -2,6 +2,7 @@
 
 * Breaking: `loadPath.SitePFT(path)` now takes only one argument, removing the previously required but ignored `settings` (@Thomas-Sedhom, #3834).
 * `check.model.settings()` now skips lookup of the model binary path if no DB connection is provided (#3863).
+* When no DB connection is provided to `check.database.settings`, it now skips with an INFO instead of a WARN. Rationale: now that the database is optional, a settings with no DB block is a valid settings.
 
 
 # PEcAn.settings 1.9.1

--- a/base/settings/R/check.all.settings.R
+++ b/base/settings/R/check.all.settings.R
@@ -904,7 +904,7 @@ check.model.settings <- function(settings, dbcon = NULL) {
 
     # check on binary for given host
     if (is.null(dbcon)) {
-      PEcAn.logger::logger.warn(
+      PEcAn.logger::logger.info(
         "No database connection available, can't check model binary"
       )
     } else if (!is.null(settings$model$id) && (settings$model$id >= 0)) {
@@ -1039,7 +1039,7 @@ check.database.settings <- function(settings) {
           PEcAn.logger::logger.debug(
             "Writing all runs/configurations to database.")
         } else {
-          PEcAn.logger::logger.warn(
+          PEcAn.logger::logger.debug(
             "Will not write runs/configurations to database.")
         }
       }
@@ -1063,11 +1063,11 @@ check.database.settings <- function(settings) {
       # check database version
       check.bety.version(dbcon)
     } else {
-      PEcAn.logger::logger.warn(
+      PEcAn.logger::logger.info(
         "No BETY database information specified; not using database.")
     }
   } else {
-    PEcAn.logger::logger.warn(
+    PEcAn.logger::logger.info(
       "No BETY database information specified; not using database.")
   }
   return(settings)


### PR DESCRIPTION
No need to alarm users when their configuration is valid.