### PR TITLE
get.parameter.samples: avoid dropping NULL priors

### DIFF
--- a/modules/uncertainty/R/ensemble.R
+++ b/modules/uncertainty/R/ensemble.R
@@ -1,34 +1,35 @@
-##' Reads output from model ensemble
-##'
-##' Reads output for an ensemble of length specified by \code{ensemble.size} and bounded by \code{start.year} 
-##' and \code{end.year}
-##' @title Read ensemble output
-##' @return a list of ensemble model output 
-##' @param ensemble.size the number of ensemble members run
-##' @param pecandir specifies where pecan writes its configuration files
-##' @param outdir directory with model output to use in ensemble analysis
-##' @param start.year first year to include in ensemble analysis
-##' @param end.year last year to include in ensemble analysis
-##' @param variable target variables for ensemble analysis
-##' @param ens.run.ids dataframe. Must contain a column named "id" giving the run IDs to be read.
-##'   If NULL, will attempt to read IDs from a file named "samples.Rdata" in \code{pecandir}
-##' @export
-##' @author Ryan Kelly, David LeBauer, Rob Kooper
+#' Reads output from model ensemble
+#'
+#' Reads output for an ensemble of length specified by \code{ensemble.size} and bounded by \code{start.year}
+#' and \code{end.year}
+#'
+#' @param ensemble.size the number of ensemble members run
+#' @param pecandir specifies where pecan writes its configuration files
+#' @param outdir directory with model output to use in ensemble analysis
+#' @param start.year first year to include in ensemble analysis
+#' @param end.year last year to include in ensemble analysis
+#' @param variable target variables for ensemble analysis
+#' @param ens.run.ids dataframe. Must contain a column named "id" giving the run IDs to be read.
+#'   If NULL, will attempt to read IDs from a file named "samples.Rdata" in \code{pecandir}
+#'
+#' @return a list of ensemble model output
+#' @export
+#' @author Ryan Kelly, David LeBauer, Rob Kooper
 #--------------------------------------------------------------------------------------------------#
-read.ensemble.output <- function(ensemble.size, pecandir, outdir, start.year, end.year, 
+read.ensemble.output <- function(ensemble.size, pecandir, outdir, start.year, end.year,
                                  variable, ens.run.ids = NULL) {
-  
+
   # load manifest
   if (is.null(ens.run.ids)) {
     manifest <- utils::read.csv(file.path(pecandir, "runs_manifest.csv"), stringsAsFactors = FALSE)
     ens.run.ids <- manifest[manifest$type == "Ensemble", ]
   }
-  
+
   expr <- variable$expression
   variables <- variable$variables
-  
+
   ensemble.output <- list()
-  
+
   # handles both (manifest has 'run_id', legacy 'ens.run.ids' might have 'id')
   run_ids <- ens.run.ids$run_id %||% ens.run.ids$id
   for (i in seq_along(run_ids)) {
@@ -36,47 +37,45 @@ read.ensemble.output <- function(ensemble.size, pecandir, outdir, start.year, en
 
     # We pass the whole 'variables' vector once, avoiding repeated file open/close.
     out.tmp <- PEcAn.utils::read.output(
-      runid = run.id, 
-      outdir = file.path(outdir, run.id), 
-      start.year = start.year, 
-      end.year = end.year, 
+      runid = run.id,
+      outdir = file.path(outdir, run.id),
+      start.year = start.year,
+      end.year = end.year,
       variables = variables
     )
-    
+
     # Assign loaded variables to local environment for evaluation
     for (var in names(out.tmp)) {
       assign(var, out.tmp[[var]])
     }
-    
+
     # derivation & aggregation
     out <- eval(parse(text = expr))
-    ensemble.output[[as.character(i)]] <- mean(out, na.rm = TRUE) 
+    ensemble.output[[as.character(i)]] <- mean(out, na.rm = TRUE)
   }
-  
+
   return(ensemble.output)
 } # read.ensemble.output
 
 
-##' Get parameter values used in ensemble
-##'
-##' Returns a matrix of randomly or quasi-randomly sampled trait values 
-##' to be assigned to traits over several model runs.
-##' given the number of model runs and a list of sample distributions for traits
-##' The model run is indexed first by model run, then by trait
-##' 
-##' @title Get Ensemble Samples
-##' @name get.ensemble.samples
-##' @param ensemble.size number of runs in model ensemble
-##' @param pft.samples random samples from parameter distribution, e.g. from a MCMC chain  
-##' @param env.samples env samples
-##' @param method the method used to generate the ensemble samples. Random generators: uniform, uniform with latin hypercube permutation. Quasi-random generators: halton, sobol, torus. Random generation draws random variates whereas quasi-random generation is deterministic but well equidistributed. Default is uniform. For small ensemble size with relatively large parameter number (e.g ensemble size < 5 and # of traits > 5) use methods other than halton. 
-##' @param param.names a list of parameter names that were fitted either by MA or PDA, important argument, if NULL parameters will be resampled independently
-##' @param ... Other arguments passed on to the sampling method
-##' 
-##' @return matrix of (quasi-)random samples from trait distributions
-##' @export
-##' @author David LeBauer, Istem Fer
-get.ensemble.samples <- function( ensemble.size, pft.samples, env.samples, 
+#' Get parameter values used in ensemble
+#'
+#' Returns a matrix of randomly or quasi-randomly sampled trait values
+#' to be assigned to traits over several model runs.
+#' given the number of model runs and a list of sample distributions for traits
+#' The model run is indexed first by model run, then by trait
+#'
+#' @param ensemble.size number of runs in model ensemble
+#' @param pft.samples random samples from parameter distribution, e.g. from a MCMC chain
+#' @param env.samples env samples
+#' @param method the method used to generate the ensemble samples. Random generators: uniform, uniform with latin hypercube permutation. Quasi-random generators: halton, sobol, torus. Random generation draws random variates whereas quasi-random generation is deterministic but well equidistributed. Default is uniform. For small ensemble size with relatively large parameter number (e.g ensemble size < 5 and # of traits > 5) use methods other than halton.
+#' @param param.names a list of parameter names that were fitted either by MA or PDA, important argument, if NULL parameters will be resampled independently
+#' @param ... Other arguments passed on to the sampling method
+#'
+#' @return matrix of (quasi-)random samples from trait distributions
+#' @export
+#' @author David LeBauer, Istem Fer
+get.ensemble.samples <- function( ensemble.size, pft.samples, env.samples,
                                  method = "random", param.names = NULL, ...) {
 
   # Define supported methods
@@ -193,42 +192,54 @@ get.ensemble.samples <- function( ensemble.size, pft.samples, env.samples,
 } # get.ensemble.samples
 
 
-##' Write ensemble config files
-##'
-##' Writes config files for use in meta-analysis and returns a list of run ids.
-##' Given a pft.xml object, a list of lists as supplied by get.sa.samples, 
-##' a name to distinguish the output files, and the directory to place the files.
-##'
-##' @param input_design design matrix describing sampled inputs (see
-##'   `run.write.configs()`). Columns named after `settings$run$inputs` tags give
-##'   1-based indices into each input's `path` list and rows follow run order.
-##'   Requires `nrow(input_design) >= ensemble.size`;
-##'   extra rows are ignored.
-##' @param ensemble.size size of ensemble
-##' @param defaults pft
-##' @param ensemble.samples list of lists supplied by \link{get.ensemble.samples}
-##' @param settings list of PEcAn settings
-##' @param model name of model to be run, e.g. "ED2" or "SIPNET"
-##' @param clean remove old output first?
-##' @param write.to.db logical: Record this run in BETY?
-##' @param restart In case this is a continuation of an old simulation. restart needs to be a list with name tags of runid, inputs, new.params (parameters), new.state (initial condition), ensemble.id (ensemble id), start.time and stop.time.See Details.
-##' @param rename Decide if we want to rename previous output files, for example convert from sipnet.out to sipnet.2020-07-16.out.
-##'
-##' @return list, containing $runs = data frame of runids, $ensemble.id = the ensemble ID for these runs and $samples with ids and samples used for each tag.  Also writes sensitivity analysis configuration files as a side effect
-##' @details The restart functionality is developed using model specific functions by calling write_restart.modelname function. First, you need to make sure that this function is already exist for your desired model.See here \url{https://pecanproject.github.io/pecan-documentation/latest/pecan-models.html}
-##' new state is a dataframe with a different column for each state variable. The number of the rows in this dataframe needs to be the same as the ensemble size.
-##' The state variables that you can use for setting up initial conditions are model specific. Check the documentation of the write_restart.<modelname> function for the model you are using.
-##' The units for the state variables need to be in the PEcAn standard units which can be found in \link[PEcAn.utils]{standard_vars}.
-##' new.params also has similar structure to ensemble.samples which is sent as an argument.
-##'
-##' @importFrom dplyr %>%
-##' @importFrom rlang .data %||%
-##' @export
-##' @author David LeBauer, Carl Davidson, Hamze Dokoohaki
+#' Write ensemble config files
+#'
+#' Writes config files for use in meta-analysis and returns a list of run ids.
+#' Given a pft.xml object, a list of lists as supplied by get.sa.samples,
+#' a name to distinguish the output files, and the directory to place the files.
+#'
+#' The restart functionality is developed using model specific functions by calling write_restart.modelname function.
+#' First, you need to make sure that this function is already exist for your desired model.
+#' See here \url{https://pecanproject.github.io/pecan-documentation/latest/pecan-models.html}.
+#' new state is a dataframe with a different column for each state variable.
+#' The number of the rows in this dataframe needs to be the same as the ensemble size.
+#' The state variables that you can use for setting up initial conditions are model specific.
+#' Check the documentation of the write_restart.<modelname> function for the model you are using.
+#' The units for the state variables need to be in the PEcAn standard units which can be found in \link[PEcAn.utils]{standard_vars}.
+#' new.params also has similar structure to ensemble.samples which is sent as an argument.
+#'
+#' @param input_design design matrix describing sampled inputs (see
+#'   `run.write.configs()`). Columns named after `settings$run$inputs` tags give
+#'   1-based indices into each input's `path` list and rows follow run order.
+#'   Requires `nrow(input_design) >= ensemble.size`;
+#'   extra rows are ignored.
+#' @param ensemble.size size of ensemble
+#' @param defaults pft
+#' @param ensemble.samples list of lists supplied by \link{get.ensemble.samples}
+#' @param settings list of PEcAn settings
+#' @param model name of model to be run, e.g. "ED2" or "SIPNET"
+#' @param clean remove old output first?
+#' @param write.to.db logical: Record this run in BETY?
+#' @param restart In case this is a continuation of an old simulation.
+#'  Needs to be a list with name tags of runid, inputs, new.params (parameters),
+#'  new.state (initial condition), ensemble.id (ensemble id), start.time and stop.time.
+#'  See Details.
+#' @param rename Decide if we want to rename previous output files, for example convert from sipnet.out to sipnet.2020-07-16.out.
+#'
+#' @return list, containing
+#'  $runs = data frame of runids,
+#'  $ensemble.id = the ensemble ID for these runs,
+#'  and $samples with ids and samples used for each tag.
+#'  Also writes sensitivity analysis configuration files as a side effect
+#'
+#' @importFrom dplyr %>%
+#' @importFrom rlang .data %||%
+#' @export
+#' @author David LeBauer, Carl Davidson, Hamze Dokoohaki
 
-write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensemble.samples, settings, model, 
+write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensemble.samples, settings, model,
                                    clean = FALSE, write.to.db = TRUE, restart = NULL, rename = FALSE) {
-  
+
   # Check for required paths
   for (input_tag in names(settings$run$inputs)) {
     input <- settings$run$inputs[[input_tag]]

--- a/modules/uncertainty/R/ensemble.R
+++ b/modules/uncertainty/R/ensemble.R
@@ -83,7 +83,7 @@ get.ensemble.samples <- function( ensemble.size, pft.samples, env.samples,
   if (!method %in% supported_methods) {
     stop("Invalid sampling method")
   }
-  
+
   ## force as numeric for compatibility with Fortran code in halton()
   ensemble.size <- as.numeric(ensemble.size)
   if (ensemble.size <= 0) {
@@ -97,11 +97,11 @@ get.ensemble.samples <- function( ensemble.size, pft.samples, env.samples,
     for (i in seq_along(pft.samples)) {
       pft2col <- c(pft2col, rep(i, length(pft.samples[[i]])))
     }
-    
+
     total.sample.num <- sum(sapply(pft.samples, length))
     random.samples <- NULL
-    
-    
+
+
     if (method == "halton") {
       PEcAn.logger::logger.info("Using ", method, "method for sampling")
       random.samples <- randtoolbox::halton(n = ensemble.size, dim = total.sample.num, ...)
@@ -124,25 +124,25 @@ get.ensemble.samples <- function( ensemble.size, pft.samples, env.samples,
       PEcAn.logger::logger.info("Using ", method, "random sampling")
       # uniform random
       random.samples <- matrix(stats::runif(ensemble.size * total.sample.num),
-                               ensemble.size, 
+                               ensemble.size,
                                total.sample.num)
     } else {
       PEcAn.logger::logger.info("Method ", method, " has not been implemented yet, using uniform random sampling")
       # uniform random
       random.samples <- matrix(stats::runif(ensemble.size * total.sample.num),
-                               ensemble.size, 
+                               ensemble.size,
                                total.sample.num)
     }
-    
-    
+
+
     ensemble.samples <- list()
     sampled.indices <- list()
-    
+
     col.i <- 0
     for (pft.i in seq(pft.samples)) {
       ensemble.samples[[pft.i]] <- matrix(nrow = ensemble.size, ncol = length(pft.samples[[pft.i]]))
       sampled.indices[[pft.i]] <- matrix(nrow = ensemble.size, ncol = length(pft.samples[[pft.i]]))
-      
+
       # meaning we want to keep MCMC samples together
       if(length(pft.samples[[pft.i]])>0 & !is.null(param.names)){ 
         if (method == "halton") {
@@ -161,14 +161,14 @@ get.ensemble.samples <- function( ensemble.size, pft.samples, env.samples,
         }
         else {
           PEcAn.logger::logger.error("Sampling method %s is not recognized", method)
-        
+
         }
-        
+
       }
-      
+
       for (trait.i in seq(pft.samples[[pft.i]])) {
         col.i <- col.i + 1
-        if (names(pft.samples[[pft.i]])[trait.i] %in% param.names[[pft.i]]) { 
+        if (names(pft.samples[[pft.i]])[trait.i] %in% param.names[[pft.i]]) {
              ensemble.samples[[pft.i]][, trait.i] <- pft.samples[[pft.i]][[trait.i]][same.i]
              sampled.indices[[pft.i]][, trait.i] <- same.i
        }else{
@@ -183,7 +183,7 @@ get.ensemble.samples <- function( ensemble.size, pft.samples, env.samples,
     }  
           ensemble.samples[[pft.i]] <- as.data.frame(ensemble.samples[[pft.i]])
           colnames(ensemble.samples[[pft.i]]) <- names(pft.samples[[pft.i]])
-    
+
   }  #end pft
    names(ensemble.samples) <- names(pft.samples)
    ans <- ensemble.samples
@@ -257,27 +257,27 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
       )
     }
   }
-  
+
   con <- NULL
   my.write.config <- paste("write.config.", model, sep = "")
   my.write_restart <- paste0("write_restart.", model)
-  
+
   if (is.null(ensemble.samples)) {
     return(list(runs = NULL, ensemble.id = NULL))
   }
-  
+
   # See if we need to write to DB
   if (!is.null(settings$database$bety$write)) {
     # specifying `write` in settings overrides write.to.db in fn args
     write.to.db <- as.logical(settings$database$bety$write)
   }
-  
+
   if (write.to.db) {
     # Open connection to database so we can store all run/ensemble information
     con <-
       try(PEcAn.DB::db.open(settings$database$bety))
     on.exit(try(PEcAn.DB::db.close(con), silent = TRUE), add = TRUE)
-    
+
     # If we fail to connect to DB then we set to NULL
     if (inherits(con, "try-error"))  {
       con <- NULL
@@ -294,14 +294,14 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
     type = character(),
     stringsAsFactors = FALSE
   )
-  
+
   # Get the workflow id
   # if workflow$id is null, set to -1
   # to avoid collision w/ database ids
   workflow.id <- settings$workflow$id %||% -1
 
-  #------------------------------------------------- if this is a new fresh run------------------  
-  if (is.null(restart)){
+  #------------------------------------------------- if this is a new fresh run------------------
+  if (is.null(restart)) {
     # create an ensemble id
     # Note: this ignores any existing settings$ensemble$id
     if (!is.null(con) && write.to.db) {
@@ -310,7 +310,7 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
         "INSERT INTO ensembles (runtype, workflow_id) ",
         "VALUES ('ensemble', ", format(workflow.id, scientific = FALSE), ")",
         "RETURNING id"), con = con)[['id']]
-      
+
       for (pft in defaults) {
         PEcAn.DB::db.query(paste0(
           "INSERT INTO posteriors_ensembles (posterior_id, ensemble_id) ",
@@ -334,8 +334,8 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
       
     }else{
       required_tags<-c("met","parameters")
-      
     }
+
     #now looking into the xml
     samp <- settings$ensemble$samplingspace
     #performing the sampling
@@ -345,7 +345,7 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
       if (input_tag %in% colnames(input_design)) {
         input_paths <- settings$run$inputs[[input_tag]]$path
         input_indices <- input_design[[input_tag]]
-        
+
         samples[[input_tag]] <- list(
           samples = lapply(input_indices, function(idx) input_paths[[idx]])
         )
@@ -356,7 +356,7 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
       purrr::walk(function(r_tag){
         if (is.null(samples[[r_tag]]) & r_tag!="parameters") samples[[r_tag]]$samples <<- rep(settings$run$inputs[[tolower(r_tag)]]$path[1], ensemble.size)
       })
-    
+
     # Reading the site.pft specific tags from xml
     site.pfts.vec <- settings$run$site$site.pft %>% unlist %>% as.character
     
@@ -380,7 +380,7 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
           )
         )
     }
-    
+
     # if no ensemble piece was in the xml I replicate n times the first element in params
     if ( is.null(samp$parameters) )            samples$parameters$samples <- ensemble.samples %>% purrr::map(~.x[rep(1, ensemble.size) , ])
     # This where we handle the parameters - ensemble.samples is already generated in run.write.config and it's sent to this function as arg - 
@@ -389,7 +389,7 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
     # find all inputs that have an id
     inputs <- names(settings$run$inputs)
     inputs <- inputs[grepl(".id$", inputs)]
-    
+
     # write configuration for each run of the ensemble
     runs <- data.frame()
     for (i in seq_len(ensemble.size)) {
@@ -398,31 +398,31 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
         # inserting this into the table and getting an id back
         run.id <- PEcAn.DB::db.query(paste0(
           "INSERT INTO runs (model_id, site_id, start_time, finish_time, outdir, ensemble_id, parameter_list) ",
-          "values ('", 
-          settings$model$id, "', '", 
-          settings$run$site$id, "', '", 
-          settings$run$start.date, "', '", 
-          settings$run$end.date, "', '", 
-          settings$run$outdir, "', ", 
-          ensemble.id, ", '", 
+          "values ('",
+          settings$model$id, "', '",
+          settings$run$site$id, "', '",
+          settings$run$start.date, "', '",
+          settings$run$end.date, "', '",
+          settings$run$outdir, "', ",
+          ensemble.id, ", '",
           paramlist, "') ",
           "RETURNING id"), con = con)[['id']]
         # associate inputs with runs
         if (!is.null(inputs)) {
           for (x in inputs) {
             PEcAn.DB::db.query(paste0("INSERT INTO inputs_runs (input_id, run_id) ",
-                                      "values (", settings$run$inputs[[x]], ", ", run.id, ")"), 
+                                      "values (", settings$run$inputs[[x]], ", ", run.id, ")"),
                                con = con)
           }
         }
-        
+
       } else {
 
         run.id <- PEcAn.utils::get.run.id("ENS", PEcAn.utils::left.pad.zeros(i, 5), site.id=settings$run$site$id)
 
       }
       runs[i, "id"] <- run.id
-      
+
       manifest_df <- rbind(manifest_df, data.frame(
         run_id = run.id,
         site_id = settings$run$site$id,
@@ -432,7 +432,7 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
         type = "Ensemble",
         stringsAsFactors = FALSE
       ))
-      
+
       # create folders (cleaning up old ones if needed)
       if (clean) {
         unlink(file.path(settings$rundir, run.id))
@@ -440,7 +440,7 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
       }
       dir.create(file.path(settings$rundir, run.id), recursive = TRUE)
       dir.create(file.path(settings$modeloutdir, run.id), recursive = TRUE)
-      
+
       # build dynamic input info string
       input_info <- ""
       #changing the structure of input tag to what the models are expecting
@@ -449,11 +449,11 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
         if (!is.null(samples[[input_tag]])) {
           settings$run$inputs[[input_tag]][["path"]] <-
             samples[[input_tag]][["samples"]][[i]]
-          input_info <- paste0(input_info,format(input_tag, width = 12, justify = "left"), ": ", 
+          input_info <- paste0(input_info,format(input_tag, width = 12, justify = "left"), ": ",
                                samples[[input_tag]]$samples[[i]], "\n")
         }
       }
-      
+
       # write run information to disk
       cat("runtype     : ensemble\n",
           "workflow id : ", format(workflow.id, scientific = FALSE), "\n",
@@ -503,15 +503,15 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
 
     }
     return(invisible(list(runs = runs, ensemble.id = ensemble.id, samples = samples, manifest = manifest_df)))
-    #------------------------------------------------- if we already have everything ------------------        
-  }else{
-    #reading retstart inputs
-    inputs<-restart$inputs
-    run.id<-restart$runid
-    new.params<-restart$new.params
-    new.state<-restart$new.state
-    ensemble.id<-restart$ensemble.id
-    
+    #------------------------------------------------- if we already have everything ------------------
+  } else {
+    #reading restart inputs
+    inputs <- restart$inputs
+    run.id <- restart$runid
+    new.params <- restart$new.params
+    new.state <- restart$new.state
+    ensemble.id <- restart$ensemble.id
+
     # Reading the site.pft specific tags from xml
     site.pfts.vec <- settings$run$site$site.pft %>% unlist %>% as.character
     
@@ -526,16 +526,15 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
         PEcAn.logger::logger.warn(paste0("The following pfts are specified for the siteid ", settings$run$site$id ," but they are not defined as a pft in pecan.xml:",
                                          site.pfts.vec[which(!(site.pfts.vec %in% defined.pfts))]))
     }
-    
+
     #if ensemble folders do not exist create them
     for(j in 1:length(run.id)){
       if(!file.exists(file.path(settings$rundir, run.id[[j]]))){
         dir.create(file.path(settings$rundir, run.id[[j]]))
       }
-      
     }
-    
-    # stop and start time are required by bc we are wrtting them down into job.sh
+
+    # stop and start time are required by bc we are writing them down into job.sh
     for (i in seq_len(ensemble.size)) {
       input_list <- list()
       for (input_tag in names(inputs)) {
@@ -544,19 +543,19 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
         if (!is.null(inputs[[input_tag]]$samples[[i]])) 
           input_list[[input_tag]] <- list(path = inputs[[input_tag]]$samples[[i]])
       }
-      
-      do.call(my.write_restart, 
-              args =  list(outdir = settings$host$outdir, 
-                           runid = run.id[[i]], 
+
+      do.call(my.write_restart,
+              args =  list(outdir = settings$host$outdir,
+                           runid = run.id[[i]],
                            start.time = restart$start.time,
-                           stop.time =restart$stop.time, 
+                           stop.time =restart$stop.time,
                            settings = settings,
-                           new.state = new.state[i, ], 
+                           new.state = new.state[i, ],
                            new.params = new.params[[i]], #new.params$`646`[[i]] for debugging
                            inputs = input_list,
                            RENAME = rename)#for restart from previous model runs, not sharing the same outdir
       )
-      
+
       manifest_df <- rbind(manifest_df, data.frame(
         run_id = run.id[[i]],
         site_id = settings$run$site$id,
@@ -592,7 +591,7 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
 #' \dontrun{
 #'   settings <- PEcAn.settings::read.settings("pecan.xml")
 #'   input.ens.gen(
-#'     settings, 
+#'     settings,
 #'     ensemble_size = 50,
 #'     input = "met",
 #'     method = "sampling"

--- a/modules/uncertainty/R/ensemble.R
+++ b/modules/uncertainty/R/ensemble.R
@@ -105,17 +105,17 @@ get.ensemble.samples <- function( ensemble.size, pft.samples, env.samples,
     if (method == "halton") {
       PEcAn.logger::logger.info("Using ", method, "method for sampling")
       random.samples <- randtoolbox::halton(n = ensemble.size, dim = total.sample.num, ...)
-      ## force as a matrix in case length(samples)=1
+      ## force as a matrix in case length(samples) = 1
       random.samples <- as.matrix(random.samples)
     } else if (method == "sobol") {
       PEcAn.logger::logger.info("Using ", method, "method for sampling")
       random.samples <- randtoolbox::sobol(n = ensemble.size, dim = total.sample.num, scrambling = 3, ...)
-      ## force as a matrix in case length(samples)=1
+      ## force as a matrix in case length(samples) = 1
       random.samples <- as.matrix(random.samples)
     } else if (method == "torus") {
       PEcAn.logger::logger.info("Using ", method, "method for sampling")
       random.samples <- randtoolbox::torus(n = ensemble.size, dim = total.sample.num, ...)
-      ## force as a matrix in case length(samples)=1
+      ## force as a matrix in case length(samples) = 1
       random.samples <- as.matrix(random.samples)
     } else if (method == "lhc") {
       PEcAn.logger::logger.info("Using ", method, "method for sampling")
@@ -144,7 +144,7 @@ get.ensemble.samples <- function( ensemble.size, pft.samples, env.samples,
       sampled.indices[[pft.i]] <- matrix(nrow = ensemble.size, ncol = length(pft.samples[[pft.i]]))
 
       # meaning we want to keep MCMC samples together
-      if(length(pft.samples[[pft.i]])>0 & !is.null(param.names)){ 
+      if (length(pft.samples[[pft.i]]) > 0 && !is.null(param.names)) {
         if (method == "halton") {
           same.i <- floor(randtoolbox::halton(ensemble.size) * length(pft.samples[[pft.i]][[1]]))+1
         } else if (method == "sobol") {
@@ -158,37 +158,36 @@ get.ensemble.samples <- function( ensemble.size, pft.samples, env.samples,
         } else if (method == "random") {
             PEcAn.logger::logger.info("Using random row sampling for MCMC draws")
            same.i <- sample(nrow(pft.samples[[pft.i]][[1]]), ensemble.size, replace = TRUE)
-        }
-        else {
+        } else {
           PEcAn.logger::logger.error("Sampling method %s is not recognized", method)
-
         }
-
       }
 
       for (trait.i in seq(pft.samples[[pft.i]])) {
         col.i <- col.i + 1
         if (names(pft.samples[[pft.i]])[trait.i] %in% param.names[[pft.i]]) {
-             ensemble.samples[[pft.i]][, trait.i] <- pft.samples[[pft.i]][[trait.i]][same.i]
-             sampled.indices[[pft.i]][, trait.i] <- same.i
-       }else{
+          ensemble.samples[[pft.i]][, trait.i] <- pft.samples[[pft.i]][[trait.i]][same.i]
+          sampled.indices[[pft.i]][, trait.i] <- same.i
+        } else {
           # Extract original trait values
           trait.values <- pft.samples[[pft.i]][[trait.i]]
           sampled.values <- stats::quantile(trait.values, random.samples[, col.i])
 
           ensemble.samples[[pft.i]][, trait.i] <- stats::quantile(pft.samples[[pft.i]][[trait.i]],
                                                                   random.samples[, col.i])
-          sampled.indices[[pft.i]][, trait.i] <- sapply(sampled.values, function(val) {which.min(abs(trait.values - val)) })
-      }   
-    }  
-          ensemble.samples[[pft.i]] <- as.data.frame(ensemble.samples[[pft.i]])
-          colnames(ensemble.samples[[pft.i]]) <- names(pft.samples[[pft.i]])
+          sampled.indices[[pft.i]][, trait.i] <- sapply(sampled.values,
+                                                        function(val) {which.min(abs(trait.values - val)) })
+        }
+      }
+      ensemble.samples[[pft.i]] <- as.data.frame(ensemble.samples[[pft.i]])
+      colnames(ensemble.samples[[pft.i]]) <- names(pft.samples[[pft.i]])
 
-  }  #end pft
-   names(ensemble.samples) <- names(pft.samples)
-   ans <- ensemble.samples
+    }  #end pft
+    names(ensemble.samples) <- names(pft.samples)
+    ans <- ensemble.samples
   }
-    return(list(ans,sampled.indices))
+
+  return(list(ans,sampled.indices))
 } # get.ensemble.samples
 
 
@@ -331,9 +330,8 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
         dplyr::collect() %>%
         dplyr::filter(.data$required == TRUE) %>%
         dplyr::pull("tag")
-      
-    }else{
-      required_tags<-c("met","parameters")
+    } else {
+      required_tags <- c("met","parameters")
     }
 
     #now looking into the xml
@@ -351,25 +349,32 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
         )
       }
     }
-    # if there is a tag required by the model but it is not specified in the xml then I replicate n times the first element 
-    required_tags%>%
-      purrr::walk(function(r_tag){
-        if (is.null(samples[[r_tag]]) & r_tag!="parameters") samples[[r_tag]]$samples <<- rep(settings$run$inputs[[tolower(r_tag)]]$path[1], ensemble.size)
+    # if there is a tag required by the model but it is not specified in the xml then I replicate n times the first element
+    required_tags %>%
+      purrr::walk(function(r_tag) {
+        if (is.null(samples[[r_tag]]) && r_tag != "parameters") {
+          samples[[r_tag]]$samples <<- rep(settings$run$inputs[[tolower(r_tag)]]$path[1], ensemble.size)
+        }
       })
 
     # Reading the site.pft specific tags from xml
-    site.pfts.vec <- settings$run$site$site.pft %>% unlist %>% as.character
-    
+    site.pfts.vec <- settings$run$site$site.pft %>%
+      unlist() %>%
+      as.character()
+
     if (!is.null(site.pfts.vec)) {
       # find the name of pfts defined in the body of pecan.xml
-      defined.pfts <-
-        settings$pfts %>% purrr::map('name') %>% unlist %>% as.character
+      defined.pfts <- settings$pfts %>%
+        purrr::map("name") %>%
+        unlist() %>%
+        as.character()
       # subset ensemble samples based on the pfts that are specified in the site and they are also sampled from.
-      if (length(which(site.pfts.vec %in% defined.pfts)) > 0)
+      if (length(which(site.pfts.vec %in% defined.pfts)) > 0) {
         ensemble.samples <-
           ensemble.samples [site.pfts.vec[which(site.pfts.vec %in% defined.pfts)]]
+      }
       # warn if there is a pft specified in the site but it's not defined in the pecan xml.
-      if (length(which(!(site.pfts.vec %in% defined.pfts))) > 0)
+      if (length(which(!(site.pfts.vec %in% defined.pfts))) > 0) {
         PEcAn.logger::logger.warn(
           paste0(
             "The following pfts are specified for the siteid ",
@@ -379,12 +384,17 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
             collapse = ","
           )
         )
+      }
     }
 
     # if no ensemble piece was in the xml I replicate n times the first element in params
-    if ( is.null(samp$parameters) )            samples$parameters$samples <- ensemble.samples %>% purrr::map(~.x[rep(1, ensemble.size) , ])
-    # This where we handle the parameters - ensemble.samples is already generated in run.write.config and it's sent to this function as arg - 
-    if ( is.null(samples$parameters$samples) ) samples$parameters$samples <- ensemble.samples
+    if ( is.null(samp$parameters) ) {
+      samples$parameters$samples <- ensemble.samples %>% purrr::map(~.x[rep(1, ensemble.size) , ])
+    }
+    # This where we handle the parameters - ensemble.samples is already generated in run.write.config and it's sent to this function as arg -
+    if ( is.null(samples$parameters$samples) ) {
+      samples$parameters$samples <- ensemble.samples
+    }
     #------------------------End of generating ensembles-----------------------------------
     # find all inputs that have an id
     inputs <- names(settings$run$inputs)
@@ -418,7 +428,7 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
 
       } else {
 
-        run.id <- PEcAn.utils::get.run.id("ENS", PEcAn.utils::left.pad.zeros(i, 5), site.id=settings$run$site$id)
+        run.id <- PEcAn.utils::get.run.id("ENS", PEcAn.utils::left.pad.zeros(i, 5), site.id = settings$run$site$id)
 
       }
       runs[i, "id"] <- run.id
@@ -444,7 +454,7 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
       # build dynamic input info string
       input_info <- ""
       #changing the structure of input tag to what the models are expecting
-      for(input_i in seq_along(settings$run$inputs)){
+      for (input_i in seq_along(settings$run$inputs)) {
         input_tag <- names(settings$run$inputs)[[input_i]]
         if (!is.null(samples[[input_tag]])) {
           settings$run$inputs[[input_tag]][["path"]] <-
@@ -471,33 +481,36 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
           "hostname    : ", settings$host$name, "\n",
           "rundir      : ", file.path(settings$host$rundir, run.id), "\n",
           "outdir      : ", file.path(settings$host$outdir, run.id), "\n",
-          file = file.path(settings$rundir, run.id, "README.txt"))
-
-
-      
-    #changing the structure of input tag to what the models are expecting
-    for (input_i in seq_along(settings$run$inputs)) {
-            input_tag <- names(settings$run$inputs)[[input_i]]
-            input <- settings$run$inputs[[input_tag]]
-  
-  
-     if (!input_tag %in% names(samples)) {
-        # Use first path (already validated as single path)
-        settings$run$inputs[[input_tag]]$path <- unlist(input$path[1])} 
-        else {
-           # Use sampled path
-          settings$run$inputs[[input_tag]]$path <- samples[[input_tag]][["samples"]][[i]]
-  }
-
-}
-
-
-      
-      do.call(my.write.config, args = list( defaults = defaults, 
-                                            trait.values = lapply(samples$parameters$samples, function(x, n) { x[n, , drop=FALSE] }, n=i), # this is the params
-                                            settings = settings,
-                                            run.id = run.id
+          file = file.path(settings$rundir, run.id, "README.txt")
       )
+
+
+
+      #changing the structure of input tag to what the models are expecting
+      for (input_i in seq_along(settings$run$inputs)) {
+        input_tag <- names(settings$run$inputs)[[input_i]]
+        input <- settings$run$inputs[[input_tag]]
+
+        if (!input_tag %in% names(samples)) {
+          # Use first path (already validated as single path)
+          settings$run$inputs[[input_tag]]$path <- unlist(input$path[1])
+        } else {
+          # Use sampled path
+          settings$run$inputs[[input_tag]]$path <- samples[[input_tag]][["samples"]][[i]]
+        }
+      }
+
+
+
+      do.call(my.write.config,
+              args = list(
+                defaults = defaults,
+                trait.values = lapply(samples$parameters$samples, # this is the params
+                                      function(x, n) { x[n, , drop = FALSE] },
+                                      n = i),
+                settings = settings,
+                run.id = run.id
+              )
       )
       cat(format(run.id, scientific = FALSE), file = file.path(settings$rundir, "runs.txt"), sep = "\n", append = TRUE)
 
@@ -513,23 +526,31 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
     ensemble.id <- restart$ensemble.id
 
     # Reading the site.pft specific tags from xml
-    site.pfts.vec <- settings$run$site$site.pft %>% unlist %>% as.character
-    
-    if(!is.null(site.pfts.vec)){
+    site.pfts.vec <- settings$run$site$site.pft %>%
+      unlist() %>%
+      as.character()
+
+    if (!is.null(site.pfts.vec)) {
       # find the name of pfts defined in the body of pecan.xml
       defined.pfts <- settings$pfts %>% purrr::map('name') %>% unlist %>% as.character
       # subset ensemble samples based on the pfts that are specified in the site and they are also sampled from.
-      if (length(which(site.pfts.vec %in% defined.pfts)) > 0 )
-        new.params <- new.params %>% purrr::map(~list(.x[[which(site.pfts.vec %in% defined.pfts)]],restart=.x$restart))
+      if (length(which(site.pfts.vec %in% defined.pfts)) > 0 ) {
+        new.params <- new.params %>% purrr::map(~list(.x[[which(site.pfts.vec %in% defined.pfts)]],restart = .x$restart))
+      }
       # warn if there is a pft specified in the site but it's not defined in the pecan xml.
-      if (length(which(!(site.pfts.vec %in% defined.pfts)))>0) 
-        PEcAn.logger::logger.warn(paste0("The following pfts are specified for the siteid ", settings$run$site$id ," but they are not defined as a pft in pecan.xml:",
-                                         site.pfts.vec[which(!(site.pfts.vec %in% defined.pfts))]))
+      if (length(which(!(site.pfts.vec %in% defined.pfts)))>0) {
+        PEcAn.logger::logger.warn(
+          "The following pfts are specified for the siteid ",
+          settings$run$site$id ,
+          " but they are not defined as a pft in pecan.xml:",
+          site.pfts.vec[which(!(site.pfts.vec %in% defined.pfts))]
+        )
+      }
     }
 
     #if ensemble folders do not exist create them
-    for(j in 1:length(run.id)){
-      if(!file.exists(file.path(settings$rundir, run.id[[j]]))){
+    for (j in 1:length(run.id)) {
+      if (!file.exists(file.path(settings$rundir, run.id[[j]]))) {
         dir.create(file.path(settings$rundir, run.id[[j]]))
       }
     }
@@ -540,15 +561,16 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
       for (input_tag in names(inputs)) {
         # if it's the parameter list, skip.
         if (input_tag == "parameters") next
-        if (!is.null(inputs[[input_tag]]$samples[[i]])) 
+        if (!is.null(inputs[[input_tag]]$samples[[i]])) {
           input_list[[input_tag]] <- list(path = inputs[[input_tag]]$samples[[i]])
+        }
       }
 
       do.call(my.write_restart,
               args =  list(outdir = settings$host$outdir,
                            runid = run.id[[i]],
                            start.time = restart$start.time,
-                           stop.time =restart$stop.time,
+                           stop.time = restart$stop.time,
                            settings = settings,
                            new.state = new.state[i, ],
                            new.params = new.params[[i]], #new.params$`646`[[i]] for debugging
@@ -566,8 +588,13 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
         stringsAsFactors = FALSE
       ))
     }
-    params<-new.params
-    return(invisible(list(runs = data.frame(id=run.id), ensemble.id = ensemble.id, samples=inputs, manifest=manifest_df)))
+    params <- new.params
+    return(invisible(
+      list(runs = data.frame(id = run.id),
+           ensemble.id = ensemble.id,
+           samples = inputs,
+           manifest = manifest_df)
+    ))
   }
 
 } # write.ensemble.configs

--- a/modules/uncertainty/R/get.parameter.samples.R
+++ b/modules/uncertainty/R/get.parameter.samples.R
@@ -94,8 +94,6 @@ get.parameter.samples <- function(settings,
 
   ## Load PFT priors and posteriors
   for (i in seq_along(pft.names)) {
-    distns <- new.env()
-
     ## Load posteriors using unified loader
     ## Detects posterior type by content (not filename).
     ## Monte Carlo samples take precedence over distribution summaries.
@@ -107,15 +105,12 @@ get.parameter.samples <- function(settings,
       hostname = settings$host$name
     )
 
-    # Populate the distns environment for downstream compatibility
     if (!is.null(posterior$prior.distns)) {
-      distns$prior.distns <- posterior$prior.distns
+      prior_distns_list[[i]] <- posterior$prior.distns
     }
-    prior_distns_list[[i]] <- distns$prior.distns
 
     if (!is.null(posterior$trait.mcmc)) {
-      distns$trait.mcmc <- posterior$trait.mcmc
-      trait_mcmc_list[[i]] <- distns$trait.mcmc
+      trait_mcmc_list[[i]] <- posterior$trait.mcmc
       ma.results <- TRUE
       # Joint posteriors (e.g. from PDA) should preserve correlations
       if (posterior$is.joint) {
@@ -123,7 +118,7 @@ get.parameter.samples <- function(settings,
       }
     } else {
       ma.results <- FALSE
-      # trait_mcmc_list[[i]] stays NULL (already initialized)
+      # trait_mcmc_list[[i]] stays NULL
     }
   } ### End for loop
 
@@ -134,8 +129,7 @@ get.parameter.samples <- function(settings,
     trait_mcmc_list   = trait_mcmc_list,
     ensemble.size     = ensemble.size,
     ens.sample.method = ens.sample.method,
-    sa_quantiles      = if ("sensitivity.analysis" %in% names(settings))
-                          settings$sensitivity.analysis$quantiles else NULL,
+    sa_quantiles      = settings$sensitivity.analysis$quantiles, # which is NULL if no SA requested
     do_ensemble       = "ensemble" %in% names(settings),
     independent       = independent
   )

--- a/modules/uncertainty/man/get.ensemble.samples.Rd
+++ b/modules/uncertainty/man/get.ensemble.samples.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/ensemble.R
 \name{get.ensemble.samples}
 \alias{get.ensemble.samples}
-\title{Get Ensemble Samples}
+\title{Get parameter values used in ensemble}
 \usage{
 get.ensemble.samples(
   ensemble.size,
@@ -30,10 +30,7 @@ get.ensemble.samples(
 matrix of (quasi-)random samples from trait distributions
 }
 \description{
-Get parameter values used in ensemble
-}
-\details{
-Returns a matrix of randomly or quasi-randomly sampled trait values 
+Returns a matrix of randomly or quasi-randomly sampled trait values
 to be assigned to traits over several model runs.
 given the number of model runs and a list of sample distributions for traits
 The model run is indexed first by model run, then by trait

--- a/modules/uncertainty/man/input.ens.gen.Rd
+++ b/modules/uncertainty/man/input.ens.gen.Rd
@@ -37,7 +37,7 @@ parent_ids to this function.
 \dontrun{
   settings <- PEcAn.settings::read.settings("pecan.xml")
   input.ens.gen(
-    settings, 
+    settings,
     ensemble_size = 50,
     input = "met",
     method = "sampling"

--- a/modules/uncertainty/man/read.ensemble.output.Rd
+++ b/modules/uncertainty/man/read.ensemble.output.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/ensemble.R
 \name{read.ensemble.output}
 \alias{read.ensemble.output}
-\title{Read ensemble output}
+\title{Reads output from model ensemble}
 \usage{
 read.ensemble.output(
   ensemble.size,
@@ -34,10 +34,7 @@ If NULL, will attempt to read IDs from a file named "samples.Rdata" in \code{pec
 a list of ensemble model output
 }
 \description{
-Reads output from model ensemble
-}
-\details{
-Reads output for an ensemble of length specified by \code{ensemble.size} and bounded by \code{start.year} 
+Reads output for an ensemble of length specified by \code{ensemble.size} and bounded by \code{start.year}
 and \code{end.year}
 }
 \author{

--- a/modules/uncertainty/man/write.ensemble.configs.Rd
+++ b/modules/uncertainty/man/write.ensemble.configs.Rd
@@ -38,22 +38,33 @@ extra rows are ignored.}
 
 \item{write.to.db}{logical: Record this run in BETY?}
 
-\item{restart}{In case this is a continuation of an old simulation. restart needs to be a list with name tags of runid, inputs, new.params (parameters), new.state (initial condition), ensemble.id (ensemble id), start.time and stop.time.See Details.}
+\item{restart}{In case this is a continuation of an old simulation.
+Needs to be a list with name tags of runid, inputs, new.params (parameters),
+new.state (initial condition), ensemble.id (ensemble id), start.time and stop.time.
+See Details.}
 
 \item{rename}{Decide if we want to rename previous output files, for example convert from sipnet.out to sipnet.2020-07-16.out.}
 }
 \value{
-list, containing $runs = data frame of runids, $ensemble.id = the ensemble ID for these runs and $samples with ids and samples used for each tag.  Also writes sensitivity analysis configuration files as a side effect
+list, containing
+ $runs = data frame of runids,
+ $ensemble.id = the ensemble ID for these runs,
+ and $samples with ids and samples used for each tag.
+ Also writes sensitivity analysis configuration files as a side effect
 }
 \description{
 Writes config files for use in meta-analysis and returns a list of run ids.
-Given a pft.xml object, a list of lists as supplied by get.sa.samples, 
+Given a pft.xml object, a list of lists as supplied by get.sa.samples,
 a name to distinguish the output files, and the directory to place the files.
 }
 \details{
-The restart functionality is developed using model specific functions by calling write_restart.modelname function. First, you need to make sure that this function is already exist for your desired model.See here \url{https://pecanproject.github.io/pecan-documentation/latest/pecan-models.html}
-new state is a dataframe with a different column for each state variable. The number of the rows in this dataframe needs to be the same as the ensemble size.
-The state variables that you can use for setting up initial conditions are model specific. Check the documentation of the write_restart.<modelname> function for the model you are using.
+The restart functionality is developed using model specific functions by calling write_restart.modelname function.
+First, you need to make sure that this function is already exist for your desired model.
+See here \url{https://pecanproject.github.io/pecan-documentation/latest/pecan-models.html}.
+new state is a dataframe with a different column for each state variable.
+The number of the rows in this dataframe needs to be the same as the ensemble size.
+The state variables that you can use for setting up initial conditions are model specific.
+Check the documentation of the write_restart.<modelname> function for the model you are using.
 The units for the state variables need to be in the PEcAn standard units which can be found in \link[PEcAn.utils]{standard_vars}.
 new.params also has similar structure to ensemble.samples which is sent as an argument.
 }

--- a/modules/uncertainty/tests/testthat/test-get_parameter_samples.R
+++ b/modules/uncertainty/tests/testthat/test-get_parameter_samples.R
@@ -160,6 +160,9 @@ test_that("multiple PFTs are handled correctly", {
   expect_true("conifer"  %in% names(result$trait.samples))
   expect_true("SLA"   %in% names(result$trait.samples[["hardwood"]]))
   expect_true("Vcmax" %in% names(result$trait.samples[["conifer"]]))
+  expect_false("SLA"   %in% names(result$trait.samples[["conifer"]]))
+  expect_false("Vcmax" %in% names(result$trait.samples[["hardwood"]]))
+
 })
 
 


### PR DESCRIPTION
One real bug, one unneeded intermediate object, and a bunch of formatting fixed while trying to find the problem:

* The real bug: In get.parameter.samples, `prior_distns_list[[i]] <- distns$prior.distns` was dropping list entries when `distns$prior.distns` was NULL, and therefore causing get_parameter_samples to (correctly!) fail its assertion that `length(prior_distns_list) == length(pfts)`. This is because R interprets `somelist[i] <- NULL` as "remove entry i from somelist entirely, shortening the list as needed" rather than "make the value at position i be null".
* The uneeded object: The temporary `distns` environment is no longer needed now that `load_posteriors` encapsulates all the file reading for us. Changed to assign directly from `posteriors` into the distn lists.
* The formatting: Before I tracked the issue into get.parameter.samples I spent some time being confused by missing braces and inconsistent indentation in get.ensemble.samples, so I committed some formatting fixes as I went. I recommend reviewing with "hide whitespace" turned on. If I did this right, the changes in ensemble.R will have zero functional effect.