### PR TITLE
workaround for reading challenging sipnet.outs

### DIFF
--- a/models/sipnet/R/model2netcdf.SIPNET.R
+++ b/models/sipnet/R/model2netcdf.SIPNET.R
@@ -74,8 +74,8 @@ model2netcdf.SIPNET <- function(outdir, sitelat, sitelon, start_date, end_date, 
       "Trying to parse output manually."
     )
     raw_lines <- readLines(sipnet_out_file)
-    raw_header <- raw_lines[[1]]
-    raw_body <- tail(raw_lines, -1)
+    raw_header <- raw_lines[[1 + skip_n]]
+    raw_body <- tail(raw_lines, -(1 + skip_n))
     # SIPNET output is right-aligned with the column names in the header.
     # We use this to figure out where the numbers end if there are no spaces.
     token_matches <- gregexpr("\\S+", raw_header, perl = TRUE)
@@ -370,7 +370,6 @@ model2netcdf.SIPNET <- function(outdir, sitelat, sitelon, start_date, end_date, 
   }
 } # model2netcdf.SIPNET
 #--------------------------------------------------------------------------------------------------#
-### EOF
 
 # Helper Function 
 
@@ -396,9 +395,3 @@ sipnet2datetime <- function(year, doy, hour){
   
   as.POSIXct(datetime)
 }
-
-
-
-
-
-

--- a/models/sipnet/R/model2netcdf.SIPNET.R
+++ b/models/sipnet/R/model2netcdf.SIPNET.R
@@ -64,7 +64,34 @@ model2netcdf.SIPNET <- function(outdir, sitelat, sitelon, start_date, end_date, 
   # if the first line starts with "year", there is no Notes line.
   first_line <- readLines(sipnet_out_file, n = 1)
   skip_n <- if (grepl("^year", first_line)) 0 else 1
-  sipnet_output <- utils::read.table(sipnet_out_file, header = T, skip = skip_n, sep = "")
+  # Temporary workaround until
+  # https://github.com/PecanProject/sipnet/issues/304 is resolved.
+  sipnet_output <- tryCatch({
+    utils::read.table(sipnet_out_file, header = TRUE, skip = skip_n, sep = "")
+  }, error = function(err) {
+    PEcAn.logger::logger.warn(
+      "Failed to read using `read.table`. ",
+      "Trying to parse output manually."
+    )
+    raw_lines <- readLines(sipnet_out_file)
+    raw_header <- raw_lines[[1]]
+    raw_body <- tail(raw_lines, -1)
+    # SIPNET output is right-aligned with the column names in the header.
+    # We use this to figure out where the numbers end if there are no spaces.
+    token_matches <- gregexpr("\\S+", raw_header, perl = TRUE)
+    proc_header <- regmatches(raw_header, token_matches)[[1]]
+    col_ends <- token_matches[[1]] + attr(token_matches[[1]], "match.length") - 1
+    col_starts <- c(1, head(col_ends, -1) + 1)
+    col_widths <- col_ends - col_starts + 1
+    result <- read.fwf(
+      textConnection(raw_body),
+      widths = col_widths,
+      col.names = proc_header,
+      na.strings = c("nan", "-nan")
+    )
+    result[] <- lapply(result, as.numeric)
+    result
+  })
   #sipnet_output_dims <- dim(sipnet_output)
   
   ### Determine number of years and output timestep

--- a/models/sipnet/R/model2netcdf.SIPNET.R
+++ b/models/sipnet/R/model2netcdf.SIPNET.R
@@ -75,7 +75,7 @@ model2netcdf.SIPNET <- function(outdir, sitelat, sitelon, start_date, end_date, 
     )
     raw_lines <- readLines(sipnet_out_file)
     raw_header <- raw_lines[[1 + skip_n]]
-    raw_body <- tail(raw_lines, -(1 + skip_n))
+    raw_body <- utils::tail(raw_lines, -(1 + skip_n))
     # SIPNET output is right-aligned with the column names in the header.
     # We use this to figure out where the numbers end if there are no spaces.
     token_matches <- gregexpr("\\S+", raw_header, perl = TRUE)
@@ -83,7 +83,7 @@ model2netcdf.SIPNET <- function(outdir, sitelat, sitelon, start_date, end_date, 
     col_ends <- token_matches[[1]] + attr(token_matches[[1]], "match.length") - 1
     col_starts <- c(1, head(col_ends, -1) + 1)
     col_widths <- col_ends - col_starts + 1
-    result <- read.fwf(
+    result <- utils::read.fwf(
       textConnection(raw_body),
       widths = col_widths,
       col.names = proc_header,

--- a/models/sipnet/R/model2netcdf.SIPNET.R
+++ b/models/sipnet/R/model2netcdf.SIPNET.R
@@ -81,7 +81,7 @@ model2netcdf.SIPNET <- function(outdir, sitelat, sitelon, start_date, end_date, 
     token_matches <- gregexpr("\\S+", raw_header, perl = TRUE)
     proc_header <- regmatches(raw_header, token_matches)[[1]]
     col_ends <- token_matches[[1]] + attr(token_matches[[1]], "match.length") - 1
-    col_starts <- c(1, head(col_ends, -1) + 1)
+    col_starts <- c(1, utils::head(col_ends, -1) + 1)
     col_widths <- col_ends - col_starts + 1
     result <- utils::read.fwf(
       textConnection(raw_body),


### PR DESCRIPTION
Try to read `sipnet.out` via `utils::read.table` by default. However, if that fails, fall back to a less efficient way that can handle weirdness like this (note: spaces between ch4 and nppStorage have been eaten up):

```
nUptake      ch4  nppStorage  bcdeltaC  bcdeltaN
   -nan     -nan-100031.5842      -nan      -nan
   -nan     -nan-100250.3078      -nan      -nan
   -nan     -nan-100560.4010      -nan      -nan
   -nan     -nan-100886.9315      -nan      -nan
   -nan     -nan-101101.1909      -nan      -nan
```

See https://github.com/PecanProject/sipnet/issues/304 for justification. Once that's resolved, we should replace this with a more reliable reader.