### PR TITLE
Update non-CRAN dependency declarations to match current R-universe expectations

### DIFF
--- a/docker/depends/pecan_deps_from_github.txt
+++ b/docker/depends/pecan_deps_from_github.txt
@@ -4,8 +4,8 @@ araiho/linkages_package
 chuhousen/amerifluxr
 ebimodeling/biocro@0.951
 RemkoDuursma/Maeswrap
+ropensci-archive/nneo
 ropensci/geonames
-ropensci/nneo
 ropensci/traits
 SticsRPacks/SticsOnR
 SticsRPacks/SticsRFiles

--- a/docker/depends/pecan_package_dependencies.csv
+++ b/docker/depends/pecan_package_dependencies.csv
@@ -604,6 +604,7 @@
 "stats","*","modules/data.remote","Suggests",FALSE
 "stats","*","modules/photosynthesis","Imports",FALSE
 "stats","*","modules/rtm","Imports",FALSE
+"SticsOnR","*","models/stics","Suggests",FALSE
 "SticsRFiles","*","models/stics","Suggests",FALSE
 "stringi","*","base/logger","Imports",FALSE
 "stringi","*","base/utils","Imports",FALSE

--- a/docker/depends/pecan_package_dependencies.csv
+++ b/docker/depends/pecan_package_dependencies.csv
@@ -268,7 +268,7 @@
 "neonstore","*","modules/data.land","Suggests",FALSE
 "neonUtilities","*","modules/data.land","Suggests",FALSE
 "nimble","*","modules/assim.sequential","Imports",FALSE
-"nneo","*","modules/data.atmosphere","Imports",FALSE
+"nneo","*","modules/data.atmosphere","Suggests",FALSE
 "optparse","*","base/settings","Imports",FALSE
 "parallel","*","modules/assim.batch","Imports",FALSE
 "parallel","*","modules/data.atmosphere","Suggests",FALSE

--- a/models/stics/DESCRIPTION
+++ b/models/stics/DESCRIPTION
@@ -20,6 +20,7 @@ Imports:
     XML,
     dplyr
 Suggests:
+    SticsOnR,
     SticsRFiles,
     testthat (>= 1.0.2)
 Remotes:

--- a/modules/assim.batch/DESCRIPTION
+++ b/modules/assim.batch/DESCRIPTION
@@ -54,6 +54,8 @@ Suggests:
     knitr (>= 1.50),
     rmarkdown (>= 2.19),
     testthat (>= 1.0.2)
+Additional_repositories:
+    https://florianhartig.r-universe.dev/
 License: BSD_3_clause + file LICENSE
 Copyright: Authors
 LazyLoad: yes

--- a/modules/data.atmosphere/DESCRIPTION
+++ b/modules/data.atmosphere/DESCRIPTION
@@ -87,6 +87,9 @@ Remotes:
     github::chuhousen/amerifluxr,
     github::ropensci/geonames,
     github::ropensci-archive/nneo
+Additional_repositories:
+    https://ropensci.r-universe.dev/,
+    https://adokter.r-universe.dev
 License: BSD_3_clause + file LICENSE
 Copyright: Authors
 LazyLoad: yes

--- a/modules/data.atmosphere/DESCRIPTION
+++ b/modules/data.atmosphere/DESCRIPTION
@@ -41,7 +41,6 @@ Imports:
     MASS,
     mgcv,
     ncdf4 (>= 1.15),
-    nneo,
     PEcAn.DB,
     PEcAn.logger,
     PEcAn.remote,
@@ -75,6 +74,7 @@ Suggests:
     ggplot2,
     knitr (>= 1.50),
     mockery,
+    nneo,
     parallel,
     PEcAn.settings,
     progress,
@@ -86,7 +86,7 @@ Remotes:
     github::adokter/suntools,
     github::chuhousen/amerifluxr,
     github::ropensci/geonames,
-    github::ropensci/nneo
+    github::ropensci-archive/nneo
 License: BSD_3_clause + file LICENSE
 Copyright: Authors
 LazyLoad: yes

--- a/modules/data.atmosphere/NEWS.md
+++ b/modules/data.atmosphere/NEWS.md
@@ -10,6 +10,7 @@
 * Updated `download.NOAA_GEFS` to work with the current (v12.3) release of GEFS (#3349).
 
 ## Changed
+* Dependency `nneo`, used by `download.NEONmet`, is now suggested rather than required. Caution: `nneo` is unmaintained, has been archived by its author on GitHub, and may be removed from a future PEcAn release.
 * Dependency `ggplot2` is now suggested rather than required. It is used in two vignettes and for optional diagnostic plots from `debias_met_regression`.
 * `download.ERA5_cds` now downloads NetCDF directly (replacing internal conversion from grib) using the R package ecmwfr (replacing python dependency on cdsapi via reticulate) (#3547).
 * `download.ERA5.cds()` now requires a valid Copernicus CDS API key, replacing the previous `.netrc` authentication. See the [ecmwfr package documentation](https://bluegreen-labs.github.io/ecmwfr/) for details.

--- a/modules/data.atmosphere/R/download.NEONmet.R
+++ b/modules/data.atmosphere/R/download.NEONmet.R
@@ -26,6 +26,8 @@
 download.NEONmet <- function(sitename, outfolder, start_date, end_date, 
                                   overwrite = FALSE, verbose = FALSE,  ...) {
 
+  PEcAn.utils::need_packages("nneo")
+
   if (!file.exists(outfolder)) {
     dir.create(outfolder)
   }

--- a/modules/data.atmosphere/tests/Rcheck_reference.log
+++ b/modules/data.atmosphere/tests/Rcheck_reference.log
@@ -9,7 +9,7 @@
 * package encoding: UTF-8
 * checking package namespace information ... OK
 * checking package dependencies ... NOTE
-Imports includes 38 non-default packages.
+Imports includes 37 non-default packages.
 Importing from so many packages makes the package vulnerable to any of
 them becoming unavailable.  Move as many as possible to Suggests and
 use conditionally.


### PR DESCRIPTION
R-universe has [stopped pulling in dependencies from the Remotes field](https://github.com/r-universe-org/help/issues/676), and now requires either a CRAN-like URL in `Additional_repositories` (e.g. for packages that exist in another universe) or for us to manually add each dependency to the pecanproject.r-universe.dev package manifest (as I've [now done](https://github.com/PecanProject/pecanproject.r-universe.dev/commit/cf075bb9d8d9a433794c9d2246023ff636f7b754 ) for our GitHub-only deps). Here I added CRANlikes for those that have them, updated the GitHub URL for nneo and moved it to Suggests, and added a missing Suggests declaration for SticsOnR so that r-universe will find it.