### PR TITLE
Optimize debias model training by removing extra GridSearchCV refit and vectorizing RMSE blend-weight search. Fixes Issue Number #3907

### DIFF
--- a/modules/assim.sequential/inst/python/pecan_debias/debias.py
+++ b/modules/assim.sequential/inst/python/pecan_debias/debias.py
@@ -14,7 +14,7 @@ def _fit_knn(X, y):
     grid = GridSearchCV(
         pipe,
         {'kneighborsregressor__n_neighbors': list(range(1, 31))},
-        cv=max(2, min(5, len(y))),
+        cv=min(5, max(2, len(y)//2)),
         scoring='neg_root_mean_squared_error',
         n_jobs=-1
     )
@@ -35,13 +35,12 @@ def _fit_extratrees(X, y):
     base = ExtraTreesRegressor(random_state=42, n_jobs=-1)
     grid = GridSearchCV(
         base, param_grid,
-        cv=max(2, min(5, len(y))),
+        cv=min(5, max(2, len(y)//2)),
         scoring='neg_root_mean_squared_error',
         n_jobs=-1
     )
     grid.fit(X, y)
     tree = grid.best_estimator_
-    tree.fit(X, y)
     return tree
 
 def _fit_one(X, y):
@@ -51,11 +50,10 @@ def _fit_one(X, y):
     knn_pred  = knn.predict(X)
     tree_pred = tree.predict(X)
     weights = np.linspace(0, 1, 101)
-    best_w, best_rmse = 0.5, np.inf
-    for w in weights:
-        rmse = np.sqrt(mean_squared_error(y, w*knn_pred + (1-w)*tree_pred))
-        if rmse < best_rmse:
-            best_rmse, best_w = rmse, w
+    # replacing the loop based RMSE search over blend weights with a vectorised approach.
+    preds = weights[:, None]*knn_pred[None, :]+(1-weights[:, None])*tree_pred[None, :]
+    rmses = np.sqrt(((preds-y)**2).mean(axis=1))
+    best_w = weights[np.argmin(rmses)]
     return knn, tree, float(best_w)
 
 def train_full_model(name, X, y, feature_names=None):


### PR DESCRIPTION
This PR makes a few small improvements to the debias model training file under modules/assim.sequential/python/pecan_debias/debias.py:

- removes an extra `tree.fit(X, y)` under `_fit_extratrees()` function on the ExtraTreesRegressor after `GridSearchCV`, since GridSearchCV already refits the best estimator by default (refit=True).
- replaces the loop-based RMSE blend-weight search with a NumPy vectorized implementation
- adjusts cross-validation fold selection to behave properly for small datasets using  `cv = min(5, max(2, len(y)//2))`.

These changes do not modify model outputs but reduce unnecessary computation and improve stability when working with smaller datasets.

## Motivation and Context

This PR addresses #3907.

The ExtraTrees model was being refit after `GridSearchCV`, even though `GridSearchCV` already refits the selected estimator. Removing this avoids duplicate computation.

The blend-weight search previously used a Python loop over candidate weights. Vectorizing this step improves readability and efficiency.

The updated CV logic keeps the number of folds reasonable when the number of samples is small, which helps avoid unstable splits.

## Review Time Estimate

- [x] When possible

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue) (#Issue Number #3907)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [x] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.