### PR TITLE
write.events: Avoid hanging on event files with large number of validation errors

### DIFF
--- a/models/sipnet/R/write.events.SIPNET.R
+++ b/models/sipnet/R/write.events.SIPNET.R
@@ -44,8 +44,10 @@
 #' @export
 write.events.SIPNET <- function(events_json, outdir) {
     # Validate input JSON against PEcAn events schema
+    # TRUE = valid; FALSE = invalid; NA = jsonvalidate package not installed,
+    # proceed without complaining
     valid <- PEcAn.data.land::validate_events_json(events_json, verbose = FALSE)
-    if (!valid) {
+    if (isFALSE(valid)) {
         PEcAn.logger::logger.error(
             "Invalid events file. More details may be available by calling",
             "PEcAn.data.land::validate_events_json(", shQuote(events_json), ")"

--- a/models/sipnet/R/write.events.SIPNET.R
+++ b/models/sipnet/R/write.events.SIPNET.R
@@ -73,17 +73,19 @@ write.events.SIPNET <- function(events_json, outdir) {
         evs <- site$events
         # Order by date and build lines
         dates <- as.Date(vapply(evs, function(e) as.character(e$date), character(1)))
+        years <- as.integer(format(dates, "%Y"))
+        days <- as.integer(format(dates, "%j"))
         ord <- order(dates)
-        lines <- character()
-        for (e in evs[ord]) {
-            d <- as.Date(e$date)
-            year <- as.integer(format(d, "%Y"))
-            day <- as.integer(format(d, "%j"))
+        lines <- character(length(ord))
+        for (i in ord) {
+            e <- evs[[i]]
+            year <- years[[i]]
+            day <- days[[i]]
             type <- e$event_type
             if (type == "tillage") {
                 f <- if (is.null(e$tillage_eff_0to1)) 0 else e$tillage_eff_0to1
                 # TODO: consider validating up front against schema rather than here
-                lines <- c(lines, sprintf("%d  %d  till  %s", year, day, f))
+                lines[i] <- sprintf("%d  %d  till  %s", year, day, f)
             } else if (type == "planting") {
                 # infer total planted biomass from leaf pool and allocation fraction
                 leaf_g <- as.numeric(if (is.null(e$leaf_c_kg_m2)) 0 else e$leaf_c_kg_m2) * kg2g
@@ -91,31 +93,28 @@ write.events.SIPNET <- function(events_json, outdir) {
                 wood_g <- woodAllocation * total_g
                 fr_g <- fineRootAllocation * total_g
                 cr_g <- coarseRootAllocation * total_g
-                lines <- c(lines, sprintf("%d  %d  plant  %s %s %s %s", year, day, leaf_g, wood_g, fr_g, cr_g))
+                lines[i] <- sprintf("%d  %d  plant  %s %s %s %s", year, day, leaf_g, wood_g, fr_g, cr_g)
             } else if (type == "fertilization") {
                 orgN_g <- as.numeric(if (is.null(e$org_n_kg_m2)) 0 else e$org_n_kg_m2) * kg2g
                 orgC_g <- as.numeric(if (is.null(e$org_c_kg_m2)) 0 else e$org_c_kg_m2) * kg2g
                 nh4_g <- as.numeric(if (is.null(e$nh4_n_kg_m2)) 0 else e$nh4_n_kg_m2) * kg2g
                 no3_g <- as.numeric(if (is.null(e$no3_n_kg_m2)) 0 else e$no3_n_kg_m2) * kg2g
                 minN_g <- nh4_g + no3_g
-                lines <- c(lines, sprintf("%d  %d  fert   %s %s %s", year, day, orgN_g, orgC_g, minN_g))
+                lines[i] <- sprintf("%d  %d  fert   %s %s %s", year, day, orgN_g, orgC_g, minN_g)
             } else if (type == "irrigation") {
                 amt_cm <- as.numeric(if (is.null(e$amount_mm)) 0 else e$amount_mm) * mm2cm
                 method_code <- if (is.null(e$method) || e$method == "soil") 1 else 0
-                lines <- c(lines, sprintf("%d  %d  irrig  %s %s", year, day, amt_cm, method_code))
+                lines[i] <- sprintf("%d  %d  irrig  %s %s", year, day, amt_cm, method_code)
             } else if (type == "harvest") {
                 abv_rem <- e$frac_above_removed_0to1 %||% 0
                 blw_rem <- e$frac_below_removed_0to1 %||% 0
                 abv_lit <- e$frac_above_to_litter_0to1 %||% (1.0 - abv_rem)
                 blw_lit <- e$frac_below_to_litter_0to1 %||% (1.0 - blw_rem)
-                lines <- c(
-                    lines,
-                    sprintf(
-                        "%d  %d harv   %s %s %s %s",
-                        year, day,
-                        abv_rem, blw_rem,
-                        abv_lit, blw_lit
-                    )
+                lines[i] <- sprintf(
+                    "%d  %d harv   %s %s %s %s",
+                    year, day,
+                    abv_rem, blw_rem,
+                    abv_lit, blw_lit
                 )
             }
         }

--- a/models/sipnet/R/write.events.SIPNET.R
+++ b/models/sipnet/R/write.events.SIPNET.R
@@ -44,7 +44,13 @@
 #' @export
 write.events.SIPNET <- function(events_json, outdir) {
     # Validate input JSON against PEcAn events schema
-    PEcAn.data.land::validate_events_json(events_json)
+    valid <- PEcAn.data.land::validate_events_json(events_json, verbose = FALSE)
+    if (!valid) {
+        PEcAn.logger::logger.error(
+            "Invalid events file. More details may be available by calling",
+            "PEcAn.data.land::validate_events_json(", shQuote(events_json), ")"
+        )
+    }
 
     # TODO add overwrite argument
     x <- jsonlite::fromJSON(events_json, simplifyVector = FALSE)

--- a/modules/data.land/R/validate_events.R
+++ b/modules/data.land/R/validate_events.R
@@ -11,8 +11,11 @@
 #'
 #' @param events_json character. Path to the JSON file to validate.
 #' @param verbose logical. When `TRUE`, include detailed AJV messages on error.
+#' @param max_errs integer. Print only this many validation errors.
+#'  To see the rest, use the `errors` attribute of the return value.
 #'
-#' @return Logical TRUE if valid, FALSE if invalid.
+#' @return Logical TRUE if valid. If invalid, FALSE with an attribute "errors"
+#'  containing a dataframe of reported problems.
 #' NA if validator unavailable.
 #'
 #' @author David LeBauer
@@ -22,7 +25,7 @@
 #' #                                package = "PEcAn.data.land"))
 #'
 #' @export
-validate_events_json <- function(events_json, verbose = TRUE) {
+validate_events_json <- function(events_json, verbose = TRUE, max_errs = 50) {
   if (!file.exists(events_json)) {
     PEcAn.logger::logger.error(glue::glue("events_json file does not exist: {events_json}"))
     return(FALSE)
@@ -44,11 +47,13 @@ validate_events_json <- function(events_json, verbose = TRUE) {
   detail <- if (is.null(errs)) {
     "<no details>"
   } else {
+    errs <- head(errs, max_errs)
     paste(sprintf(
       "%s: %s",
       ifelse(nzchar(errs$instancePath), errs$instancePath, "<root>"), errs$message
     ), collapse = "; ")
   }
   PEcAn.logger::logger.error(glue::glue("events_json does not conform to schema: {events_json}; {detail}"))
-  FALSE
+
+  ok
 }

--- a/modules/data.land/R/validate_events.R
+++ b/modules/data.land/R/validate_events.R
@@ -47,7 +47,7 @@ validate_events_json <- function(events_json, verbose = TRUE, max_errs = 50) {
   detail <- if (is.null(errs)) {
     "<no details>"
   } else {
-    errs <- head(errs, max_errs)
+    errs <- utils::head(errs, max_errs)
     paste(sprintf(
       "%s: %s",
       ifelse(nzchar(errs$instancePath), errs$instancePath, "<root>"), errs$message

--- a/modules/data.land/man/validate_events_json.Rd
+++ b/modules/data.land/man/validate_events_json.Rd
@@ -4,15 +4,19 @@
 \alias{validate_events_json}
 \title{Validate PEcAn events JSON against schema v0.1.0}
 \usage{
-validate_events_json(events_json, verbose = TRUE)
+validate_events_json(events_json, verbose = TRUE, max_errs = 50)
 }
 \arguments{
 \item{events_json}{character. Path to the JSON file to validate.}
 
 \item{verbose}{logical. When `TRUE`, include detailed AJV messages on error.}
+
+\item{max_errs}{integer. Print only this many validation errors.
+To see the rest, use the `errors` attribute of the return value.}
 }
 \value{
-Logical TRUE if valid, FALSE if invalid.
+Logical TRUE if valid. If invalid, FALSE with an attribute "errors"
+ containing a dataframe of reported problems.
 NA if validator unavailable.
 }
 \description{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
Noticed on a file that returned more than 150k(!) errors, for which `json_validate` does finish after about 25 seconds but then `validate_events_json` hangs forever trying to paste all the errors together into a single error message.

Attacked this in two places:

(1) inside write.events.SIPNET, call `validate_events_json` with verbose = FALSE for a quick result and advise users to call `validate_events_json` directly for more details.
(2) inside validate_events_json, only print the first n (default 50) errors and return the full error object as an attribute (same as json_validate does) for anyone who wants the thousands of gory details.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
