### PR TITLE
feat: add lightweight `clean-src` Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ depends = .doc/$(1) .install/$(1) .check/$(1) .test/$(1)
 
 ### Rules
 
-.PHONY: all install check test document clean shiny pkgdocs \
+.PHONY: all install check test document clean clean-src shiny pkgdocs \
             check_base check_models check_modules help
 
 all: install document
@@ -140,6 +140,12 @@ clean:
 		find "$$p" \( -name \*.mod -o -name \*.o -o -name \*.so \) -delete; \
 	done
 
+clean-src:
+	@echo "Removing compiled source artifacts..."
+	for p in $(SRCS_TO_CLEAN); do \
+		find "$$p" \( -name \*.mod -o -name \*.o -o -name \*.so \) -delete; \
+	done
+
 help:
 	@echo "Usage: make [target]"
 	@echo ""
@@ -167,6 +173,7 @@ help:
 	@echo "  book           Render the PEcAn bookdown documentation"
 	@echo "  pkgdocs        Build package documentation websites using pkgdown"
 	@echo "  clean          Remove build artifacts"
+	@echo "  clean-src      Remove compiled source artifacts (.o, .so, .mod) without full rebuild"
 	@echo "  help           Show this help message"
 
 ### Dependencies


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
Adds a lightweight `clean-src` Makefile target that removes compiled source artifacts (`.o`, `.so`, `.mod`) without deleting `.install`, `.check`, `.test`, or `.doc` directories. 

Avoids unnecessary rebuilds when only compiled objects are stale
## Testing

Verified locally: using `make clean-src` followed by `make` reduced rebuild time to 3 to 4 minutes compared to a full clean rebuild.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
