### PR TITLE
avoid Bety connection attempt on pft lookup with no db

### DIFF
--- a/modules/uncertainty/NEWS.md
+++ b/modules/uncertainty/NEWS.md
@@ -5,6 +5,7 @@
 sensitivity analysis. This function ensures non-parameter inputs
 (met, IC, soil) are held constant, which is required for valid 
 variance decomposition in one-at-a-time (OAT) sensitivity analysis (#3729)
+* `get.parameter.samples()` now consistently accepts PFTs with no `outdir` specified. These previously failed when no database connection was available.
 
 
 

--- a/modules/uncertainty/R/get.parameter.samples.R
+++ b/modules/uncertainty/R/get.parameter.samples.R
@@ -71,7 +71,7 @@ get.parameter.samples <- function(settings,
     ### Get output directory info
     if (!is.null(pfts[[i.pft]]$outdir)) {
       outdirs[i.pft] <- pfts[[i.pft]]$outdir
-    } else {
+    } else if (!is.null(con)) {
       outdirs[i.pft] <- unique(
         PEcAn.DB::dbfile.check(
           type = "Posterior",
@@ -79,7 +79,8 @@ get.parameter.samples <- function(settings,
           con = con
         )$file_path
       )
-    }
+    } # else do nothing: outdirs[i.pft] stays NULL and load.posteriors will handle it
+
   } ### End of for loop to extract pft names
 
   PEcAn.logger::logger.info("Selected PFT(s): ", pft.names)

--- a/modules/uncertainty/R/load_posteriors.R
+++ b/modules/uncertainty/R/load_posteriors.R
@@ -291,5 +291,12 @@ load.posteriors.legacy <- function(outdir = NULL,
     }
   }
 
+  if (is.null(result$prior.distns) && is.null(result$trait.mcmc)) {
+    PEcAn.logger::logger.warn(
+      "No posteriors found: outdir =", shQuote(outdir),
+      "posteriorid =", shQuote(posteriorid)
+    )
+  }
+
   return(result)
 }


### PR DESCRIPTION
killing off yet another place our ability to run without Bety was secretly conditional on one specific run configuration: PFTs with only a`settings$pfts$[pft]$posterior.files` and no `settings$pfts$[pft]$outdir` are allowed (in fact encouraged) now, but leaving outdir unset was making get.parameter.samples attempt a database lookup.

Also added a warning if we fall all the way through load_posteriors without finding any values.