### PR TITLE
Fix posterior pagination URL and workflow zip download logic

### DIFF
--- a/apps/api/R/posteriors.R
+++ b/apps/api/R/posteriors.R
@@ -104,7 +104,7 @@ searchPosteriors <- function(req, pft_id = NA, host_id = NA,
       result$prev_page <- paste0(
         req$rook.url_scheme, "://",
         req$HTTP_HOST,
-        "/api/workflows",
+        "/api/posteriors",
         req$PATH_INFO,
         substr(req$QUERY_STRING,
                0,

--- a/apps/api/R/workflows.R
+++ b/apps/api/R/workflows.R
@@ -312,7 +312,9 @@ getWorkflowFilesAsZip <- function(req, id, filenames, res){
 
       full_files[i] <- filepath
     }
-    zip_file <- zip::zipr("output.zip", full_files)
-    return(zip_file)
+    zip_path <- zip::zipr("output.zip", full_files)
+    bin <- readBin(zip_path, "raw", n = file.info(zip_path)$size)
+    file.remove(zip_path)
+    return(bin)
   }
 }


### PR DESCRIPTION
Found a couple of functional bugs while going through the API code:

> error in posteriors.R: In searchPosteriors, the prev_page URL was pointing to the /api/workflows endpoint instead of /api/posteriors. I've updated this to use the correct path.

> Broken zip download in workflows.R: The getWorkflowFilesAsZip function was returning the filename string "output.zip" rather than the actual binary content. I updated it to use readBin() so the API correctly serves the file, and added file.remove() to clean up the temporary zip after it's sent.