### PR TITLE
fix logical operator in dbfile.move type check

### DIFF
--- a/base/db/R/dbfiles.R
+++ b/base/db/R/dbfiles.R
@@ -766,7 +766,7 @@ dbfile.move <- function(old.dir, new.dir, file.type, siteid = NULL, register = F
   files.indb <- 0
 
   # check for file type and update to make it *.file type
-  if (file.type != "clim" | file.type != "nc") {
+  if (file.type != "clim" && file.type != "nc") {
     PEcAn.logger::logger.error("File type not supported by move at this time. Currently only supports NC and CLIM files")
     error <- 1
   }


### PR DESCRIPTION
dbfile.move was using | instead of && in the file type check, which made the condition always true and caused the error block to fire for both valid inputs. Changed to &&.

Part of #3937