### PR TITLE
Do conversions tests

### DIFF
--- a/base/workflow/tests/testthat/test.do_conversions.R
+++ b/base/workflow/tests/testthat/test.do_conversions.R
@@ -29,3 +29,99 @@ test_that("`do_conversions` able to call met.process if the input tag has met, u
     expect_true(file.exists(file.path(getwd(), "pecan.METProcess.xml")))
   })
 })
+
+test_that("`do_conversions` silently converts character inputs to NULL", {
+  withr::with_tempdir({
+    settings <- list(
+      host = list(name = "localhost"),
+      outdir = getwd(),
+      database = list(dbfiles = getwd()),
+      run = list(inputs = "some_legacy_string")
+    )
+    # Should not error, and inputs should be treated as NULL (loop skipped)
+    ret <- do_conversions(settings)
+    # needsave stays FALSE, no METProcess.xml written, settings returned as-is
+    expect_false(file.exists(file.path(getwd(), "pecan.METProcess.xml")))
+  })
+})
+
+test_that("`do_conversions` skips input when path exists and force is NULL", {
+  withr::with_tempdir({
+    mocked_met <- mockery::mock(list(path = "should_not_be_called"))
+    mockery::stub(do_conversions, "PEcAn.data.atmosphere::met.process", mocked_met)
+    settings <- list(
+      host = list(name = "localhost"),
+      database = list(dbfiles = getwd()),
+      outdir = getwd(),
+      run = list(
+        site = list(id = 0),
+        inputs = list(met = list(path = "/existing/path"))  # path exists, force is NULL
+      )
+    )
+    ret <- do_conversions(settings)
+    # met.process should NOT have been called
+    mockery::expect_called(mocked_met, 0)
+    # path should be unchanged
+    expect_equal(ret$run$inputs$met$path, "/existing/path")
+    # needsave FALSE so no xml written
+    expect_false(file.exists(file.path(getwd(), "pecan.METProcess.xml")))
+  })
+})
+
+test_that("`do_conversions` does NOT skip input when path exists but force is set", {
+  withr::with_tempdir({
+    mocked_met <- mockery::mock(list(path = "new_path"))
+    mockery::stub(do_conversions, "PEcAn.data.atmosphere::met.process", mocked_met)
+    mockery::stub(do_conversions, "PEcAn.utils::status.check", mockery::mock(0))
+    settings <- list(
+      host = list(name = "localhost"),
+      database = list(dbfiles = getwd()),
+      outdir = getwd(),
+      run = list(
+        site = list(id = 0),
+        inputs = list(met = list(path = "/existing/path", force = TRUE))
+      )
+    )
+    ret <- do_conversions(settings)
+    # met.process SHOULD have been called because force is set
+    mockery::expect_called(mocked_met, 1)
+    expect_equal(ret$run$inputs$met$path, "new_path")
+  })
+})
+
+test_that("`do_conversions` returns settings unchanged when inputs is empty list", {
+  withr::with_tempdir({
+    settings <- list(
+      host = list(name = "localhost"),
+      outdir = getwd(),
+      database = list(dbfiles = getwd()),
+      run = list(inputs = list())
+    )
+    ret <- do_conversions(settings)
+    # Empty inputs — needsave stays FALSE, no xml written
+    expect_false(file.exists(file.path(getwd(), "pecan.METProcess.xml")))
+    expect_equal(ret$run$inputs, list())
+  })
+})
+
+test_that("`do_conversions` reads pecan.METProcess.xml when needsave is FALSE and file exists", {
+  withr::with_tempdir({
+    # Write a settings xml with a sentinel value
+    xml_path <- file.path(getwd(), "pecan.METProcess.xml")
+    writeLines(
+      "<pecan>
+        <outdir>sentinel_value</outdir>
+      </pecan>",
+      xml_path
+    )
+    settings <- list(
+      host = list(name = "localhost"),
+      outdir = getwd(),
+      database = list(dbfiles = getwd()),
+      run = list(inputs = list())  # empty inputs → needsave stays FALSE
+    )
+    ret <- do_conversions(settings)
+    # Should have read from xml and returned the sentinel value
+    expect_equal(ret$outdir, "sentinel_value")
+  })
+})


### PR DESCRIPTION
## New tests cover:
- character inputs silently coerced to NULL (legacy fallback)
- skip logic when input path exists and force is NULL
- force flag overrides skip logic
- empty inputs list returns settings unchanged
- reads pecan.METProcess.xml when needsave is FALSE


## Tests added

| Test | Why |
|---|---|
| character inputs → NULL | character inputs being silently coerced to NULL (legacy fallback) |
| skip when path exists + force is NULL | skip logic when an input already has a path and force is NULL |
| no skip when force is set | force flag overriding the skip logic |
| empty inputs list → no XML written | empty inputs list returning settings unchanged |
| reads pecan.METProcess.xml via empty inputs | reading pecan.METProcess.xml via the empty-inputs entry path |

## Notes
- No production code was changed, tests only
- Tests 4 and 5 are intentionally paired — they pin both
  sides of the path/force branch condition together
- Tests 1 and 7 both cover the XML read path but via
  different entry conditions, confirming the behavior is
  robust across routes into that branch

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
