### PR TITLE
fix(tests): remove duplicate <sensitivity.analysis> block in migration-test-ebi-forecast.xml

### DIFF
--- a/tests/migration-test-ebi-forecast.xml
+++ b/tests/migration-test-ebi-forecast.xml
@@ -34,15 +34,6 @@
     </quantiles>
     <variable>NPP</variable>
   </sensitivity.analysis>
-  
-    <sensitivity.analysis>
-    <quantiles>
-      <sigma>-1</sigma>
-      <sigma>1</sigma>
-    </quantiles>
-    <variable>NPP</variable>
-  </sensitivity.analysis>
-
 
   <model>
     <binary>/home/kooper/bin/sipnet.runk</binary>


### PR DESCRIPTION
Fixes #3959 

The <sensitivity.analysis> block in tests/migration-test-ebi-forecast.xml 
was written twice back to back. Removed the second occurrence.

just cleanup.