### PR TITLE
model2netcdf.SIPNET: Fix SoilMoistFrac units

### DIFF
--- a/models/sipnet/R/model2netcdf.SIPNET.R
+++ b/models/sipnet/R/model2netcdf.SIPNET.R
@@ -128,7 +128,7 @@ model2netcdf.SIPNET <- function(outdir, sitelat, sitelon, start_date, end_date, 
       # Water pools
       dplyr::across(
         .cols = c(
-          dplyr::all_of(c("soilWater", "soilWetnessFrac", "snow")),
+          dplyr::all_of(c("soilWater", "snow")),
           dplyr::any_of("litterWater") # Only present in V1 output
         ),
         .fns = cm_to_mm

--- a/models/sipnet/tests/testthat/test-model2netcdf.SIPNET.R
+++ b/models/sipnet/tests/testthat/test-model2netcdf.SIPNET.R
@@ -202,7 +202,7 @@ test_that("pools are converted from gC/m2 to kgC/m2", {
   out_dir <- setup_sipnet_test(sip)$outdir
   pec <- PEcAn.utils::read.output(
     ncfiles = file.path(out_dir, "2002.nc"),
-    variables = c("litter_carbon_content", "SoilMoist"),
+    variables = c("litter_carbon_content", "SoilMoist", "SoilMoistFrac"),
     dataframe = TRUE,
     verbose = FALSE,
     print_summary = FALSE
@@ -210,6 +210,7 @@ test_that("pools are converted from gC/m2 to kgC/m2", {
 
   expect_equal(pec$litter_carbon_content, sip$litter / 1000) # g -> kg
   expect_equal(pec$SoilMoist, sip$soilWater * 10) # cm -> mm AKA kg H2O/m2
+  expect_equal(pec$SoilMoistFrac, sip$soilWetnessFrac) # no conversion needed
 })
 
 test_that("fluxes are converted from gC/m2/timestep to kg/m2/sec", {


### PR DESCRIPTION
Fixing a thinko I introduced in #3925: Soil wetness fraction does not need a unit conversion when writing to netCDF.
