### PR TITLE
restart workflow: use inital PFT, return null if no segments

### DIFF
--- a/modules/data.land/R/events_to_crop_cycle_starts.R
+++ b/modules/data.land/R/events_to_crop_cycle_starts.R
@@ -6,30 +6,31 @@
 #' These are the dates when single-PFT models will need to restart to update
 #' their crop parameterization.
 #'
-#' TODO: For now this function requires each planting event to specify a
-#' `crop` attribute, but note that this is not enforced by v0.1 of the PEcAn
-#' events schema. The schema instead allows each site object to specify a
-#' site-level `PFT` attribute that is implied constant over time.
-#' As I write this I think the schema may need to change to require a crop or
-#' PFT identifier be specified for every planting event.
+#' Requires each planting event to specify a `crop_code` attribute,
+#' and reports a crop cycle change every time the crop code changes.
+#' Note that crop codes are not required to match your model's PFT names,
+#' so deciding how (or whether) to change parameterization on these dates
+#' is up to the model operator.
+#'
+#' Also note that only _changes_ in crop code are detected:
+#' If the event file contains no planting events the result has zero rows,
+#' and any crop present before the first observed planting event
+#' (say from initial conditions) is not reported.
 #'
 #' @param event_json path to an `events.json` file
 #'
 #' @return data frame with columns `site_id`, `date`, `crop`,
 #'  with one row per detected crop cycle.
-#' @export
 #' @author Chris Black
 #'
 #' @examples
-#' # Not currently runnable because file does not list crop in planting events.
-#' # Revisit after deciding if schema update is warranted.
-#' \dontrun{
 #' evts <- system.file(
 #'   "events_fixtures/events_site1_site2.json",
 #'   package = "PEcAn.data.land"
 #' )
 #' events_to_crop_cycle_starts(evts)
-#' }
+#'
+#' @export
 events_to_crop_cycle_starts <- function(event_json) {
   jsonlite::read_json(event_json) |>
     dplyr::bind_rows() |>

--- a/modules/data.land/man/events_to_crop_cycle_starts.Rd
+++ b/modules/data.land/man/events_to_crop_cycle_starts.Rd
@@ -29,15 +29,12 @@ As I write this I think the schema may need to change to require a crop or
 PFT identifier be specified for every planting event.
 }
 \examples{
-# Not currently runnable because file does not list crop in planting events.
-# Revisit after deciding if schema update is warranted.
-\dontrun{
 evts <- system.file(
   "events_fixtures/events_site1_site2.json",
   package = "PEcAn.data.land"
 )
 events_to_crop_cycle_starts(evts)
-}
+
 }
 \author{
 Chris Black

--- a/modules/data.land/man/events_to_crop_cycle_starts.Rd
+++ b/modules/data.land/man/events_to_crop_cycle_starts.Rd
@@ -21,12 +21,16 @@ These are the dates when single-PFT models will need to restart to update
 their crop parameterization.
 }
 \details{
-TODO: For now this function requires each planting event to specify a
-`crop` attribute, but note that this is not enforced by v0.1 of the PEcAn
-events schema. The schema instead allows each site object to specify a
-site-level `PFT` attribute that is implied constant over time.
-As I write this I think the schema may need to change to require a crop or
-PFT identifier be specified for every planting event.
+Requires each planting event to specify a `crop_code` attribute,
+and reports a crop cycle change every time the crop code changes.
+Note that crop codes are not required to match your model's PFT names,
+so deciding how (or whether) to change parameterization on these dates
+is up to the model operator.
+
+Also note that only _changes_ in crop code are detected:
+If the event file contains no planting events the result has zero rows,
+and any crop present before the first observed planting event
+(say from initial conditions) is not reported.
 }
 \examples{
 evts <- system.file(

--- a/workflows/sipnet-restart-workflow/utils.R
+++ b/workflows/sipnet-restart-workflow/utils.R
@@ -106,14 +106,22 @@ segment_dataframe <- function(run_settings) {
       end_date = dplyr::lead(.data$start_date - 1, default = run_end),
     )
 
+  if(nrow(segments) == 0) {
+    # No restarts to be scheduled
+    return(segments)
+  }
+
   # If we start *before* the first planting, add a segment for that.
   if (run_start < min(segments[["start_date"]])) {
     first_segment <- tibble::tibble(
-      crop_cycle_id = 0,
       site_id = segments[["site_id"]][[1]],
       start_date = run_start,
       end_date = segments[["start_date"]][[1]] - 1,
-      crop_code = NA_character_
+      crop_code = NA_character_,
+      # Brittle assumption alert:
+      # Expects site.pft to be a list with names `veg`, `soil`.
+      # Nothing else in PEcAn enforces these names.
+      pft = run_settings$run$site$site.pft$veg %||% NA_character_
     )
     segments <- dplyr::bind_rows(first_segment, segments)
   }
@@ -162,9 +170,18 @@ write_segment_configs <- function(
   i_param <- run_row[["param"]] %||% 1
   run_traits <- lapply(ensemble_samples, \(dat) dat[i_param, ])
 
-  segments <- segment_dataframe(run_settings) |>
+  segments <- segment_dataframe(run_settings)
+
+  if (nrow(segments) == 0) {
+    # No restarts needed. Return path to unaltered full-run script.
+    return(file.path(run_dir, "job.sh"))
+  }
+
+  segments <- segments |>
+    # Adds an all-NA pft column if needed without clobbering one that exists already
+    dplyr::bind_rows(tibble::tibble(pft = character())) |>
     dplyr::mutate(
-      pft = crop2pft(.data$crop_code),
+      pft = dplyr::coalesce(.data$pft, crop2pft(.data$crop_code)),
       segment_dir = file.path(segment_rootdir, sprintf("segment_%s", .data$segment_id))
     )
   write.csv(segments, file = file.path(run_dir, "segments.csv"), row.names = FALSE)


### PR DESCRIPTION
* When no restarts are detected, return immediately and let the unsegmented job.sh run normally
* Use `site.pft` as the crop type for the initial segment if it's specified
* Doc tweaks to events_to_crop_cycle_starts