### PR TITLE
events_to_crop_cycle_starts: avoid slow unnest of full events file

### DIFF
--- a/modules/data.land/R/events_to_crop_cycle_starts.R
+++ b/modules/data.land/R/events_to_crop_cycle_starts.R
@@ -33,24 +33,46 @@
 #' @export
 events_to_crop_cycle_starts <- function(event_json) {
   jsonlite::read_json(event_json) |>
-    dplyr::bind_rows() |>
-    dplyr::mutate(events = purrr::map(.data$events, as.data.frame)) |>
-    tidyr::unnest("events") |>
-    dplyr::filter(.data$event_type %in% c("planting", "harvest")) |>
+    purrr::map_dfr(get_plantings) |>
     dplyr::mutate(date = as.Date(.data$date)) |>
-    dplyr::arrange(.data$date) |>
     find_crop_changes()
 }
+
+
+
+# Pull date and crop code out of planting events,
+# ignoring all other event types
+get_plantings <- function(site) {
+  is_planting <- vapply(X = site$events,
+                     FUN = \(x) x$event_type == "planting",
+                     FUN.VALUE = logical(1))
+  if(!any(is_planting)) {
+    return(data.frame())
+  }
+  dates <- vapply(X = site$events[is_planting],
+                  FUN = `[[`,
+                  FUN.VALUE = character(1),
+                  "date")
+  codes <- vapply(X = site$events[is_planting],
+                  FUN = `[[`,
+                  FUN.VALUE = character(1),
+                  "crop_code")
+
+  data.frame(site_id = site$site_id, date = dates, crop_code = codes)
+}
+
+
+
 
 # helper for events_to_crop_cyle_starts,
 # mostly to ease unit testing
 find_crop_changes <- function(event_df) {
+  if ("event_type" %in% colnames(event_df)) {
+    event_df <- dplyr::filter(event_df, .data$event_type == "planting")
+  }
   event_df |>
-    dplyr::filter(.data$event_type == "planting") |>
     dplyr::arrange(.data$site_id, .data$date) |>
     dplyr::mutate(crop_cycle_id = dplyr::consecutive_id(.data$site_id, .data$crop_code)) |>
-    dplyr::group_by(.data$site_id, .data$crop_cycle_id) |>
-    dplyr::slice_min(.data$date) |>
-    dplyr::ungroup() |>
+    dplyr::slice_min(.data$date, by = c("site_id", "crop_cycle_id")) |>
     dplyr::select("site_id", "date", "crop_code")
 }


### PR DESCRIPTION
In large multisite runs, the existing code turns out to be very slow because it starts by materializing a single dataframe of all events from all sites before filtering back down to only two columns from only the plantings.  With this patch the segmentation stage of my 594-run test workflow dropped from 100 minutes(!) to 9 minutes.

In a separate future PR we could likely get a further speedup by refactoring the segmentation pipeline to call events_to_crop_cycle_starts once per JSON file and reuse it for every site, rather than the current design of reading it fresh each time. For my test case (with a single event json for all 594 runs) that will have a big payoff, but will need some attention to make sure it works right for workflows with separate jsons per site or ensemble member.