### PR TITLE
write.events.SIPNET: Handle leafon+leafoff, warn on unknown event types

### DIFF
--- a/models/sipnet/R/write.events.SIPNET.R
+++ b/models/sipnet/R/write.events.SIPNET.R
@@ -122,6 +122,14 @@ write.events.SIPNET <- function(events_json, outdir) {
                     abv_rem, blw_rem,
                     abv_lit, blw_lit
                 )
+            } else if (type == "leafon") {
+                lines[i] <- sprintf("%d  %d  leafon", year, day)
+            } else if (type == "leafoff") {
+                lines[i] <- sprintf("%d  %d  leafoff", year, day)
+            } else {
+                PEcAn.logger::logger.warn(
+                    "unknown event type", sQuote(type), "at year", year, "day", day
+                )
             }
         }
         dir.create(outdir, showWarnings = FALSE, recursive = TRUE)


### PR DESCRIPTION
Carrying phenology event support through from JSON (#3971) into events.in files.