### PR TITLE
fix: Bug fix for invalid indices in `input.ens.gen`

### DIFF
--- a/modules/uncertainty/R/ensemble.R
+++ b/modules/uncertainty/R/ensemble.R
@@ -642,14 +642,12 @@ input.ens.gen <- function(settings, ensemble_size, input, method = "sampling", p
   }
 
   if (!is.null(parent_ids)) {
+    # parent_ids enforces 1:1 mapping between parent and child runs.
+    stopifnot(
+      length(parent_ids$ids) == ensemble_size,
+      all(parent_ids$ids %in% seq_along(input_path))
+    )
     samples$ids <- parent_ids$ids
-    out.of.sample.size <- length(samples$ids[samples$ids > length(input_path)])
-    # sample for those that our outside the param size -
-    # for example, parent id may send id number 200 but we have only 100 sample for param
-    samples$ids[samples$ids %in% out.of.sample.size] <- sample(
-      seq_along(input_path),
-      out.of.sample.size,
-      replace = TRUE)
   } else if (tolower(method) == "sampling") {
     samples$ids <- sample(
       seq_along(input_path),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
Fixes #3980 

The `parent_ids` block in `input.ens.gen` was computing `out.of.sample.size` as a scalar count but then using it as a vector of indices in `%in%`, causing the wrong elements to be replaced while the actual out-of-range indices stayed as `NA`.

The entire silent-replacement block is removed. `input.ens.gen` now validates that `parent_ids` has the correct length and all indices are in range, erroring immediately if not.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
