### PR TITLE
input.ens.gen: Parent handling improvements

### DIFF
--- a/modules/uncertainty/NEWS.md
+++ b/modules/uncertainty/NEWS.md
@@ -1,7 +1,10 @@
 # PEcAn.uncertainty 1.9.0.9000
 
-* `input.ens.gen()` no longer skips inputs that have a parent but no sampling method.
-  Additionally, argument `parent_ids` now accepts integer vectors even if not wrapped in a list (#3780).
+* Multiple bugfixes in `input.ens.gen()` handling of parent ids (#3783):
+    - No longer skips inputs that have a parent but no sampling method.
+    - Argument `parent_ids` now accepts integer vectors even if not wrapped in a list.
+    - New argument `bad_parent_action` chooses how to handle parent ids that do not match an input path:
+      default "error" to stop with an error, "resample" to replace invalid indices from the input paths that do exist.
 * run.ensemble.analysis() now respects `settings$modeloutdir` rather than assuming an `out/` folder inside `settings$outdir` (@Akash-paluvai, #3722).
 * Added `generate_OAT_SA_design()` for creating input design matrices for
 sensitivity analysis. This function ensures non-parameter inputs

--- a/modules/uncertainty/NEWS.md
+++ b/modules/uncertainty/NEWS.md
@@ -1,5 +1,7 @@
 # PEcAn.uncertainty 1.9.0.9000
 
+* `input.ens.gen()` no longer skips inputs that have a parent but no sampling method.
+  Additionally, argument `parent_ids` now accepts integer vectors even if not wrapped in a list (#3780).
 * run.ensemble.analysis() now respects `settings$modeloutdir` rather than assuming an `out/` folder inside `settings$outdir` (@Akash-paluvai, #3722).
 * Added `generate_OAT_SA_design()` for creating input design matrices for
 sensitivity analysis. This function ensures non-parameter inputs

--- a/modules/uncertainty/R/ensemble.R
+++ b/modules/uncertainty/R/ensemble.R
@@ -618,19 +618,23 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
 #' and then pass those as parents to the soil moisture ensemble:
 #' `input.ens.gen(..., input = "soilmoist", parent_ids = met_ids)`.
 #'
-#' If `parent_ids` contains any indices larger than the length of the input
+#' If any indices in `parent_ids` are larger than the length of the input
 #' being sampled (e.g. `53` when the input only has 25 paths),
-#' the valid indices are currently used as-is and the invalid ones filled by
-#' sampling with replacement.
-#' We discourage relying on this behavior and it may change in the future:
-#' Parent to child mappings are intended to be strictly 1:1,
-#' so index mismatches are very likely to mean an error in the pairing.
+#' the result is determined by `bad_parent_action`:
+#' "error" stops execution and requests the user to fix their inputs,
+#' "resample" uses the valid parents as-is and replaces the invalid parents
+#' via method = "sampling".
+#' Note that method "resample" is provided for backwards compatibility;
+#' we strongly recommend validating parent-child alignment before calling
+#' `input.ens.gen`, ideally in the same process that generates your parent ids.
 #'
 #' @param settings list of PEcAn settings
 #' @param input name of input to sample, e.g. "met", "veg", "pss"
 #' @param method Method for sampling - For now looping or sampling with replacement is implemented
 #' @param parent_ids integer vector of indices to be used as-is
 #' @param ensemble_size size of ensemble
+#' @param bad_parent_action How to handle entries in `parent_id` that are not
+#'  valid indices into the paths given for this input. See details
 #'
 #' @return A list with elements `id` showing the order of sampling
 #'  and `samples` with the paths selected from those indices.
@@ -647,7 +651,12 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
 #'   )
 #' }
 #'
-input.ens.gen <- function(settings, ensemble_size, input, method = "sampling", parent_ids = NULL) {
+input.ens.gen <- function(settings,
+                          ensemble_size,
+                          input,
+                          method = "sampling",
+                          parent_ids = NULL,
+                          bad_parent_action = c("error", "resample")) {
 
   samples <- list()
   samples$ids <- c()
@@ -665,6 +674,7 @@ input.ens.gen <- function(settings, ensemble_size, input, method = "sampling", p
   }
 
   if (!is.null(parent_ids)) {
+    bad_parent_action <- match.arg(bad_parent_action)
 
     # Legacy support: versions through 1.9.0 expected parent_ids to be a list,
     # but only component `ids` was used
@@ -677,14 +687,23 @@ input.ens.gen <- function(settings, ensemble_size, input, method = "sampling", p
         "parent_ids must be an integer vector the same length as the ensemble")
     }
 
+    out.of.sample <- !(parent_ids %in% seq_along(input_path))
+    if (any(out.of.sample)) {
+      if (bad_parent_action == "error") {
+        PEcAn.logger::logger.error(
+          "parent_ids must be valid indices for input paths. Bad values:",
+          toString(parent_ids[out.of.sample])
+        )
+      } else if (bad_parent_action == "resample") {
+        # sample for those that are outside the param size -
+        # for example, parent id may send id number 200 but we have only 100 sample for param
+        parent_ids[out.of.sample] <- sample(
+          seq_along(input_path),
+          sum(out.of.sample),
+          replace = TRUE)
+      }
+    }
     samples$ids <- parent_ids
-    out.of.sample.size <- length(samples$ids[samples$ids > length(input_path)])
-    # sample for those that our outside the param size -
-    # for example, parent id may send id number 200 but we have only 100 sample for param
-    samples$ids[samples$ids %in% out.of.sample.size] <- sample(
-      seq_along(input_path),
-      out.of.sample.size,
-      replace = TRUE)
   } else if (tolower(method) == "sampling") {
     samples$ids <- sample(
       seq_along(input_path),

--- a/modules/uncertainty/R/ensemble.R
+++ b/modules/uncertainty/R/ensemble.R
@@ -601,17 +601,39 @@ write.ensemble.configs <- function(input_design , ensemble.size, defaults, ensem
 
 
 
-#' Function for generating samples based on sampling method, parent or etc
+#' Generate an ensemble of samples from one input
+#'
+#' Given an input containing paths to multiple files, this function samples
+#' from the given paths to make an ensemble of the requested size.
+#' If method is `sampling` they are sampled with replacement from the full set;
+#' if method is `looping` they are taken sequentially with the sequence
+#' repeating as needed.
+#'
+#' If `parent_ids` is provided, it is used as the indices for the current input.
+#' Use this when you have multiple inputs whose files should be sampled as a
+#' coordinated set.
+#' For example if your soil moisture files are matched to the rainfall amounts
+#' in your weather files, generate the met ensemble first
+#' (`met_ids <- input.ens.gen(..., input = "met", parent_ids = NULL)`)
+#' and then pass those as parents to the soil moisture ensemble:
+#' `input.ens.gen(..., input = "soilmoist", parent_ids = met_ids)`.
+#'
+#' If `parent_ids` contains any indices larger than the length of the input
+#' being sampled (e.g. `53` when the input only has 25 paths),
+#' the valid indices are currently used as-is and the invalid ones filled by
+#' sampling with replacement.
+#' We discourage relying on this behavior and it may change in the future:
+#' Parent to child mappings are intended to be strictly 1:1,
+#' so index mismatches are very likely to mean an error in the pairing.
 #'
 #' @param settings list of PEcAn settings
 #' @param input name of input to sample, e.g. "met", "veg", "pss"
 #' @param method Method for sampling - For now looping or sampling with replacement is implemented
-#' @param parent_ids This is basically the order of the paths that the parent is sampled.See Details.
+#' @param parent_ids integer vector of indices to be used as-is
 #' @param ensemble_size size of ensemble
 #'
-#' @return For a given input/tag in the pecan xml and a method, this function returns a list with $id showing the order of sampling and $samples with samples of that input.
-#' @details If for example met was a parent and it's sampling method resulted in choosing the first, third and fourth samples, these are the ids that need to be sent as
-#' parent_ids to this function.
+#' @return A list with elements `id` showing the order of sampling
+#'  and `samples` with the paths selected from those indices.
 #' @export
 #'
 #' @examples

--- a/modules/uncertainty/R/ensemble.R
+++ b/modules/uncertainty/R/ensemble.R
@@ -665,7 +665,19 @@ input.ens.gen <- function(settings, ensemble_size, input, method = "sampling", p
   }
 
   if (!is.null(parent_ids)) {
-    samples$ids <- parent_ids$ids
+
+    # Legacy support: versions through 1.9.0 expected parent_ids to be a list,
+    # but only component `ids` was used
+    if (is.list(parent_ids) && !is.null(parent_ids$ids)) {
+      parent_ids <- parent_ids$ids
+    }
+
+    if (length(parent_ids) != ensemble_size || !is.numeric(parent_ids)) {
+      PEcAn.logger::logger.error(
+        "parent_ids must be an integer vector the same length as the ensemble")
+    }
+
+    samples$ids <- parent_ids
     out.of.sample.size <- length(samples$ids[samples$ids > length(input_path)])
     # sample for those that our outside the param size -
     # for example, parent id may send id number 200 but we have only 100 sample for param

--- a/modules/uncertainty/R/ensemble.R
+++ b/modules/uncertainty/R/ensemble.R
@@ -652,7 +652,8 @@ input.ens.gen <- function(settings, ensemble_size, input, method = "sampling", p
   samples <- list()
   samples$ids <- c()
 
-  if (is.null(method)) return(NULL)
+  if (is.null(method) && is.null(parent_ids)) return(NULL)
+
   # parameter is exceptional it needs to be handled spearatly
   if (input == "parameters") return(NULL)
 

--- a/modules/uncertainty/man/input.ens.gen.Rd
+++ b/modules/uncertainty/man/input.ens.gen.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/ensemble.R
 \name{input.ens.gen}
 \alias{input.ens.gen}
-\title{Function for generating samples based on sampling method, parent or etc}
+\title{Generate an ensemble of samples from one input}
 \usage{
 input.ens.gen(
   settings,
@@ -21,17 +21,36 @@ input.ens.gen(
 
 \item{method}{Method for sampling - For now looping or sampling with replacement is implemented}
 
-\item{parent_ids}{This is basically the order of the paths that the parent is sampled.See Details.}
+\item{parent_ids}{integer vector of indices to be used as-is}
 }
 \value{
-For a given input/tag in the pecan xml and a method, this function returns a list with $id showing the order of sampling and $samples with samples of that input.
+A list with elements `id` showing the order of sampling
+ and `samples` with the paths selected from those indices.
 }
 \description{
-Function for generating samples based on sampling method, parent or etc
+Given an input containing paths to multiple files, this function samples
+from the given paths to make an ensemble of the requested size.
+If method is `sampling` they are sampled with replacement from the full set;
+if method is `looping` they are taken sequentially with the sequence
+repeating as needed.
 }
 \details{
-If for example met was a parent and it's sampling method resulted in choosing the first, third and fourth samples, these are the ids that need to be sent as
-parent_ids to this function.
+If `parent_ids` is provided, it is used as the indices for the current input.
+Use this when you have multiple inputs whose files should be sampled as a
+coordinated set.
+For example if your soil moisture files are matched to the rainfall amounts
+in your weather files, generate the met ensemble first
+(`met_ids <- input.ens.gen(..., input = "met", parent_ids = NULL)`)
+and then pass those as parents to the soil moisture ensemble:
+`input.ens.gen(..., input = "soilmoist", parent_ids = met_ids)`.
+
+If `parent_ids` contains any indices larger than the length of the input
+being sampled (e.g. `53` when the input only has 25 paths),
+the valid indices are currently used as-is and the invalid ones filled by
+sampling with replacement.
+We discourage relying on this behavior and it may change in the future:
+Parent to child mappings are intended to be strictly 1:1,
+so index mismatches are very likely to mean an error in the pairing.
 }
 \examples{
 \dontrun{

--- a/modules/uncertainty/man/input.ens.gen.Rd
+++ b/modules/uncertainty/man/input.ens.gen.Rd
@@ -9,7 +9,8 @@ input.ens.gen(
   ensemble_size,
   input,
   method = "sampling",
-  parent_ids = NULL
+  parent_ids = NULL,
+  bad_parent_action = c("error", "resample")
 )
 }
 \arguments{
@@ -22,6 +23,9 @@ input.ens.gen(
 \item{method}{Method for sampling - For now looping or sampling with replacement is implemented}
 
 \item{parent_ids}{integer vector of indices to be used as-is}
+
+\item{bad_parent_action}{How to handle entries in `parent_id` that are not
+valid indices into the paths given for this input. See details}
 }
 \value{
 A list with elements `id` showing the order of sampling
@@ -44,13 +48,15 @@ in your weather files, generate the met ensemble first
 and then pass those as parents to the soil moisture ensemble:
 `input.ens.gen(..., input = "soilmoist", parent_ids = met_ids)`.
 
-If `parent_ids` contains any indices larger than the length of the input
+If any indices in `parent_ids` are larger than the length of the input
 being sampled (e.g. `53` when the input only has 25 paths),
-the valid indices are currently used as-is and the invalid ones filled by
-sampling with replacement.
-We discourage relying on this behavior and it may change in the future:
-Parent to child mappings are intended to be strictly 1:1,
-so index mismatches are very likely to mean an error in the pairing.
+the result is determined by `bad_parent_action`:
+"error" stops execution and requests the user to fix their inputs,
+"resample" uses the valid parents as-is and replaces the invalid parents
+via method = "sampling".
+Note that method "resample" is provided for backwards compatibility;
+we strongly recommend validating parent-child alignment before calling
+`input.ens.gen`, ideally in the same process that generates your parent ids.
 }
 \examples{
 \dontrun{

--- a/modules/uncertainty/tests/testthat/test-input.ens.gen.R
+++ b/modules/uncertainty/tests/testthat/test-input.ens.gen.R
@@ -34,17 +34,24 @@ test_that("complains on length mismatch", {
 })
 
 
-# This is legacy behavior that we may want to remove!
-# But meanwhile it was implemented on purpose and we shouldn't break it
-# accidentally.
-test_that("takes samples to replace invalid parent indices", {
+test_that("bad parent action", {
   s <- list()
   s$run$inputs$a$path <- paste0(1:10, ".nc")
 
-  res <- input.ens.gen(s, ensemble_size = 10, input = "a", parent_ids = 6:15)
-  expect_equal(res$ids[1:5], 6:10)
-  expect_true(all(res$ids[6:10] %in% 1:10))
+  res_samp <- input.ens.gen(s, ensemble_size = 10, input = "a",
+                            parent_ids = 6:15,
+                            bad_parent_action = "resample")
+  expect_equal(res_samp$ids[1:5], 6:10)
+  expect_true(all(res_samp$ids[6:10] %in% 1:10))
 
+  res_err <- capture.output(
+    input.ens.gen(s, ensemble_size = 4, input = "a",
+                  parent_ids = c(1, NA, 3, 11),
+                  bad_parent_action = "error"),
+    type = "message"
+  )
+  expect_match(res_err, "must be valid indices", all = FALSE)
+  expect_match(res_err, "NA, 11", all = FALSE)
 })
 
 test_that("parent ids used even when no sampling method given", {

--- a/modules/uncertainty/tests/testthat/test-input.ens.gen.R
+++ b/modules/uncertainty/tests/testthat/test-input.ens.gen.R
@@ -1,0 +1,65 @@
+
+test_that("child gets parent ids", {
+  s <- list()
+  s$run$inputs$met$path <- paste0(1:50, ".clim")
+
+  parent_idx <- sample(20, replace = TRUE)
+  child_idx <- input.ens.gen(s, ensemble_size = 20,
+                             input = "met", parent_ids = parent_idx)
+
+  expect_equal(parent_idx, child_idx$ids)
+})
+
+test_that("parent ids accepted as vector or as list for compatibility", {
+  s <- list()
+  s$run$inputs$soil$path <- paste0(1:20, ".csv")
+
+  expect_identical(
+    input.ens.gen(s, ensemble_size = 20, input = "soil", parent_ids = 1:20),
+    input.ens.gen(s, ensemble_size = 20, input = "soil",
+                  parent_ids = list(ids = 1:20))
+  )
+})
+
+test_that("complains on length mismatch", {
+  s <- list()
+  s$run$inputs$soil$path <- paste0(1:20, ".csv")
+
+  res <- capture.output(
+    input.ens.gen(s, ensemble_size = 10, input = "soil", parent_ids = 1:3),
+    type = "message"
+  )
+
+  expect_match(res, "same length as the ensemble", all = FALSE)
+})
+
+
+# This is legacy behavior that we may want to remove!
+# But meanwhile it was implemented on purpose and we shouldn't break it
+# accidentally.
+test_that("takes samples to replace invalid parent indices", {
+  s <- list()
+  s$run$inputs$a$path <- paste0(1:10, ".nc")
+
+  res <- input.ens.gen(s, ensemble_size = 10, input = "a", parent_ids = 6:15)
+  expect_equal(res$ids[1:5], 6:10)
+  expect_true(all(res$ids[6:10] %in% 1:10))
+
+})
+
+test_that("parent ids used even when no sampling method given", {
+  s <- list()
+  s$run$inputs$met$path <- paste0(1:10, ".nc")
+
+  parents <- c(1, 7, 5, 2)
+
+  for (method in list("sampling", "looping", NULL)) {
+    res <- input.ens.gen(s,
+                         ensemble_size = 4,
+                         input = "met",
+                         method = method,
+                         parent_ids = parents)
+    expect_equal(res$ids, parents)
+  }
+})
+

--- a/modules/uncertainty/tests/testthat/test_ensemble.R
+++ b/modules/uncertainty/tests/testthat/test_ensemble.R
@@ -4,16 +4,6 @@ library(testthat)
 # Mock a model write.configs function to avoid model-specific errors
 write.configs.SIPNET <- function(...) TRUE
 
-# Helper: make input with correct structure
-make_input_sets <- function(paths) {
-  lapply(paths, function(p) list(path = p))
-}
-
-# Helper: make ensemble.samples with the correct structure
-make_samples <- function(samples) {
-  lapply(paths, function(p) list(path = p))
-}
-
 # 1. One input, no samples → should pass
 test_that("1 input, no samples: passes", {
   settings <- list(run = list(inputs = list(input = list(path = "IC1"))))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
* No longer skips inputs with a parent but not sampling method
* Now accepts `parent_ids` as a plain integer vector instead of requiring list(ids=vec)
* Fixes #3980 and adds new options `bad_parent_action` to control behavior.
* Edited function documentation for clarity
* Added unit tests
