### PR TITLE
read.output: Return empty df if no files when dataframe=TRUE

### DIFF
--- a/base/utils/R/read.output.R
+++ b/base/utils/R/read.output.R
@@ -293,7 +293,13 @@ read.output <- function(runid, outdir,
     }
   }
 
-  model <- as.data.frame(result) # put into a data.frame
+  model <- as.data.frame(result)
+  if (nofiles) {
+    colnames(model) <- variables
+    model[["posix"]] <- NA
+    model[["year"]] <- NA
+    return(model)
+  }
   model[["posix"]] <- as.POSIXct(model[["posix"]], origin = run_origin, tz = "UTC")
   model[["year"]] <- lubridate::year(model[["posix"]])
 

--- a/base/utils/tests/testthat/test-read.output.R
+++ b/base/utils/tests/testthat/test-read.output.R
@@ -74,7 +74,6 @@ test_that("handles arbitrary time offsets", {
 
 test_that("Correct behavior when no NetCDF files present", {
   empty_testdir <- withr::local_tempdir()
-  expected <- "no netCDF files of model output present"
   out_log <- capture.output(type = "message", {
     out <- read.output(runid = "", outdir = empty_testdir,
                 start.year = 2001, end.year = 2002)
@@ -82,6 +81,15 @@ test_that("Correct behavior when no NetCDF files present", {
   expect_match(out_log, "no netCDF files of model output present", all = FALSE)
   expect_match(out_log, "No files found. Returning all NA", all = FALSE)
   expect_equal(out, list(NA))
+
+  out_log_df <- capture.output(type = "message", {
+    out_df <- read.output(runid = "", outdir = empty_testdir,
+                          start.year = 2001, end.year = 2002,
+                          dataframe = TRUE, variables = "AGB")
+  })
+  expect_match(out_log_df, "No files found. Returning all NA", all = FALSE)
+  expect_equal(out_df, data.frame(AGB = NA, posix = NA, year = NA))
+  str(out_df)
 })
 
 test_that("Correctly read all variables, from custom ncfiles", {


### PR DESCRIPTION
Helpful for bulk analysis of multisite runs, where I do a lot of usages like 

```
list.files("path/to/output/out", "\\.nc$", recursive=TRUE, full.names=TRUE) |>
  map(\(path)
    PEcAn.utils::read.output(
      ncfiles=path ,
      runid="",
      dataframe=TRUE,
      start.year=2016,
      end.year=2023,
      variables=NULL) |>
    mutate(runid = basename(dirname(path)))) |>
	list_rbind()
```

and having the return value always be a (possibly empty) dataframe lets the mapping keep working even if all runs at one site have failed.