### PR TITLE
fix(data.atmosphere): use .data$sitename in download_NOAA_GEFS_EFI filter

### DIFF
--- a/modules/data.atmosphere/NEWS.md
+++ b/modules/data.atmosphere/NEWS.md
@@ -7,6 +7,7 @@
 * `download.ERA5_cds` gains options `time`, `dataset`, `product_type`, all defaulting to the values previously hard-coded (#3547).
 
 ## Fixed
+* Fixed `download_NOAA_GEFS_EFI`: the `sitename` filter compared the argument to itself (`sitename == sitename`), always returning data for all NEON sites instead of the requested one. Changed to `.data$sitename == sitename`.
 * Updated `download.NOAA_GEFS` to work with the current (v12.3) release of GEFS (#3349).
 
 ## Changed

--- a/modules/data.atmosphere/R/download_noaa_gefs_efi.R
+++ b/modules/data.atmosphere/R/download_noaa_gefs_efi.R
@@ -20,7 +20,7 @@ download_NOAA_GEFS_EFI <- function(sitename, outfolder, start_date, site.lat, si
                     start_date = start_date)
   
   weather = met %>% 
-    dplyr::filter(.data$reference_datetime == as.POSIXct(start_date,tz="UTC"), sitename == sitename) %>%
+    dplyr::filter(.data$reference_datetime == as.POSIXct(start_date,tz="UTC"), .data$sitename == sitename) %>%
     dplyr::collect() %>%
     dplyr::select(.data$sitename, .data$prediction, .data$variable, .data$horizon, .data$parameter, .data$datetime)
   


### PR DESCRIPTION
## Bug

`download_NOAA_GEFS_EFI` filters the downloaded met tibble to the requested NEON site with:

```r
dplyr::filter(.data$reference_datetime == ..., sitename == sitename)
```

`sitename == sitename` compares the function argument to itself, which is always `TRUE`. The site filter has no effect, so the function returns met data for **every** NEON site merged together instead of only the requested one. Any model run using this function receives mixed multi-site meteorology.

## Fix

```r
# Before
dplyr::filter(.data$reference_datetime == as.POSIXct(start_date, tz = "UTC"), sitename == sitename)

# After
dplyr::filter(.data$reference_datetime == as.POSIXct(start_date, tz = "UTC"), .data$sitename == sitename)
```

Adding the `.data$` prefix makes dplyr compare the `sitename` column against the `sitename` argument, as intended.