### PR TITLE
fix(utils): use logger.severe for unsupported end.year type in read.output

### DIFF
--- a/base/utils/NEWS.md
+++ b/base/utils/NEWS.md
@@ -1,5 +1,9 @@
 # PEcAn.utils 1.8.2
 
+## Fixed
+
+* `read.output()`: an unsupported `end.year` type now stops execution (`logger.severe`) instead of silently continuing with a broken value (`logger.error`), matching the existing behaviour for `start.year`.
+
 ## Changed
 
 * `read.output()`: `start.year` and `end.year` now default to `NULL` (read all years) instead of `NA`, and both `NULL` and `NA` are accepted as "read all years" sentinels (#3987).

--- a/base/utils/R/read.output.R
+++ b/base/utils/R/read.output.R
@@ -124,7 +124,7 @@ read.output <- function(runid, outdir,
         )
       }
     } else {
-      PEcAn.logger::logger.error(
+      PEcAn.logger::logger.severe(
         "`end.year` must be of type numeric, character, Date, or POSIXt",
         "but given `", end.year, "` which is type `", typeof(end.year), "`."
       )


### PR DESCRIPTION
## Bug

`read.output()` validates both `start.year` and `end.year` type, but handles them inconsistently when the type is unsupported:

```r
# start.year — correctly fatal:
} else {
  PEcAn.logger::logger.severe(
    "`start.year` must be of type numeric, character, Date, or POSIXt ..."
  )
}

# end.year — non-fatal, execution continues with broken value:
} else {
  PEcAn.logger::logger.error(   # <-- should be logger.severe
    "`end.year` must be of type numeric, character, Date, or POSIXt ..."
  )
}
```

With an unsupported `end.year` type, `logger.error` only logs the problem and lets execution continue. The broken `end.year` value then reaches the `nc_years <= end.year` comparison, which either errors or silently returns all-FALSE, causing `read.output` to read zero files and return all-NA output.

## Fix

Change `logger.error` to `logger.severe` on the `end.year` else-branch, matching the existing behaviour for `start.year`.