### PR TITLE
fix(utils): correct Weibull SD formula in distn.stats

### DIFF
--- a/base/utils/NEWS.md
+++ b/base/utils/NEWS.md
@@ -1,5 +1,9 @@
 # PEcAn.utils 1.8.2
 
+## Fixed
+
+* `distn.stats()`: corrected the Weibull standard deviation formula, which was returning variance (`b^2 * (...)`) instead of SD (`b * sqrt(...)`). The test expectation is also corrected.
+
 ## Changed
 
 * `read.output()`: `start.year` and `end.year` now default to `NULL` (read all years) instead of `NA`, and both `NULL` and `NA` are accepted as "read all years" sentinels (#3987).

--- a/base/utils/R/distn.stats.R
+++ b/base/utils/R/distn.stats.R
@@ -39,7 +39,7 @@ distn.stats <- function(distn, a, b) {
     sd   <- (b - a) / sqrt(12)
   } else if (distn == "weibull") {
     mean <- b * gamma(1 + 1 / a)
-    sd   <- b ^ 2 * (gamma(1 + 2 / a) - (gamma(1 + 1 / a)) ^ 2)
+    sd   <- b * sqrt(gamma(1 + 2 / a) - (gamma(1 + 1 / a)) ^ 2)
   }
   return(c(mean, sd))
 } # distn.stats

--- a/base/utils/tests/testthat/test.distn.stats.R
+++ b/base/utils/tests/testthat/test.distn.stats.R
@@ -8,8 +8,8 @@ test_that("distn.stats works for different distributions",{
   expect_equal(distn.stats("t", 2), c(0, Inf))
   expect_equal(distn.stats("lnorm", 2, 3), 
                c(exp(2 + 0.5*3^2), sqrt(exp(2*2 + 3^2)*(exp(3^2)-1))))
-  expect_equal(distn.stats("weibull", 2,3), 
-               c(3 * gamma(1+1/2), 3^2 * (gamma(1 + 2/2) - (gamma(1 + 1/2))^2)))
+  expect_equal(distn.stats("weibull", 2,3),
+               c(3 * gamma(1+1/2), 3 * sqrt(gamma(1 + 2/2) - (gamma(1 + 1/2))^2)))
 })
 
 test_that("distn.table.stats works for different distributions",{


### PR DESCRIPTION
## Bug

`distn.stats()` computes the Weibull standard deviation using the wrong formula. The current code returns the **variance**, not the SD:

```r
# Current (wrong) - this is variance:
sd <- b^2 * (gamma(1 + 2/a) - (gamma(1 + 1/a))^2)

# Correct SD:
sd <- b * sqrt(gamma(1 + 2/a) - (gamma(1 + 1/a))^2)
```

The correct Weibull moments are:
- Mean: `b * gamma(1 + 1/a)`
- Variance: `b^2 * (gamma(1 + 2/a) - gamma(1 + 1/a)^2)`
- SD: `sqrt(Variance)` = `b * sqrt(gamma(1 + 2/a) - gamma(1 + 1/a)^2)`

## Numerical verification

For `shape = 2`, `scale = 3`:

| Formula | Value |
|---------|-------|
| Old code (`b^2 * (...)`) | 1.931 |
| Monte Carlo SD (1M samples) | 1.390 |
| Correct formula (`b * sqrt(...)`) | 1.390 |
| True variance | 1.931 |

The old formula exactly matches the variance, not the SD.

## Test

The existing test in `test.distn.stats.R` encoded the same wrong formula as the expected value, so it passed without catching the bug. The test expectation is corrected here to match the true SD.