### PR TITLE
fix(db): fire warning when query.trait.data finds no trait data

### DIFF
--- a/base/db/NEWS.md
+++ b/base/db/NEWS.md
@@ -1,5 +1,9 @@
 # PEcAn.DB 1.8.2
 
+## Fixed
+
+* `query.trait.data()`: the `warning()` call for missing trait data was placed after `return(NA)` and therefore never fired. Moved before the return and changed to `logger.warn()` for consistency with the rest of the codebase.
+
 * Refactored `convert.input()` internals into smaller, and hopefully more testable, chunks. No user-visible changes expected.
 * Roxygen cleanup.
 

--- a/base/db/R/query.trait.data.R
+++ b/base/db/R/query.trait.data.R
@@ -126,8 +126,8 @@ query.trait.data <- function(trait, spstr, con = NULL, update.check.only = FALSE
   ## if result is empty, stop run
   
   if (nrow(result) == 0) {
+    PEcAn.logger::logger.warn("there is no data for", trait)
     return(NA)
-    warning(paste("there is no data for", trait))
   } else {
     
     ## Do we really want to print each trait table?? Seems like a lot of


### PR DESCRIPTION
## Bug

In `query.trait.data()`, the `warning()` for an empty result is placed **after** `return(NA)`, making it dead code that never executes:

```r
if (nrow(result) == 0) {
  return(NA)
  warning(paste("there is no data for", trait))  # never reached
}
```

`query.trait.data` is called by `query.traits()` for every trait in the meta-analysis pipeline. When a trait has no data in the database, the function silently returns `NA` with no message. The caller stores this as `trait.data[[trait]] <- NA`, and downstream code encounters an unexpected `NA` instead of an empty data frame, leading to cryptic failures with no indication of the root cause.

## Fix

Move the warning before the `return()` and convert it to `PEcAn.logger::logger.warn()` for consistency with the rest of the codebase.

```r
if (nrow(result) == 0) {
  PEcAn.logger::logger.warn("there is no data for", trait)
  return(NA)
}
```