### PR TITLE
fix(data.atmosphere): correct hour-of-day calculation in downscale_solar_geom_halfhour

### DIFF
--- a/modules/data.atmosphere/NEWS.md
+++ b/modules/data.atmosphere/NEWS.md
@@ -7,6 +7,7 @@
 * `download.ERA5_cds` gains options `time`, `dataset`, `product_type`, all defaulting to the values previously hard-coded (#3547).
 
 ## Fixed
+* `downscale_solar_geom_halfhour()`: corrected the hour-of-day calculation from `* 48` to `* 24`. The previous formula produced a half-hour index (0-47) instead of an hour of day (0-23), causing `cos_solar_zenith_angle()` to compute a solar hour angle roughly pi radians off and therefore wrong potential shortwave radiation in all half-hourly downscaled met files.
 * Fixed `download_NOAA_GEFS_EFI`: the `sitename` filter compared the argument to itself (`sitename == sitename`), always returning data for all NEON sites instead of the requested one. Changed to `.data$sitename == sitename`.
 * Updated `download.NOAA_GEFS` to work with the current (v12.3) release of GEFS (#3349).
 

--- a/modules/data.atmosphere/R/half_hour_downscale.R
+++ b/modules/data.atmosphere/R/half_hour_downscale.R
@@ -343,7 +343,7 @@ downscale_repeat_6hr_to_half_hrly <- function(df, varName, hr = 0.5){
 downscale_solar_geom_halfhour <- function(doy, lon, lat) {
   
   dt <- stats::median(diff(doy)) * 86400 # average number of seconds in time interval
-  hr <- (doy - floor(doy)) * 48 # hour of day for each element of doy
+  hr <- (doy - floor(doy)) * 24 # hour of day for each element of doy
   
   ## calculate potential radiation
   cosz <- cos_solar_zenith_angle(doy, lat, lon, dt, hr)


### PR DESCRIPTION
## Bug

`downscale_solar_geom_halfhour()` computes the hour of day as:

```r
hr <- (doy - floor(doy)) * 48  # wrong
```

`cos_solar_zenith_angle()` expects `hr` as the **hour of day** (0-23), and uses it to compute the solar hour angle:

```r
h <- pi/12 * (hr - t0)  # t0 is solar noon in hours
```

Multiplying by 48 gives a **half-hour index** (0-47), not the hour of day. The sibling function `downscale_solar_geom` (in `downscaling_helper_functions.R` line 167) correctly uses `* 24`:

```r
hr <- (doy - floor(doy)) * 24  # correct
```

## Impact

With `* 48`, the `hr` value is twice as large as the true hour. This makes the solar hour angle `h` roughly pi radians off from its correct value — placing the sun on the opposite side of the sky. The resulting potential shortwave radiation (`rpot = 1366 * cosz`) is systematically wrong for all half-hourly downscaled met files that use solar geometry for shortwave radiation.

`downscale_solar_geom_halfhour` is called directly in `downscale_ShortWave_to_half_hrly` (lines 221-222), which is used by `temporal_downscale_half_hour` to distribute 6-hourly NOAA GEFS shortwave radiation to half-hourly intervals.

## Fix

Change `* 48` to `* 24`, matching the sibling function.