### PR TITLE
fix(benchmark): add use='pairwise.complete.obs' to metric_PPMC

### DIFF
--- a/modules/benchmark/NEWS.md
+++ b/modules/benchmark/NEWS.md
@@ -1,5 +1,9 @@
 # PEcAn.benchmark 1.7.5.9000
 
+## Fixed
+
+* `metric_PPMC()`: added `use = "pairwise.complete.obs"` to `stats::cor()` so the Pearson correlation is computed on available pairs rather than returning `NA` whenever any observation is missing. This matches the behaviour of `metric_cor()` in the same package.
+
 * Improved clarity of code examples that are not run at check time.
 
 

--- a/modules/benchmark/R/metric_PPMC.R
+++ b/modules/benchmark/R/metric_PPMC.R
@@ -11,5 +11,5 @@ metric_PPMC <- function(metric_dat, ...) {
   # numer <- sum((metric_dat$obvs - mean(metric_dat$obvs)) * (metric_dat$model - mean(metric_dat$model)))
   # denom <- sqrt(sum((metric_dat$obvs - mean(metric_dat$obvs)) ^ 2)) * sqrt(sum((metric_dat$model - mean(metric_dat$model)) ^ 2))
   # return(numer / denom)
-  return(stats::cor(metric_dat$obvs, metric_dat$model))
+  return(stats::cor(metric_dat$obvs, metric_dat$model, use = "pairwise.complete.obs"))
 } # metric_PPMC


### PR DESCRIPTION
## Bug

`metric_PPMC()` calls `stats::cor()` without a `use` argument:

```r
return(stats::cor(metric_dat$obvs, metric_dat$model))
```

`stats::cor()` defaults to `use = "everything"`, which returns `NA` if **any** element of either vector is `NA`. In practice, benchmark datasets almost always have some missing values, so `metric_PPMC` silently returns `NA` while every other metric in the module computes a valid score.

## Fix

Add `use = "pairwise.complete.obs"`, matching the behaviour of `metric_cor()` in the same package:

```r
return(stats::cor(metric_dat$obvs, metric_dat$model, use = "pairwise.complete.obs"))
```

This computes the Pearson correlation on all pairs where both observation and model value are non-missing, consistent with how R's `cor.test()` and the companion `metric_cor()` function handle gaps.