### PR TITLE
fix(meta.analysis): fix stray ')' in logfile default and honor logfile arg in sink()

### DIFF
--- a/modules/meta.analysis/NEWS.md
+++ b/modules/meta.analysis/NEWS.md
@@ -2,6 +2,11 @@
 
 * New function `PEcAn.MA::meta_analysis_standalone` runs meta-analysis without database or file IO (#3728).
 
+## Fixed
+
+* `pecan.ma()`: removed stray `)` inside the default `logfile` path string that caused the path to be literally `meta-analysis.log)` (with a closing parenthesis in the filename).
+* `pecan.ma()`: `sink()` now correctly redirects output to the caller-supplied `logfile` argument instead of always hardcoding the path to `meta-analysis.log` inside `outdir`, making the argument actually effective.
+
 
 # PEcAn.MA 1.7.5
 

--- a/modules/meta.analysis/R/meta.analysis.R
+++ b/modules/meta.analysis/R/meta.analysis.R
@@ -58,7 +58,7 @@ pecan.ma <- function(trait.data, prior.distns,
                      j.iter,
                      outdir,
                      random = FALSE, overdispersed = TRUE,
-                     logfile = file.path(outdir, "meta-analysis.log)"),
+                     logfile = file.path(outdir, "meta-analysis.log"),
                      verbose = TRUE) {
 
   mcmc.object <- list()  #  initialize output list of mcmc objects for each trait
@@ -69,7 +69,7 @@ pecan.ma <- function(trait.data, prior.distns,
   j.iter   <- as.numeric(j.iter)  # Added by SPS 08.27.2013. issue #1803
   ## log the mcmc chain parameters
   if (!is.null(logfile)) {
-    sink(file = file.path(outdir, "meta-analysis.log"), split = TRUE)
+    sink(file = logfile, split = TRUE)
     on.exit(sink(NULL), add = TRUE)
   }
   if (verbose) {

--- a/modules/meta.analysis/man/pecan.ma.Rd
+++ b/modules/meta.analysis/man/pecan.ma.Rd
@@ -12,7 +12,7 @@ pecan.ma(
   outdir,
   random = FALSE,
   overdispersed = TRUE,
-  logfile = file.path(outdir, "meta-analysis.log)"),
+  logfile = file.path(outdir, "meta-analysis.log"),
   verbose = TRUE
 )
 }


### PR DESCRIPTION
## Summary

Two bugs in `pecan.ma()` that have been silently misbehaving since the `logfile` argument was introduced:

1. **Stray `)` in default path**: The default value for the `logfile` parameter was
   ```r
   logfile = file.path(outdir, "meta-analysis.log)")
   #                                              ^-- stray closing paren inside string
   ```
   This caused the log file to be created with a garbled filename (`meta-analysis.log)`) on every standard run.

2. **`sink()` ignores `logfile` argument**: Inside the function body, `sink()` re-computed the path from scratch instead of using the argument:
   ```r
   # Before (ignores logfile):
   sink(file = file.path(outdir, "meta-analysis.log"), split = TRUE)
   # After (correct):
   sink(file = logfile, split = TRUE)
   ```
   Any caller that passed a custom `logfile` path (e.g., to write to a different directory or filename) saw output silently go to the wrong file.

## Test plan

- [ ] Run `pecan.ma()` with default arguments; confirm log file is created as `meta-analysis.log` (no trailing paren).
- [ ] Run `pecan.ma()` with a custom `logfile` path; confirm output is written to that path.
- [ ] Run `pecan.ma()` with `logfile = NULL`; confirm no `sink()` is called (behavior unchanged).