### PR TITLE
Sipnet segmented restart: read crop_changes.csv if provided

### DIFF
--- a/workflows/sipnet-restart-workflow/02-prepare-settings.R
+++ b/workflows/sipnet-restart-workflow/02-prepare-settings.R
@@ -87,7 +87,8 @@ ensemble_settings <- list(
   variable = "NEE",
   samplingspace = list(
     parameters = list(method = "uniform"),
-    events = list(method = "sampling"),
+    event_json = list(method = "sampling"),
+    events = list(parent = "event_json"),
     met = list(method = "sampling"),
     poolinitcond = list(method = "sampling")
   ),
@@ -127,10 +128,8 @@ settings_raw <- PEcAn.settings::as.Settings(list(
     inputs = list(
       met = list(path = metfiles),
       poolinitcond = list(path = icfiles),
-      events = list(
-        path = sipnet_eventfiles,
-        source = events_json_files
-      )
+      event_json = list(path = events_json_files),
+      events = list(path = sipnet_eventfiles)
     )
   ),
   host = list(

--- a/workflows/sipnet-restart-workflow/04-plot-outputs.R
+++ b/workflows/sipnet-restart-workflow/04-plot-outputs.R
@@ -8,7 +8,7 @@ outdir_root <- config[["outdir_root"]]
 
 settings <- PEcAn.settings::read.settings(file.path(outdir_root, "settings.xml"))
 events_json_file <- settings |>
-  purrr::chuck("run", "inputs", "events", "source", "path1")
+  purrr::chuck("run", "inputs", "event_json", "path", "path1")
 
 events <- jsonlite::read_json(events_json_file, simplifyVector = FALSE)
 

--- a/workflows/sipnet-restart-workflow/utils.R
+++ b/workflows/sipnet-restart-workflow/utils.R
@@ -88,12 +88,18 @@ write_segmented_configs.SIPNET <- function(settings, input_design = NULL, ...) {
 }
 
 segment_dataframe <- function(run_settings) {
-  events_json <- run_settings$run$inputs$events$source
-  stopifnot(file.exists(events_json))
-
-  crop_cycles <- PEcAn.data.land::events_to_crop_cycle_starts(events_json) |>
-    dplyr::filter(.data$site_id == run_settings$run$site$id) |>
-    dplyr::ungroup()
+  crop_change_csv <- run_settings$run$inputs$crop_changes$path
+  if (!is.null(crop_change_csv)) {
+    stopifnot(file.exists(crop_change_csv))
+    crop_cycles <- read.csv(crop_change_csv)
+    crop_cycles$date <- as.Date(crop_cycles$date)
+  } else {
+    events_json <- run_settings$run$inputs$event_json$path
+    stopifnot(file.exists(events_json))
+    crop_cycles <- PEcAn.data.land::events_to_crop_cycle_starts(events_json) |>
+      dplyr::filter(.data$site_id == run_settings$run$site$id) |>
+      dplyr::ungroup()
+  }
 
   run_start <- as.Date(run_settings$run$start.date)
   run_end <- as.Date(run_settings$run$end.date)
@@ -135,7 +141,7 @@ segment_dataframe <- function(run_settings) {
         .data$end_date > .env$run_start
       )
     if (nrow(segments) < 1) {
-      PEcAn.logger::logger.severe(
+      PEcAn.logger::logger.error(
         "Filtering resulted in no segments. ",
         "This is an invalid state; check settings and events.json."
       )
@@ -220,6 +226,7 @@ write_segment_configs <- function(
 
     segment_rundir_withid <- file.path(segment_rundir, runid_dummy)
     dir.create(segment_rundir_withid, showWarnings = FALSE, recursive = TRUE)
+    file.create(file.path(segment_rundir_withid, "README.txt"))
     segment_outdir_withid <- file.path(segment_outdir, runid_dummy)
     dir.create(segment_outdir_withid, showWarnings = FALSE, recursive = TRUE)
 


### PR DESCRIPTION
* Adds option to pass crop change schedules as a separate CSV per site rather than reparse them from events.json every time. To create the CSVs in advance, use something like `PEcAn.data.land::events_to_crop_cycle_starts(json_path) |> group_by(site_id) |> group_walk(~write.csv(.x, paste0("cycles-", .y$site_id, ".csv))`.
* Changes expected settings structure for schedules passed as JSON: Instead of hacking them in as metadata in `settings$run$inputs$events$source` (where settings$run$inputs$events$path points to the events.in files), you should pass the JSON paths in a separate `settings$run$inputs$event_json` and declare `event_json` as a parent of `events` in `settings$ensemble$samplingspace`.
* Writes a dummy zero-byte README.txt into each segment run directory to avoid a runtime complaint from `job.sh`

##  Context
Events for the current MAGiC ensembles are organized as a single JSON file per ensemble member, containing all events from all sites in the run, and rereading the full file from segment_dataframe (which is called separately for each site) was taking up most of the runtime. 

The performance difference won't be nearly as large for runs organized with fewer sites per JSON file, but I also appreciate the step up in clarity from having the restart schedule summarized in a 2-column CSV right alongside each events.in file.
