### PR TITLE
split_sipnet_met: handle end times at year boundaries

### DIFF
--- a/models/sipnet/R/sipnet_time_range_idx.R
+++ b/models/sipnet/R/sipnet_time_range_idx.R
@@ -61,12 +61,9 @@ sipnet_time_range_idx <- function(yrs, ydays, hrs,
   if (first_row == 0) { # Start time is within file; find first matching row
     first_row <- match(
       TRUE,
-      # Note the `==` instead of `>=` on year. This reduces search scope,
-      # but does mean this will fail in the weird case where a whole start year
-      # is missing from the _middle_ of the file.
-      # (The missing-from-the-beginning-of-the-file case was handled above)
-      yrs == start_yr &
-        (ydays > start_yday  | (ydays == start_yday & hrs >= start_hr))
+      yrs > start_yr |
+        (yrs == start_yr &
+          (ydays > start_yday  | (ydays == start_yday & hrs >= start_hr)))
     )
     if (is.na(first_row)) {
       # no matches = file ended before start time => return 0
@@ -88,9 +85,9 @@ sipnet_time_range_idx <- function(yrs, ydays, hrs,
   if (last_row == 0) { # End time is within file; find last matching row
     # Can't use match() here because that only gives the _first_ candidate
     last_row_candidates <- which(
-      # Same caveat about missing years as for first_row
-      yrs == end_yr &
-      (ydays < end_yday | (ydays == end_yday & hrs < end_hr))
+      yrs < end_yr |
+        (yrs == end_yr &
+          (ydays < end_yday | (ydays == end_yday & hrs < end_hr)))
     )
     if (length(last_row_candidates) > 0) {
       last_row <- max(last_row_candidates)

--- a/models/sipnet/tests/testthat/test-sipnet_time_range_idx.R
+++ b/models/sipnet/tests/testthat/test-sipnet_time_range_idx.R
@@ -12,7 +12,7 @@ test_that("subsetting by index", {
     sipnet_time_range_idx(
       dat$V1, dat$V2, dat$V3,
       1999, 1, 7.5,
-      2001, 365, 17), # NB file ends at 16.5, recall end time not exclusive
+      2001, 365, 17), # NB file ends at 16.5, recall end time is exclusive
     list(start = 1, end = 2190)
   )
 
@@ -23,6 +23,20 @@ test_that("subsetting by index", {
       1999, 2, 12,
       1999, 10, 16.5),
     list(start = 4, end = 19)
+  )
+  expect_equal(
+    sipnet_time_range_idx(
+      dat$V1, dat$V2, dat$V3,
+      1999, 2, 12,
+      2000, 1, 0),
+    list(start = 4, end = 730)
+  )
+  expect_equal(
+    sipnet_time_range_idx(
+      dat$V1, dat$V2, dat$V3,
+      2000, 1, 0,
+      2000, 2, 0),
+    list(start = 731, end = 732)
   )
 
   # Starting before file


### PR DESCRIPTION
Fixup for a corner case in #3990: If end time is `<YYYY>-01-01`, implied hour = 0 meant no lines matched. Fixed by also considering years earlier than YYYY.