### PR TITLE
feat(meta.analysis): in-memory trait_data/prior_distns for run.meta.analysis.pft (Modularity Part 2)

### DIFF
--- a/modules/meta.analysis/R/run.meta.analysis.R
+++ b/modules/meta.analysis/R/run.meta.analysis.R
@@ -1,28 +1,28 @@
-#' Complete meta-analysis workflow for a single plant functional type (PFT)
-#'
-#' @param trait_data (list) Named list of trait data. List item names must be
-#' trait names (consistent with `priors` argument). List values are
-#' `data.frame`s with the following required columns:
-#'  `name`, `mean` `statname`, `stat`, `greenhouse`, `n`,
-#'  `site_id`, `specie_id`, `citation_id`, `cultivar_id`,
-#'  `date`, `time`, `control`
-#' @param priors (list) Named list of priors
-#' @param iterations (integer) Number of sampler iterations for MCMC analysis
-#' @param outdir (character; default = `tempdir() / "pecan-meta-analysis"`)
-#'    Path to directory where outputs will be stored.
-#' @param pft_name (character; default = NA) Name of PFT (for logging purposes).
-#' @param random (boolean; default = TRUE) Should random effects be used?
-#' @param use_ghs (boolean; default = TRUE) If TRUE, do not exclude greenhouse data
-#' @param gamma_tau (numeric; default = 0.01) Prior on gamma tau parameter
-#' @inheritParams pecan.ma
-#' @inheritParams pecan.ma.summary
-#'
-#' @return (list) List of trait meta-analysis results, including:
-#'    - `trait.mcmc`: MCMC samples
-#'    - `post.distns`: Posterior distributions
-#'    - `jagged.data`: "JAGS-ified" input data (after GHG screen, if applied)
-#'
-#' @export
+##' Complete meta-analysis workflow for a single plant functional type (PFT)
+##'
+##' @param trait_data (list) Named list of trait data. List item names must be
+##' trait names (consistent with `priors` argument). List values are
+##' `data.frame`s with the following required columns:
+##'  `name`, `mean` `statname`, `stat`, `greenhouse`, `n`,
+##'  `site_id`, `specie_id`, `citation_id`, `cultivar_id`,
+##'  `date`, `time`, `control`
+##' @param priors (list) Named list of priors
+##' @param iterations (integer) Number of sampler iterations for MCMC analysis
+##' @param outdir (character; default = `tempdir() / "pecan-meta-analysis"`)
+##'    Path to directory where outputs will be stored.
+##' @param pft_name (character; default = NA) Name of PFT (for logging purposes).
+##' @param random (boolean; default = TRUE) Should random effects be used?
+##' @param use_ghs (boolean; default = TRUE) If TRUE, do not exclude greenhouse data
+##' @param gamma_tau (numeric; default = 0.01) Prior on gamma tau parameter
+##' @inheritParams pecan.ma
+##' @inheritParams pecan.ma.summary
+##'
+##' @return (list) List of trait meta-analysis results, including:
+##'    - `trait.mcmc`: MCMC samples
+##'    - `post.distns`: Posterior distributions
+##'    - `jagged.data`: "JAGS-ified" input data (after GHG screen, if applied)
+##'
+##' @export
 meta_analysis_standalone <- function(
   trait_data,
   priors,
@@ -182,21 +182,30 @@ check_consistent <- function(point, prior,
   return(c(no_error = FALSE, no_warning = FALSE))
 }
 
-#' "Workflow" version of run.meta.analysis.pft
-#' #' Run Bayesian meta-analysis for a single PFT (file-based wrapper)
+#' Run Bayesian meta-analysis for a single PFT (file-based wrapper)
 #'
-#' @md
-#' Thin wrapper around \code{\link[PEcAn.MA]{meta_analysis_standalone}} that reads trait data and
-#' priors from disk, runs the meta-analysis, and saves results back to disk.
-#' Also registers result files in the BETYdb posteriors table.
+#' Thin wrapper around \code{\link[PEcAn.MA]{meta_analysis_standalone}} that
+#' reads trait data and priors either directly from in-memory R objects (when
+#' `trait_data` and `prior_distns` are provided) or from `.Rdata` files in
+#' `pft$outdir` (the legacy path). Results are always saved back to
+#' `pft$outdir` for scientific provenance and registered in BETYdb.
 #'
 #' @details
-#' **Upstream contract (reads from `pft$outdir`):**
+#' **Input contract:** Trait data and priors enter via one of two paths:
 #' \describe{
-#'   \item{`trait.data.Rdata`}{Named list of data frames produced by
-#'     \code{\link[PEcAn.DB]{get.trait.data.pft}}. Loaded into `trait_env$trait.data`.}
-#'   \item{`prior.distns.Rdata`}{Data frame of prior distributions produced by
-#'     \code{\link[PEcAn.DB]{get.trait.data.pft}}. Loaded into `prior_env$prior.distns`.}
+#'   \item{In-memory (preferred for new code)}{Pass both `trait_data` and
+#'     `prior_distns` as function arguments. Disk loading is skipped entirely.
+#'     Either both arguments must be provided or both must be `NULL` —
+#'     passing only one is an error.}
+#'   \item{Disk-based (legacy)}{When both `trait_data` and `prior_distns`
+#'     are `NULL`, the function reads:
+#'     \itemize{
+#'       \item `trait.data.Rdata` — Named list of trait data frames produced
+#'         by \code{\link[PEcAn.DB]{get.trait.data.pft}}.
+#'       \item `prior.distns.Rdata` — Data frame of prior distributions
+#'         produced by \code{\link[PEcAn.DB]{get.trait.data.pft}}.
+#'     }
+#'     loaded from `pft$outdir`.}
 #' }
 #'
 #' **File-based side effects (saved to `pft$outdir`):**
@@ -214,14 +223,21 @@ check_consistent <- function(point, prior,
 #'     model (see \code{\link[PEcAn.MA]{jagify}}).}
 #' }
 #'
-#' **Downstream contract:** The files `trait.mcmc.Rdata` and
-#' `post.distns.Rdata` are expected by \code{\link[PEcAn.uncertainty]{get.parameter.samples}} (in
-#' `PEcAn.uncertainty`), which loads them to generate ensemble and sensitivity
-#' analysis samples.
+#' These saves are unconditional: calling this wrapper is the provenance
+#' opt-in mechanism. Callers that need a purely in-memory analysis with no
+#' filesystem side effects should call
+#' \code{\link[PEcAn.MA]{meta_analysis_standalone}} directly.
 #'
-#' **Note:** The core computation is performed by \code{\link[PEcAn.MA]{meta_analysis_standalone}},
-#' which accepts and returns R objects directly — see its documentation for
-#' the pure-function interface.
+#' **Downstream contract:** The files `trait.mcmc.Rdata` and
+#' `post.distns.Rdata` are expected by `PEcAn.uncertainty::get.parameter.samples()`
+#' (in `PEcAn.uncertainty`), which loads them to generate ensemble and
+#' sensitivity analysis samples. The same objects are now also attached to
+#' the returned `pft` list (see Value below), so callers wired to the
+#' modular pipeline can consume them without re-reading the `.Rdata` files.
+#'
+#' **Note:** The core computation is performed by
+#' \code{\link[PEcAn.MA]{meta_analysis_standalone}}, which accepts and returns
+#' R objects directly — see its documentation for the pure-function interface.
 #'
 #' @param pft (list) PFT list object, as defined in settings. Must include the
 #'  following: `outdir`, `name`, `posteriorid`
@@ -229,9 +245,23 @@ check_consistent <- function(point, prior,
 #' @param dbcon (DBI connection object) BETY database connection object
 #' @param update (boolean; default = FALSE) If `TRUE`, replace existing
 #'   posteriors with new ones
+#' @param trait_data (named list; default = `NULL`) Optional in-memory trait
+#'   data with the same structure as the contents of `trait.data.Rdata`. When
+#'   non-`NULL`, must be provided alongside `prior_distns` and the `.Rdata`
+#'   files in `pft$outdir` are not read.
+#' @param prior_distns (data frame; default = `NULL`) Optional in-memory prior
+#'   distributions with the same structure as the contents of
+#'   `prior.distns.Rdata`. When non-`NULL`, must be provided alongside
+#'   `trait_data` and the `.Rdata` files in `pft$outdir` are not read.
+#' @param return_data (boolean; default = FALSE) If `TRUE`, attach `trait.mcmc`,
+#'   `post.distns`, and `jagged.data` to the returned `pft` for in-memory
+#'   chaining. Defaults to `FALSE` to preserve legacy behavior — attaching
+#'   these objects to a `pft` that is embedded in a settings object would
+#'   inflate the settings and can break serialization.
 #'
-#' @return The `pft` list (invisibly), or `NA` if no trait data are available.
-#'   The returned `pft` list is a named list with the following elements:
+#' @return The `pft` list with three additional elements attached, or `NA`
+#'   if no trait data are available for this PFT. The returned `pft` list
+#'   contains:
 #'   \describe{
 #'     \item{`name`}{(character) PFT name, e.g. `"temperate.deciduous"`.}
 #'     \item{`outdir`}{(character) Path to directory where output files are
@@ -240,64 +270,149 @@ check_consistent <- function(point, prior,
 #'       BETYdb's `posteriors` table.}
 #'     \item{`constants`}{(named list, optional) Trait values to treat as
 #'       fixed constants, bypassing the meta-analysis.}
+#'     \item{`trait.mcmc`}{(named list) `mcmc.list` objects, one per trait.}
+#'     \item{`post.distns`}{(data frame) Fitted posterior distributions.}
+#'     \item{`jagged.data`}{(named list) JAGS-formatted data frames.}
 #'   }
-#'   The function's primary outputs are communicated through files saved in
-#'   `pft$outdir`.
+#'   File-based side effects in `pft$outdir` are preserved for backward
+#'   compatibility and scientific provenance.
 #'
 #' @inheritParams meta_analysis_standalone
-run.meta.analysis.pft <- function(pft, iterations, random = TRUE, threshold = 1.2, dbfiles, dbcon, use_ghs = TRUE, update = FALSE) {
-  # check to see if get.trait was executed
-  if (!file.exists(file.path(pft$outdir, "trait.data.Rdata")) || 
-      !file.exists(file.path(pft$outdir, "prior.distns.Rdata"))) {
-    PEcAn.logger::logger.severe("Could not find output from get.trait for", pft$name)
-    return(NA)
+run.meta.analysis.pft <- function(pft, iterations,
+                                  random = TRUE, threshold = 1.2,
+                                  dbfiles, dbcon,
+                                  use_ghs = TRUE, update = FALSE,
+                                  trait_data = NULL,
+                                  prior_distns = NULL,
+                                  return_data = FALSE) {
+
+  # Attach MA outputs to the pft only when the caller opts in. Default FALSE
+  # preserves legacy behavior: when a pft is folded back into a settings
+  # object, attaching large mcmc/jagged objects would bloat settings and can
+  # break serialization. Modular callers that consume results in-memory pass
+  # return_data = TRUE. (Same opt-in pattern as get.trait.data.pft, #3978.)
+  attach_results <- function(pft, trait.mcmc, post.distns, jagged.data = NULL) {
+    if (!return_data) {
+      return(pft)
+    }
+    pft$trait.mcmc  <- trait.mcmc
+    pft$post.distns <- post.distns
+    if (!is.null(jagged.data)) {
+      pft$jagged.data <- jagged.data
+    }
+    pft
   }
-  
+
+  # Validate the in-memory inputs: both must be provided together or both
+  # must be NULL. Mixing the two modes (e.g. updated trait data against
+  # stale priors loaded from disk) is almost always a mistake, so we catch
+  # it loudly rather than silently falling back to a partial disk load.
+  trait_provided <- !is.null(trait_data)
+  prior_provided <- !is.null(prior_distns)
+  if (trait_provided != prior_provided) {
+    PEcAn.logger::logger.severe(
+      "`trait_data` and `prior_distns` must both be provided together,",
+      "or both must be NULL.",
+      "Got: trait_data =", if (trait_provided) "<provided>" else "NULL",
+      ", prior_distns =", if (prior_provided) "<provided>" else "NULL"
+    )
+  }
+  in_memory_inputs <- trait_provided
+
+  # check to see if get.trait was executed (only required for the disk path —
+  # in-memory callers have already supplied the data we'd otherwise load)
+  if (!in_memory_inputs) {
+    if (!file.exists(file.path(pft$outdir, "trait.data.Rdata")) ||
+        !file.exists(file.path(pft$outdir, "prior.distns.Rdata"))) {
+      PEcAn.logger::logger.severe("Could not find output from get.trait for", pft$name)
+      return(NA)
+    }
+  }
+
   # check to see if run.meta.analysis can be skipped
-  if (file.exists(file.path(pft$outdir, "trait.mcmc.Rdata")) && 
-      file.exists(file.path(pft$outdir, "post.distns.Rdata")) && 
+  if (file.exists(file.path(pft$outdir, "trait.mcmc.Rdata")) &&
+      file.exists(file.path(pft$outdir, "post.distns.Rdata")) &&
       update != TRUE) {
     PEcAn.logger::logger.info("Assuming get.trait copied results already")
-    return(pft)
+
+    # Legacy default (return_data = FALSE): return the bare pft without reading
+    # anything back from disk.
+    if (!return_data) {
+      return(pft)
+    }
+
+    # return_data = TRUE: load the cached results and attach them so the
+    # modular chain gets the same return contract on a cache-hit as it does
+    # on a fresh analysis.
+    mcmc_env <- new.env()
+    load(file.path(pft$outdir, "trait.mcmc.Rdata"), envir = mcmc_env)
+    post_env <- new.env()
+    load(file.path(pft$outdir, "post.distns.Rdata"), envir = post_env)
+
+    # jagged.data is optional: older posteriors copied via get.trait.data.pft
+    # may not include this file, so attach only if it exists on disk.
+    jagged.data <- NULL
+    jagged_path <- file.path(pft$outdir, "jagged.data.Rdata")
+    if (file.exists(jagged_path)) {
+      jagged_env <- new.env()
+      load(jagged_path, envir = jagged_env)
+      jagged.data <- jagged_env[["jagged.data"]]
+    }
+
+    return(attach_results(pft, mcmc_env[["trait.mcmc"]],
+                          post_env[["post.distns"]], jagged.data))
   }
-  
+
   # make sure there is a posteriorid
   if (is.null(pft$posteriorid)) {
     PEcAn.logger::logger.severe("Make sure to pass in pft list from get.trait. Missing posteriorid for", pft$name)
     return(NA)
   }
-  
+
   # make sure random and use_ghs is logical, and threshold is numeric
   # when someone re-reads xml and continues from meta.analysis these can cause bugs (especially the threshold bug is very subtle)
   random    <- as.logical(random)
   use_ghs   <- as.logical(use_ghs)
   threshold <- as.numeric(threshold)
-  
+
   # get list of existing files so they get ignored saving
   old.files <- list.files(path = pft$outdir)
-  
+
   PEcAn.logger::logger.info("-------------------------------------------------------------------")
   PEcAn.logger::logger.info(" Running meta.analysis for PFT:", pft$name)
   PEcAn.logger::logger.info("-------------------------------------------------------------------")
-  
-  ## Load trait data for PFT
-  trait_env <- new.env()
-  load(file.path(pft$outdir, "trait.data.Rdata"), envir = trait_env)
-  prior_env <- new.env()
-  load(file.path(pft$outdir, "prior.distns.Rdata"), envir = prior_env)
-  
-  if (length(trait_env$trait.data) == 0) {
+
+  ## Resolve trait data and priors: prefer in-memory objects when provided,
+  ## otherwise fall back to loading from pft$outdir (legacy path).
+  if (in_memory_inputs) {
+    PEcAn.logger::logger.debug(
+      "Using in-memory `trait_data` and `prior_distns`;",
+      "skipping load() from", pft$outdir
+    )
+    trait.data <- trait_data
+    prior.distns <- prior_distns
+  } else {
+    ## Load trait data for PFT
+    trait_env <- new.env()
+    load(file.path(pft$outdir, "trait.data.Rdata"), envir = trait_env)
+    prior_env <- new.env()
+    load(file.path(pft$outdir, "prior.distns.Rdata"), envir = prior_env)
+    trait.data <- trait_env[["trait.data"]]
+    prior.distns <- prior_env[["prior.distns"]]
+  }
+
+  if (length(trait.data) == 0) {
     PEcAn.logger::logger.info("no trait data for PFT", pft$name, "\n so no meta-analysis will be performed")
     return(NA)
   }
-  
+
   # create path where to store files
   pathname <- file.path(dbfiles, "posterior", pft$posteriorid)
   dir.create(pathname, showWarnings = FALSE, recursive = TRUE)
 
   ma_result <- meta_analysis_standalone(
-    trait_data = trait_env[["trait.data"]],
-    priors = prior_env[["prior.distns"]],
+    trait_data = trait.data,
+    priors = prior.distns,
     iterations = iterations,
     pft_name = pft[["name"]],
     outdir = pft[["outdir"]],
@@ -317,25 +432,25 @@ run.meta.analysis.pft <- function(pft, iterations, random = TRUE, threshold = 1.
   jagged.data <- ma_result[["jagged.data"]]
   save(jagged.data, file = file.path(pft$outdir, "jagged.data.Rdata"))
   rm(jagged.data)
-  
+
   ### Save the meta.analysis output
   trait.mcmc <- ma_result[["trait.mcmc"]]
   save(trait.mcmc, file = file.path(pft$outdir, "trait.mcmc.Rdata"))
   rm(trait.mcmc)
-  
+
   dist_MA_path <- file.path(pft$outdir, "post.distns.MA.Rdata")
   post.distns <- ma_result[["post.distns"]]
   save(post.distns, file = dist_MA_path)
   rm(post.distns)
 
   dist_path <- file.path(pft$outdir, "post.distns.Rdata")
-  
+
   # Symlink to post.distns.Rdata (no 'MA' identifier)
   if (file.exists(dist_path)) {
     file.remove(dist_path)
   }
   file.symlink(dist_MA_path, dist_path)
-  
+
   ### save and store in database all results except those that were there already
   for (file in list.files(path = pft$outdir)) {
     # Skip file if it was there already, or if it's a symlink (like the post.distns.Rdata link above)
@@ -346,12 +461,19 @@ run.meta.analysis.pft <- function(pft, iterations, random = TRUE, threshold = 1.
     file.copy(file.path(pft$outdir, file), filename)
     PEcAn.DB::dbfile.insert(pathname, file, "Posterior", pft$posteriorid, dbcon)
   }
+
+  # Attach analysis results to the returned pft (when return_data = TRUE) so
+  # downstream functions (e.g. get.parameter.samples) can consume them
+  # in-memory without re-reading the .Rdata files we just wrote for provenance.
+  # The rm() calls above only removed the local aliases — the data is still
+  # alive in `ma_result`.
+  return(attach_results(pft, ma_result[["trait.mcmc"]],
+                        ma_result[["post.distns"]], ma_result[["jagged.data"]]))
 } # run.meta.analysis.pft
 
 ##--------------------------------------------------------------------------------------------------##
 ##' Run meta-analysis across all PFTs
 ##'
-##' @md
 ##' Iterates over a list of PFTs and runs \code{\link[PEcAn.MA]{run.meta.analysis.pft}} for each
 ##' one. This is the main entry point called by \code{\link[PEcAn.MA]{runModule.run.meta.analysis}}.
 ##'
@@ -369,26 +491,32 @@ run.meta.analysis.pft <- function(pft, iterations, random = TRUE, threshold = 1.
 ##' @inheritParams meta_analysis_standalone
 ##' @inheritParams run.meta.analysis.pft
 ##'
-##' @return nothing, as side effect saves \code{trait.mcmc} created by
-##' \code{\link{pecan.ma}} and post.distns created by
-##' \code{\link{approx.posterior}(trait.mcmc, ...)}  to trait.mcmc.Rdata
-##'   and post.distns.Rdata, respectively
+##' @return Invisibly, a list (one element per input PFT) of the values
+##'   returned by \code{\link{run.meta.analysis.pft}}. Each element is either
+##'   the input `pft` list with `trait.mcmc`, `post.distns`, and `jagged.data`
+##'   attached, or `NA` when no meta-analysis was performed for that PFT.
+##'   Provenance files (`trait.mcmc.Rdata`, `post.distns.Rdata`, etc.) are
+##'   also written to each `pft$outdir` as a side effect.
 ##' @export
 ##' @author Shawn Serbin, David LeBauer
-run.meta.analysis <- function(pfts, iterations, random = TRUE, threshold = 1.2, dbfiles, database, use_ghs = TRUE , update = FALSE) {
+run.meta.analysis <- function(pfts, iterations, random = TRUE, threshold = 1.2, dbfiles, database, use_ghs = TRUE , update = FALSE, return_data = FALSE) {
   # process all pfts
   dbcon <- PEcAn.DB::db.open(database)
   on.exit(PEcAn.DB::db.close(dbcon), add = TRUE)
 
-  result <- lapply(pfts, run.meta.analysis.pft, iterations = iterations, random = random, 
-                   threshold = threshold, dbfiles = dbfiles, dbcon = dbcon, use_ghs = use_ghs, update = update)
+  result <- lapply(pfts, run.meta.analysis.pft, iterations = iterations, random = random,
+                   threshold = threshold, dbfiles = dbfiles, dbcon = dbcon, use_ghs = use_ghs, update = update,
+                   return_data = return_data)
+  invisible(result)
 } # run.meta.analysis.R
 ## ==================================================================================================#
 #' Run meta-analysis on all PFTs in a (list of) PEcAn settings
 #'
 ##' @param settings a PEcAn settings or MultiSettings object
-##' @return list of PFTs, invisibly;
-##'  saves MA results to `settings$pft$outdir` as a side effect
+##' @return Invisibly, the list of PFTs returned by \code{run.meta.analysis},
+##'   each with `trait.mcmc`, `post.distns`, and `jagged.data` attached (or
+##'   `NA` for PFTs with no trait data). MA results are also saved to
+##'   `settings$pft$outdir` as a side effect.
 ##' @export
 runModule.run.meta.analysis <- function(settings) {
   if (PEcAn.settings::is.MultiSettings(settings)) {
@@ -401,11 +529,11 @@ runModule.run.meta.analysis <- function(settings) {
       pfts        <- c(pfts, pfts.i[ind])
       pft.names   <- sapply(pfts, function(x) x$name)
     }
-    
-    PEcAn.logger::logger.info(paste0("Running meta-analysis on all PFTs listed by any Settings object in the list: ", 
+
+    PEcAn.logger::logger.info(paste0("Running meta-analysis on all PFTs listed by any Settings object in the list: ",
                        paste(pft.names, collapse = ", ")))
-    
-    run.meta.analysis(
+
+    result <- run.meta.analysis(
       pfts,
       settings$meta.analysis$iter,
       settings$meta.analysis$random.effects$on,
@@ -415,7 +543,7 @@ runModule.run.meta.analysis <- function(settings) {
       settings$meta.analysis$random.effects$use_ghs
     )
   } else if (PEcAn.settings::is.Settings(settings)) {
-      run.meta.analysis(
+      result <- run.meta.analysis(
         settings$pfts,
         settings$meta.analysis$iter,
         settings$meta.analysis$random.effects$on,
@@ -428,6 +556,7 @@ runModule.run.meta.analysis <- function(settings) {
   } else {
     stop("runModule.run.meta.analysis only works with Settings or MultiSettings")
   }
+  invisible(result)
 } # runModule.run.meta.analysis
 
 ##--------------------------------------------------------------------------------------------------#
@@ -440,7 +569,7 @@ runModule.run.meta.analysis <- function(settings) {
 ##' @return result of `p<distn>(point, parama, paramb)`
 ##' @author David LeBauer
 p.point.in.prior <- function(point, prior) {
-  out <- do.call(paste0("p", prior$distn), 
+  out <- do.call(paste0("p", prior$distn),
                  list(point, prior$parama, prior$paramb))
   return(out)
 } # p.point.in.prior

--- a/modules/meta.analysis/man/run.meta.analysis.Rd
+++ b/modules/meta.analysis/man/run.meta.analysis.Rd
@@ -12,7 +12,8 @@ run.meta.analysis(
   dbfiles,
   database,
   use_ghs = TRUE,
-  update = FALSE
+  update = FALSE,
+  return_data = FALSE
 )
 }
 \arguments{
@@ -32,15 +33,33 @@ run.meta.analysis(
 \item{use_ghs}{(boolean; default = TRUE) If TRUE, do not exclude greenhouse data}
 
 \item{update}{logical: Rerun the meta-analysis if result files already exist?}
+
+\item{return_data}{(boolean; default = FALSE) If \code{TRUE}, attach \code{trait.mcmc},
+\code{post.distns}, and \code{jagged.data} to the returned \code{pft} for in-memory
+chaining. Defaults to \code{FALSE} to preserve legacy behavior — attaching
+these objects to a \code{pft} that is embedded in a settings object would
+inflate the settings and can break serialization.}
 }
 \value{
-nothing, as side effect saves \code{trait.mcmc} created by
-\code{\link{pecan.ma}} and post.distns created by
-\code{\link{approx.posterior}(trait.mcmc, ...)}  to trait.mcmc.Rdata
-and post.distns.Rdata, respectively
+Invisibly, a list (one element per input PFT) of the values
+returned by \code{\link{run.meta.analysis.pft}}. Each element is either
+the input \code{pft} list with \code{trait.mcmc}, \code{post.distns}, and \code{jagged.data}
+attached, or \code{NA} when no meta-analysis was performed for that PFT.
+Provenance files (\code{trait.mcmc.Rdata}, \code{post.distns.Rdata}, etc.) are
+also written to each \code{pft$outdir} as a side effect.
 }
 \description{
-Run meta-analysis across all PFTs
+Iterates over a list of PFTs and runs \code{\link[PEcAn.MA]{run.meta.analysis.pft}} for each
+one. This is the main entry point called by \code{\link[PEcAn.MA]{runModule.run.meta.analysis}}.
+}
+\details{
+This will use the following items from settings:
+\itemize{
+\item \code{settings$pfts}
+\item \code{settings$database$bety}
+\item \code{settings$database$dbfiles}
+\item \code{settings$meta.analysis$update}
+}
 }
 \author{
 Shawn Serbin, David LeBauer

--- a/modules/meta.analysis/man/run.meta.analysis.pft.Rd
+++ b/modules/meta.analysis/man/run.meta.analysis.pft.Rd
@@ -2,8 +2,7 @@
 % Please edit documentation in R/run.meta.analysis.R
 \name{run.meta.analysis.pft}
 \alias{run.meta.analysis.pft}
-\title{"Workflow" version of run.meta.analysis.pft
-#' Run Bayesian meta-analysis for a single PFT (file-based wrapper)}
+\title{Run Bayesian meta-analysis for a single PFT (file-based wrapper)}
 \usage{
 run.meta.analysis.pft(
   pft,
@@ -13,7 +12,10 @@ run.meta.analysis.pft(
   dbfiles,
   dbcon,
   use_ghs = TRUE,
-  update = FALSE
+  update = FALSE,
+  trait_data = NULL,
+  prior_distns = NULL,
+  return_data = FALSE
 )
 }
 \arguments{
@@ -35,10 +37,27 @@ default = 1.2 following Bolker 2008 Ecological Models and Data in R}
 
 \item{update}{(boolean; default = FALSE) If \code{TRUE}, replace existing
 posteriors with new ones}
+
+\item{trait_data}{(named list; default = \code{NULL}) Optional in-memory trait
+data with the same structure as the contents of \code{trait.data.Rdata}. When
+non-\code{NULL}, must be provided alongside \code{prior_distns} and the \code{.Rdata}
+files in \code{pft$outdir} are not read.}
+
+\item{prior_distns}{(data frame; default = \code{NULL}) Optional in-memory prior
+distributions with the same structure as the contents of
+\code{prior.distns.Rdata}. When non-\code{NULL}, must be provided alongside
+\code{trait_data} and the \code{.Rdata} files in \code{pft$outdir} are not read.}
+
+\item{return_data}{(boolean; default = FALSE) If \code{TRUE}, attach \code{trait.mcmc},
+\code{post.distns}, and \code{jagged.data} to the returned \code{pft} for in-memory
+chaining. Defaults to \code{FALSE} to preserve legacy behavior — attaching
+these objects to a \code{pft} that is embedded in a settings object would
+inflate the settings and can break serialization.}
 }
 \value{
-The \code{pft} list (invisibly), or \code{NA} if no trait data are available.
-The returned \code{pft} list is a named list with the following elements:
+The \code{pft} list with three additional elements attached, or \code{NA}
+if no trait data are available for this PFT. The returned \code{pft} list
+contains:
 \describe{
 \item{\code{name}}{(character) PFT name, e.g. \code{"temperate.deciduous"}.}
 \item{\code{outdir}}{(character) Path to directory where output files are
@@ -47,21 +66,36 @@ stored (trait data, priors, posteriors, MCMC samples).}
 BETYdb's \code{posteriors} table.}
 \item{\code{constants}}{(named list, optional) Trait values to treat as
 fixed constants, bypassing the meta-analysis.}
+\item{\code{trait.mcmc}}{(named list) \code{mcmc.list} objects, one per trait.}
+\item{\code{post.distns}}{(data frame) Fitted posterior distributions.}
+\item{\code{jagged.data}}{(named list) JAGS-formatted data frames.}
 }
-The function's primary outputs are communicated through files saved in
-\code{pft$outdir}.
+File-based side effects in \code{pft$outdir} are preserved for backward
+compatibility and scientific provenance.
 }
 \description{
-"Workflow" version of run.meta.analysis.pft
-#' Run Bayesian meta-analysis for a single PFT (file-based wrapper)
+Thin wrapper around \code{\link[PEcAn.MA]{meta_analysis_standalone}} that
+reads trait data and priors either directly from in-memory R objects (when
+\code{trait_data} and \code{prior_distns} are provided) or from \code{.Rdata} files in
+\code{pft$outdir} (the legacy path). Results are always saved back to
+\code{pft$outdir} for scientific provenance and registered in BETYdb.
 }
 \details{
-\strong{Upstream contract (reads from \code{pft$outdir}):}
+\strong{Input contract:} Trait data and priors enter via one of two paths:
 \describe{
-\item{\code{trait.data.Rdata}}{Named list of data frames produced by
-\code{\link[PEcAn.DB]{get.trait.data.pft}}. Loaded into \code{trait_env$trait.data}.}
-\item{\code{prior.distns.Rdata}}{Data frame of prior distributions produced by
-\code{\link[PEcAn.DB]{get.trait.data.pft}}. Loaded into \code{prior_env$prior.distns}.}
+\item{In-memory (preferred for new code)}{Pass both \code{trait_data} and
+\code{prior_distns} as function arguments. Disk loading is skipped entirely.
+Either both arguments must be provided or both must be \code{NULL} —
+passing only one is an error.}
+\item{Disk-based (legacy)}{When both \code{trait_data} and \code{prior_distns}
+are \code{NULL}, the function reads:
+\itemize{
+\item \code{trait.data.Rdata} — Named list of trait data frames produced
+by \code{\link[PEcAn.DB]{get.trait.data.pft}}.
+\item \code{prior.distns.Rdata} — Data frame of prior distributions
+produced by \code{\link[PEcAn.DB]{get.trait.data.pft}}.
+}
+loaded from \code{pft$outdir}.}
 }
 
 \strong{File-based side effects (saved to \code{pft$outdir}):}
@@ -79,12 +113,19 @@ frames (one per trait) formatted for use in the JAGS meta-analysis
 model (see \code{\link[PEcAn.MA]{jagify}}).}
 }
 
-\strong{Downstream contract:} The files \code{trait.mcmc.Rdata} and
-\code{post.distns.Rdata} are expected by \code{\link[PEcAn.uncertainty]{get.parameter.samples}} (in
-\code{PEcAn.uncertainty}), which loads them to generate ensemble and sensitivity
-analysis samples.
+These saves are unconditional: calling this wrapper is the provenance
+opt-in mechanism. Callers that need a purely in-memory analysis with no
+filesystem side effects should call
+\code{\link[PEcAn.MA]{meta_analysis_standalone}} directly.
 
-\strong{Note:} The core computation is performed by \code{\link[PEcAn.MA]{meta_analysis_standalone}},
-which accepts and returns R objects directly — see its documentation for
-the pure-function interface.
+\strong{Downstream contract:} The files \code{trait.mcmc.Rdata} and
+\code{post.distns.Rdata} are expected by \code{PEcAn.uncertainty::get.parameter.samples()}
+(in \code{PEcAn.uncertainty}), which loads them to generate ensemble and
+sensitivity analysis samples. The same objects are now also attached to
+the returned \code{pft} list (see Value below), so callers wired to the
+modular pipeline can consume them without re-reading the \code{.Rdata} files.
+
+\strong{Note:} The core computation is performed by
+\code{\link[PEcAn.MA]{meta_analysis_standalone}}, which accepts and returns
+R objects directly — see its documentation for the pure-function interface.
 }

--- a/modules/meta.analysis/man/runModule.run.meta.analysis.Rd
+++ b/modules/meta.analysis/man/runModule.run.meta.analysis.Rd
@@ -10,8 +10,10 @@ runModule.run.meta.analysis(settings)
 \item{settings}{a PEcAn settings or MultiSettings object}
 }
 \value{
-list of PFTs, invisibly;
-saves MA results to \code{settings$pft$outdir} as a side effect
+Invisibly, the list of PFTs returned by \code{run.meta.analysis},
+each with \code{trait.mcmc}, \code{post.distns}, and \code{jagged.data} attached (or
+\code{NA} for PFTs with no trait data). MA results are also saved to
+\code{settings$pft$outdir} as a side effect.
 }
 \description{
 Run meta-analysis on all PFTs in a (list of) PEcAn settings

--- a/modules/meta.analysis/tests/testthat/test-run.meta.analysis.pft.R
+++ b/modules/meta.analysis/tests/testthat/test-run.meta.analysis.pft.R
@@ -281,3 +281,259 @@ test_that("run.meta.analysis.pft returns NA when trait.data is empty list", {
 
   expect_true(is.na(result))
 })
+
+# ---------------------------------------------------------------------------
+# In-memory input path (Modularity Part 2)
+# ---------------------------------------------------------------------------
+
+test_that("run.meta.analysis.pft errors when only trait_data is provided", {
+  pft_outdir <- file.path(tempdir(), "test-partial-trait-only")
+  on.exit(unlink(pft_outdir, recursive = TRUE), add = TRUE)
+
+  pft <- create_test_pft(outdir = pft_outdir, pft_name = "test.partial.trait")
+  trait_data <- list(SLA = create_test_trait_data())
+
+  expect_error(
+    PEcAn.MA:::run.meta.analysis.pft(
+      pft = pft,
+      iterations = 1000,
+      random = TRUE,
+      threshold = 1.2,
+      dbfiles = tempdir(),
+      dbcon = NULL,
+      use_ghs = TRUE,
+      update = FALSE,
+      trait_data = trait_data,
+      prior_distns = NULL
+    ),
+    "must both be provided together"
+  )
+})
+
+test_that("run.meta.analysis.pft errors when only prior_distns is provided", {
+  pft_outdir <- file.path(tempdir(), "test-partial-prior-only")
+  on.exit(unlink(pft_outdir, recursive = TRUE), add = TRUE)
+
+  pft <- create_test_pft(outdir = pft_outdir, pft_name = "test.partial.prior")
+  prior_distns <- create_test_priors("SLA")
+
+  expect_error(
+    PEcAn.MA:::run.meta.analysis.pft(
+      pft = pft,
+      iterations = 1000,
+      random = TRUE,
+      threshold = 1.2,
+      dbfiles = tempdir(),
+      dbcon = NULL,
+      use_ghs = TRUE,
+      update = FALSE,
+      trait_data = NULL,
+      prior_distns = prior_distns
+    ),
+    "must both be provided together"
+  )
+})
+
+test_that("run.meta.analysis.pft skips disk loading when in-memory inputs are provided", {
+  # When in-memory inputs are provided, the function must not attempt to read
+  # trait.data.Rdata or prior.distns.Rdata. We verify this by ensuring those
+  # files do not exist on disk and confirming the function still proceeds to
+  # call meta_analysis_standalone() with our in-memory objects (stubbed via
+  # mockery to avoid the JAGS dependency in unit tests).
+  pft_outdir <- file.path(tempdir(), "test-in-memory-skips-load")
+  unlink(pft_outdir, recursive = TRUE)
+  dir.create(pft_outdir, recursive = TRUE, showWarnings = FALSE)
+  on.exit(unlink(pft_outdir, recursive = TRUE), add = TRUE)
+
+  pft <- create_test_pft(outdir = pft_outdir, pft_name = "test.in.memory.skip")
+
+  trait_data <- list(SLA = create_test_trait_data(n_obs = 10))
+  prior_distns <- create_test_priors("SLA")
+
+  # Canned result mimicking what meta_analysis_standalone() returns.
+  # Kept structurally simple so save() succeeds without JAGS objects.
+  fake_ma_result <- list(
+    trait.mcmc  = list(SLA = list()),
+    post.distns = data.frame(
+      distn = "norm", parama = 20, paramb = 5, n = NA_real_,
+      row.names = "SLA", stringsAsFactors = FALSE
+    ),
+    jagged.data = list(SLA = data.frame(Y = 1:10))
+  )
+
+  ma_mock <- mockery::mock(fake_ma_result)
+  mockery::stub(run.meta.analysis.pft, "meta_analysis_standalone", ma_mock)
+  # Stub DB registration so we don't need a real BETY connection
+  mockery::stub(run.meta.analysis.pft, "PEcAn.DB::dbfile.insert", NULL)
+
+  result <- run.meta.analysis.pft(
+    pft = pft,
+    iterations = 100,
+    random = TRUE,
+    threshold = 1.2,
+    dbfiles = tempdir(),
+    dbcon = NULL,
+    use_ghs = TRUE,
+    update = FALSE,
+    trait_data = trait_data,
+    prior_distns = prior_distns,
+    return_data = TRUE
+  )
+
+  # meta_analysis_standalone should be called exactly once with our objects
+  mockery::expect_called(ma_mock, 1)
+  call_args <- mockery::mock_args(ma_mock)[[1]]
+  expect_identical(call_args$trait_data, trait_data)
+  expect_identical(call_args$priors, prior_distns)
+
+  # Return contract: pft with trait.mcmc, post.distns, jagged.data attached
+  expect_type(result, "list")
+  expect_equal(result$name, "test.in.memory.skip")
+  expect_identical(result$trait.mcmc,  fake_ma_result$trait.mcmc)
+  expect_identical(result$post.distns, fake_ma_result$post.distns)
+  expect_identical(result$jagged.data, fake_ma_result$jagged.data)
+
+  # Provenance side-effects: wrapper still writes .Rdata files for audit trail
+  expect_true(file.exists(file.path(pft_outdir, "trait.mcmc.Rdata")))
+  expect_true(file.exists(file.path(pft_outdir, "post.distns.Rdata")))
+  expect_true(file.exists(file.path(pft_outdir, "post.distns.MA.Rdata")))
+  expect_true(file.exists(file.path(pft_outdir, "jagged.data.Rdata")))
+})
+
+test_that("run.meta.analysis.pft returns NA when in-memory trait_data is empty", {
+  pft_outdir <- file.path(tempdir(), "test-in-memory-empty")
+  unlink(pft_outdir, recursive = TRUE)
+  dir.create(pft_outdir, recursive = TRUE, showWarnings = FALSE)
+  on.exit(unlink(pft_outdir, recursive = TRUE), add = TRUE)
+
+  pft <- create_test_pft(outdir = pft_outdir, pft_name = "test.in.memory.empty")
+
+  # Mirrors the disk-path "no observations" branch: when length(trait_data) == 0
+  # the function logs an info message and returns NA without running JAGS.
+  result <- PEcAn.MA:::run.meta.analysis.pft(
+    pft = pft,
+    iterations = 100,
+    random = TRUE,
+    threshold = 1.2,
+    dbfiles = tempdir(),
+    dbcon = NULL,
+    use_ghs = TRUE,
+    update = FALSE,
+    trait_data = list(),
+    prior_distns = create_test_priors("SLA")
+  )
+
+  expect_true(is.na(result))
+})
+
+test_that("run.meta.analysis.pft skip path attaches existing results to returned pft", {
+  pft_outdir <- file.path(tempdir(), "test-skip-attaches-results")
+  unlink(pft_outdir, recursive = TRUE)
+  dir.create(pft_outdir, recursive = TRUE, showWarnings = FALSE)
+  on.exit(unlink(pft_outdir, recursive = TRUE), add = TRUE)
+
+  pft <- create_test_pft(outdir = pft_outdir, pft_name = "test.skip.attaches")
+
+  # Set up input files (precondition) plus the output files that trigger the
+  # skip path. We use recognizable sentinel values to verify they're loaded
+  # and attached, not silently dropped.
+  setup_trait_files(pft$outdir, trait_names = "SLA")
+
+  trait.mcmc <- list(SLA = "sentinel-mcmc")
+  save(trait.mcmc, file = file.path(pft$outdir, "trait.mcmc.Rdata"))
+  post.distns <- data.frame(
+    distn = "norm", parama = 99, paramb = 99, n = NA_real_,
+    row.names = "SLA", stringsAsFactors = FALSE
+  )
+  save(post.distns, file = file.path(pft$outdir, "post.distns.Rdata"))
+  jagged.data <- list(SLA = "sentinel-jagged")
+  save(jagged.data, file = file.path(pft$outdir, "jagged.data.Rdata"))
+
+  result <- PEcAn.MA:::run.meta.analysis.pft(
+    pft = pft,
+    iterations = 1000,
+    random = TRUE,
+    threshold = 1.2,
+    dbfiles = tempdir(),
+    dbcon = NULL,
+    use_ghs = TRUE,
+    update = FALSE,
+    return_data = TRUE
+  )
+
+  expect_equal(result$name, "test.skip.attaches")
+  expect_equal(result$trait.mcmc,  list(SLA = "sentinel-mcmc"))
+  expect_equal(result$post.distns$parama, 99)
+  expect_equal(result$jagged.data, list(SLA = "sentinel-jagged"))
+})
+
+test_that("run.meta.analysis.pft skip path tolerates missing jagged.data.Rdata", {
+  # Older posteriors copied via get.trait.data.pft may not include
+  # jagged.data.Rdata. The skip path should still succeed and return a pft
+  # with trait.mcmc and post.distns attached.
+  pft_outdir <- file.path(tempdir(), "test-skip-no-jagged")
+  unlink(pft_outdir, recursive = TRUE)
+  dir.create(pft_outdir, recursive = TRUE, showWarnings = FALSE)
+  on.exit(unlink(pft_outdir, recursive = TRUE), add = TRUE)
+
+  pft <- create_test_pft(outdir = pft_outdir, pft_name = "test.skip.no.jagged")
+
+  setup_trait_files(pft$outdir, trait_names = "SLA")
+  trait.mcmc <- list()
+  save(trait.mcmc, file = file.path(pft$outdir, "trait.mcmc.Rdata"))
+  post.distns <- data.frame()
+  save(post.distns, file = file.path(pft$outdir, "post.distns.Rdata"))
+  # Deliberately do NOT save jagged.data.Rdata
+
+  result <- PEcAn.MA:::run.meta.analysis.pft(
+    pft = pft,
+    iterations = 1000,
+    random = TRUE,
+    threshold = 1.2,
+    dbfiles = tempdir(),
+    dbcon = NULL,
+    use_ghs = TRUE,
+    update = FALSE,
+    return_data = TRUE
+  )
+
+  expect_type(result, "list")
+  expect_equal(result$name, "test.skip.no.jagged")
+  expect_true("trait.mcmc" %in% names(result))
+  expect_true("post.distns" %in% names(result))
+  expect_false("jagged.data" %in% names(result))
+})
+
+test_that("run.meta.analysis.pft does NOT attach results by default (return_data = FALSE)", {
+  # Guards the serialization-safe default: a pft folded back into a settings
+  # object must not gain large mcmc/jagged fields unless the caller opts in.
+  pft_outdir <- file.path(tempdir(), "test-no-attach-default")
+  unlink(pft_outdir, recursive = TRUE)
+  dir.create(pft_outdir, recursive = TRUE, showWarnings = FALSE)
+  on.exit(unlink(pft_outdir, recursive = TRUE), add = TRUE)
+
+  pft <- create_test_pft(outdir = pft_outdir, pft_name = "test.no.attach")
+
+  # Input + output files present so the function takes the skip path.
+  setup_trait_files(pft$outdir, trait_names = "SLA")
+  trait.mcmc <- list(SLA = "x")
+  save(trait.mcmc, file = file.path(pft$outdir, "trait.mcmc.Rdata"))
+  post.distns <- data.frame()
+  save(post.distns, file = file.path(pft$outdir, "post.distns.Rdata"))
+
+  result <- PEcAn.MA:::run.meta.analysis.pft(
+    pft = pft,
+    iterations = 1000,
+    random = TRUE,
+    threshold = 1.2,
+    dbfiles = tempdir(),
+    dbcon = NULL,
+    use_ghs = TRUE,
+    update = FALSE
+  )
+
+  # Default return_data = FALSE: bare pft, no attached MA outputs.
+  expect_false("trait.mcmc"  %in% names(result))
+  expect_false("post.distns" %in% names(result))
+  expect_false("jagged.data" %in% names(result))
+})

--- a/modules/meta.analysis/tests/testthat/test.run.meta.analysis.R
+++ b/modules/meta.analysis/tests/testthat/test.run.meta.analysis.R
@@ -25,9 +25,35 @@ test_that("`run.meta.analysis.pft` throws an error if it cannot find output from
 
 test_that("`run.meta.analysis.pft` throws an error for missing posteriorid", {
   pft <- list(outdir = "test", name = "ebifarm.salix")
+  # Stub file.exists -> TRUE so the input-file check and the skip-check both pass;
+  # update = TRUE then forces past the skip so we reach the posteriorid check.
   mockery::stub(run.meta.analysis.pft, 'file.exists', TRUE)
   expect_error(
     run.meta.analysis.pft(pft = pft, iterations = 1, dbfiles = NULL, dbcon = NULL, update = TRUE),
     "Missing posteriorid"
   )
+})
+
+test_that("run.meta.analysis returns the list of per-PFT results invisibly", {
+  fake_pft_result <- list(name = "fake.pft", trait.mcmc = "stub", post.distns = "stub")
+  mocked_res <- mockery::mock(fake_pft_result, cycle = TRUE)
+  mockery::stub(run.meta.analysis, 'run.meta.analysis.pft', mocked_res)
+  mockery::stub(run.meta.analysis, 'PEcAn.DB::db.open', 1)
+  mockery::stub(run.meta.analysis, 'PEcAn.DB::db.close', 1)
+
+  pfts <- list('ebifarm.salix', 'temperate.coniferous')
+
+  # The function returns invisibly; verify that explicitly, then unwrap the value.
+  visible_result <- withVisible(
+    run.meta.analysis(pfts = pfts, iterations = 1, dbfiles = NULL, database = NULL)
+  )
+  expect_false(visible_result$visible)
+  result <- visible_result$value
+
+  # Result should be a list, one entry per input PFT, each carrying the
+  # attached MA outputs from run.meta.analysis.pft.
+  expect_type(result, "list")
+  expect_length(result, 2)
+  expect_identical(result[[1]], fake_pft_result)
+  expect_identical(result[[2]], fake_pft_result)
 })


### PR DESCRIPTION
Follows #3978. Cuts the second disk hop in the chain — right now run.meta.analysis.pft() reloads trait.data.Rdata/prior.distns.Rdata that get.trait.data.pft() just wrote seconds earlier.

- Added optional trait_data + prior_distns. Pass both and the load() from pft$outdir is skipped. Pass only one and it errors instead of doing a half-disk/half-memory load.
- Added return_data (default FALSE). On TRUE the MA outputs get attached to the returned pft; on FALSE you get the bare pft like before. Did it this way because of your #3978 point — attaching these to a pft that goes back into settings breaks serialization, so default stays legacy-safe.
- runModule.run.meta.analysis() left on default FALSE since that's the one writing into settings.
- Provenance saves / dbfile.insert() unchanged.
- Also fixed a broken roxygen title on run.meta.analysis.pft.

Format-agnostic on purpose — doesn't touch file formats, that's the separate saveRDS/CSV track. Independent of #3810.
Tests green: FAIL 0 | WARN 0 | SKIP 1 | PASS 116.
GSoC 2026 Week 2.