### PR TITLE
feat(uncertainty): outdir opt-in for get.parameter.samples wrapper (Modularity Part 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - `PEcAn.utils::transformstats()`: corrected the LSD-to-SE conversion. The previous implementation included an extra `sqrt(n)` factor, causing SE estimates derived from LSD to appear `sqrt(n)` times smaller than they should be, non-conservatively over-weighting those observations in meta-analysis. (#3998)
 
 ### Changed
+- `PEcAn.uncertainty::get.parameter.samples()`: replaced the `save_to_disk` flag (from #3860) with an `outdir` argument (default `settings$outdir`) controlling whether `samples.Rdata` is written; `outdir = NULL` skips the save. Existing callers are unaffected (@omkarrr2533, #4016)
 - Updated Docker architecture documentation to match current docker-compose.yml: removed portainer/minio/thredds, added rstudio/api sections, updated service lists and volumes (#3268).
 - Improved PEcAn.SIPNET documentation including README, model description, and current installation instructions (@Eshaan-byte; #3703, #3705).
 - `assign.treatments` has been renamed to `assign_treatments` and moved from `PEcAn.utils` to `PEcAn.MA` since that's the only place where it's used.
@@ -45,7 +46,6 @@ For more information about this file see also [Keep a Changelog](http://keepacha
   `PEcAn.visualization`, `rjags`, `sirt`, and `sp` from `Imports` to
   `Suggests` (@omkarrr2533, #3599).
 - Management events specified via `events.json` are now required to specify a crop code for each planting event, so that models can know when to restart with a different PFT (#3828, #3836).
-
 
 
 ## [1.10.0] - 2026-01-06

--- a/modules/meta.analysis/tests/testthat/test-p.point.in.prior.R
+++ b/modules/meta.analysis/tests/testthat/test-p.point.in.prior.R
@@ -1,22 +1,5 @@
-# test-get.parameter.samples.R
-# Documents the invisible(NULL) return value problem in get.parameter.samples()
-#
-# get.parameter.samples() ends with save() and has no return() statement,
-# so it returns invisible(NULL). This means callers cannot programmatically
-# access results without loading the saved file.
-# The GSoC project "Refactoring the PEcAn trait meta-analysis workflow"
-# aims to fix this by returning a named list instead.
-
-
-
-test_that("get.parameter.samples returns invisible(NULL) — documenting the problem", {
-  skip(paste0(
-    "Requires full PEcAn settings + database connection. ",
-    "Current function ends with save() and no return(), ",
-    "so it returns invisible(NULL). ",
-    "GSoC refactoring will make it return a named list."
-  ))
-})
+# test-p.point.in.prior.R
+# Unit tests for PEcAn.MA:::p.point.in.prior()
 
 # ---------------------------------------------------------------------------
 # p.point.in.prior (helper used throughout the pipeline)

--- a/modules/uncertainty/R/get.parameter.samples.R
+++ b/modules/uncertainty/R/get.parameter.samples.R
@@ -19,7 +19,7 @@
 #'
 #' **File-based side effects (saved to `settings$outdir`):**
 #' \describe{
-#'   \item{`samples.Rdata`}{When `save_to_disk = TRUE`, bundles 5 objects:
+#'   \item{`samples.Rdata`}{When `outdir` is non-`NULL` (the default), bundles 5 objects:
 #'     \itemize{
 #'       \item `trait.samples` — Named list (PFT -> trait -> numeric vector of
 #'         length `iterations`). Raw MCMC or prior-sampled values.
@@ -45,7 +45,11 @@
 #' @param posterior.files list of filenames to read from
 #' @param ens.sample.method one of `"halton"`, `"sobol"`, `"torus"`, `"lhc"`,
 #'   `"uniform"`
-#' @param save_to_disk logical. If `TRUE` (default), saves `samples.Rdata`.
+#' @param outdir character path; directory to write `samples.Rdata` to for
+#'   provenance. Defaults to `settings$outdir`, preserving the legacy
+#'   always-save behaviour for existing callers (none of which pass it).
+#'   Pass `outdir = NULL` to skip the save entirely; the pure
+#'   `get_parameter_samples()` never writes to disk regardless.
 #'
 #' @return Named list with 5 elements: `trait.samples`, `sa.samples`,
 #'   `ensemble.samples`, `runs.samples`, `env.samples`. Returned invisibly.
@@ -60,7 +64,7 @@ get.parameter.samples <- function(settings,
                                   ensemble.size = 1,
                                   posterior.files = rep(NA, length(settings$pfts)),
                                   ens.sample.method = "uniform",
-                                  save_to_disk = TRUE) {
+                                  outdir = settings$outdir) {
   .Deprecated("get_parameter_samples")
 
   ### Identify PFTs in the input settings.xml file
@@ -172,15 +176,19 @@ get.parameter.samples <- function(settings,
     independent       = independent
   )
 
-  ## ---- Save to disk for backward compatibility ----
-  if (save_to_disk) {
+  ## ---- Save to disk for provenance (opt-in via `outdir`) ----
+  # `outdir` defaults to `settings$outdir`, so existing callers (none of which
+  # pass it) write `samples.Rdata` exactly as before. Pass `outdir = NULL` to
+  # skip the save for a purely in-memory call; the pure get_parameter_samples()
+  # never writes to disk at all.
+  if (!is.null(outdir)) {
     ensemble.samples <- result$ensemble.samples
     trait.samples    <- result$trait.samples
     sa.samples       <- result$sa.samples
     runs.samples     <- result$runs.samples
     env.samples      <- result$env.samples
     save(ensemble.samples, trait.samples, sa.samples, runs.samples, env.samples,
-         file = file.path(settings$outdir, "samples.Rdata"))
+         file = file.path(outdir, "samples.Rdata"))
   }
 
   invisible(result)

--- a/modules/uncertainty/man/get.parameter.samples.Rd
+++ b/modules/uncertainty/man/get.parameter.samples.Rd
@@ -9,7 +9,7 @@ get.parameter.samples(
   ensemble.size = 1,
   posterior.files = rep(NA, length(settings$pfts)),
   ens.sample.method = "uniform",
-  save_to_disk = TRUE
+  outdir = settings$outdir
 )
 }
 \arguments{
@@ -22,7 +22,11 @@ get.parameter.samples(
 \item{ens.sample.method}{one of \code{"halton"}, \code{"sobol"}, \code{"torus"}, \code{"lhc"},
 \code{"uniform"}}
 
-\item{save_to_disk}{logical. If \code{TRUE} (default), saves \code{samples.Rdata}.}
+\item{outdir}{character path; directory to write \code{samples.Rdata} to for
+provenance. Defaults to \code{settings$outdir}, preserving the legacy
+always-save behaviour for existing callers (none of which pass it).
+Pass \code{outdir = NULL} to skip the save entirely; the pure
+\code{get_parameter_samples()} never writes to disk regardless.}
 }
 \value{
 Named list with 5 elements: \code{trait.samples}, \code{sa.samples},
@@ -48,7 +52,7 @@ independent samples are drawn from \code{post.distns}.}
 
 \strong{File-based side effects (saved to \code{settings$outdir}):}
 \describe{
-\item{\code{samples.Rdata}}{When \code{save_to_disk = TRUE}, bundles 5 objects:
+\item{\code{samples.Rdata}}{When \code{outdir} is non-\code{NULL} (the default), bundles 5 objects:
 \itemize{
 \item \code{trait.samples} — Named list (PFT -> trait -> numeric vector of
 length \code{iterations}). Raw MCMC or prior-sampled values.

--- a/modules/uncertainty/tests/testthat/test-get.parameter.samples.R
+++ b/modules/uncertainty/tests/testthat/test-get.parameter.samples.R
@@ -1,0 +1,160 @@
+# ============================================================
+# Tests for the get.parameter.samples() wrapper (Layer 2)
+#
+# These exercise the WRAPPER's behaviour, not the pure
+# get_parameter_samples() (covered in test-get_parameter_samples.R).
+#
+# Focus: the `outdir` argument added in GSoC 2026 Week 3, which
+# replaced the `save_to_disk` flag from #3860:
+#   * default (outdir = settings$outdir) -> writes samples.Rdata as before
+#   * explicit outdir                    -> writes there instead
+#   * outdir = NULL                      -> no save
+#   * the saved file keeps the 5-object name contract
+#   * the result list is still returned invisibly
+#   * the loaded posteriors are still delegated to the pure function
+#
+# load.posteriors() and get_parameter_samples() are stubbed with
+# mockery so these run with no database and no real MCMC objects.
+# ============================================================
+
+skip_if_not_installed("mockery")
+skip_if_not_installed("PEcAn.logger")
+skip_if_not_installed("withr")
+
+# ---- Helper: minimal single-PFT settings (no $database -> no DB calls) ----
+make_test_settings <- function(outdir) {
+  list(
+    pfts = list(list(name = "temperate.deciduous", outdir = outdir)),
+    outdir = outdir
+  )
+}
+
+# ---- Helper: canned load.posteriors() return ----
+fake_posterior <- function() {
+  list(
+    prior.distns = data.frame(
+      distn = "norm", parama = 20, paramb = 5, n = 50,
+      row.names = "SLA", stringsAsFactors = FALSE
+    ),
+    trait.mcmc = NULL,
+    is.joint = FALSE
+  )
+}
+
+# ---- Helper: canned get_parameter_samples() return ----
+fake_samples_result <- function() {
+  list(
+    trait.samples    = list(),
+    sa.samples       = list(),
+    ensemble.samples = list(),
+    runs.samples     = list(),
+    env.samples      = list()
+  )
+}
+
+
+# Save location is driven by `outdir`
+
+test_that("samples.Rdata is written to settings$outdir by default", {
+  tmp <- withr::local_tempdir()
+  settings <- make_test_settings(tmp)
+
+  mockery::stub(get.parameter.samples, "load.posteriors", fake_posterior())
+  mockery::stub(get.parameter.samples, "get_parameter_samples", fake_samples_result())
+
+  suppressWarnings(get.parameter.samples(settings))
+
+  expect_true(file.exists(file.path(tmp, "samples.Rdata")))
+})
+
+
+test_that("explicit outdir overrides settings$outdir for the save", {
+  tmp_settings <- withr::local_tempdir()
+  tmp_explicit <- withr::local_tempdir()
+  settings <- make_test_settings(tmp_settings)
+
+  mockery::stub(get.parameter.samples, "load.posteriors", fake_posterior())
+  mockery::stub(get.parameter.samples, "get_parameter_samples", fake_samples_result())
+
+  suppressWarnings(get.parameter.samples(settings, outdir = tmp_explicit))
+
+  expect_true(file.exists(file.path(tmp_explicit, "samples.Rdata")))
+  expect_false(file.exists(file.path(tmp_settings, "samples.Rdata")))
+})
+
+
+test_that("outdir = NULL skips the save entirely", {
+  tmp <- withr::local_tempdir()
+  settings <- make_test_settings(tmp)
+
+  mockery::stub(get.parameter.samples, "load.posteriors", fake_posterior())
+  mockery::stub(get.parameter.samples, "get_parameter_samples", fake_samples_result())
+
+  suppressWarnings(get.parameter.samples(settings, outdir = NULL))
+
+  expect_false(file.exists(file.path(tmp, "samples.Rdata")))
+})
+
+
+# Saved file keeps the downstream name contract
+
+test_that("samples.Rdata bundles the 5 expected objects", {
+  # Downstream consumers (run.write.configs, get.results,
+  # run.sensitivity.analysis, read.ensemble.ts) read these exact names,
+  # so the save contract must not drift.
+  tmp <- withr::local_tempdir()
+  settings <- make_test_settings(tmp)
+
+  mockery::stub(get.parameter.samples, "load.posteriors", fake_posterior())
+  mockery::stub(get.parameter.samples, "get_parameter_samples", fake_samples_result())
+
+  suppressWarnings(get.parameter.samples(settings))
+
+  e <- new.env()
+  load(file.path(tmp, "samples.Rdata"), envir = e)
+  expect_setequal(
+    ls(e),
+    c("ensemble.samples", "trait.samples", "sa.samples",
+      "runs.samples", "env.samples")
+  )
+})
+
+
+# Return contract
+
+test_that("returns the get_parameter_samples result invisibly", {
+  tmp <- withr::local_tempdir()
+  settings <- make_test_settings(tmp)
+  fake <- fake_samples_result()
+
+  mockery::stub(get.parameter.samples, "load.posteriors", fake_posterior())
+  mockery::stub(get.parameter.samples, "get_parameter_samples", fake)
+
+  # withVisible must sit INSIDE suppressWarnings, so it captures the
+  # wrapper's own visibility rather than suppressWarnings()'s.
+  vis <- suppressWarnings(
+    withVisible(get.parameter.samples(settings, outdir = NULL))
+  )
+
+  expect_identical(vis$value, fake)
+  expect_false(vis$visible)
+})
+
+# Delegation still wired correctly after the edit
+
+test_that("loaded posteriors are delegated to get_parameter_samples", {
+  tmp <- withr::local_tempdir()
+  settings <- make_test_settings(tmp)
+  post <- fake_posterior()
+
+  mockery::stub(get.parameter.samples, "load.posteriors", post)
+  mock_gps <- mockery::mock(fake_samples_result())
+  mockery::stub(get.parameter.samples, "get_parameter_samples", mock_gps)
+
+  suppressWarnings(get.parameter.samples(settings, outdir = NULL))
+
+  mockery::expect_called(mock_gps, 1)
+  args <- mockery::mock_args(mock_gps)[[1]]
+  expect_identical(args$prior_distns_list[[1]], post$prior.distns)
+  expect_true(args$independent)
+})


### PR DESCRIPTION
Third PR in the trait → meta-analysis → parameter-sampling modularity series (after #3860 Part 1, #4010 Part 2). Cleans up the `get.parameter.samples()` wrapper now that the pure `get_parameter_samples()` from #3860 does the computation.

## What changed
- Replaces the `save_to_disk` flag (added in #3860) with an `outdir` parameter, default `settings$outdir`. `samples.Rdata` is written when `outdir` is non-NULL (the default) and skipped when `outdir = NULL`. This matches the `outdir`-as-opt-in-provenance convention used across the rest of the refactor.
- The wrapper stays `.Deprecated` and still delegates to `get_parameter_samples()`. The return value is unchanged from develop — it returns the samples list invisibly (the switch from `invisible(NULL)` to the list landed in #3860); this PR just adds a test that locks that contract in.

## Backward compatibility
No behavior change for existing callers — none of them pass the new argument, so `outdir` defaults to `settings$outdir` and `samples.Rdata` is written exactly as before. The only removal is `save_to_disk`: grepped the repo, it appears only inside `get.parameter.samples.R` and nothing passes it, so dropping it is safe (it was never in a release).

Per the Slack discussion with @mdietze and @infotroph: nothing changes for disk-writing workflows in this PR. The `ensemble.samples.*.Rdata` / `sensitivity.samples.*.Rdata` files that workflows like the SIPNET segmented restart (#3919 / #4008) rely on are written by `run.write.configs()`, which this PR does not touch, and `samples.Rdata` still writes by default. Migrating the `generate_*_design()` and SDA callers to the dash function is deferred to Phase 2/3.

## Tests
Adds `test-get.parameter.samples.R` in the correct package path (`modules/uncertainty/`): default save to `settings$outdir`, explicit `outdir` override, `outdir = NULL` skip, the 5-object `samples.Rdata` name contract, invisible return, and delegation to `get_parameter_samples()`. `load.posteriors()` and `get_parameter_samples()` are stubbed with `mockery`, so it runs with no database. Local run for this file: `[ FAIL 0 | SKIP 0 | PASS 10 ]`.

Also relocates the misplaced `test-get.parameter.samples.R` under `modules/meta.analysis/tests/testthat/` (added in #3858): renamed to `test-p.point.in.prior.R` since its remaining tests cover the `PEcAn.MA` helper `p.point.in.prior()`, and dropped the obsolete `get.parameter.samples` skip-test (stale since #3860, superseded by the test added here).