### PR TITLE
use tempfile for duckdb dbdir to avoid concurrent collision

### DIFF
--- a/workflows/preprocess-event-parquet/01a-clean-irrigation.R
+++ b/workflows/preprocess-event-parquet/01a-clean-irrigation.R
@@ -5,7 +5,7 @@ irr_path <- "/projectnb/dietzelab/ccmmf/usr/ashiklom/event-outputs/irrigation_al
 outdir <- "_output"
 dir.create(outdir, showWarnings = FALSE, recursive = TRUE)
 
-dbdir <- file.path(Sys.getenv("TMPDIR", "/tmp"), "temp.duckdb")
+dbdir <- tempfile("duckdb", fileext = ".duckdb")
 conn <- DBI::dbConnect(duckdb::duckdb(dbdir = dbdir))
 on.exit({
   DBI::dbDisconnect(conn, shutdown = TRUE)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->
switches the temp dbdir from a fixed path

two R sessions on same host with the same $TMPDIR collide on the same file, and duckdb's exclusive lock makes the second one fail with an IO exception.
tempfile() gives each R session its own unique path. on.exit cleanup stays as belt and suspenders, R's session tempdir cleanup catches any leftovers even on crash


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
