### PR TITLE
test(uncertainty): add integration test for the trait → MA → samples chain

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,20 +5,30 @@ on :
 
   schedule:
     # run Thursday 4:30 AM UTC
-  - cron: '30 4 * * 4'    
+  - cron: '30 4 * * 4'
 jobs:
   test:
     runs-on: ubuntu-latest
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    
-    container: 
+      PGHOST: postgres
+
+    services:
+      postgres:
+        image: mdillon/postgis:9.5
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    container:
       image: pecan/base:develop
 
     steps:
     - name: Checkout source code
       uses: actions/checkout@v4
+
+    # initialize database
+    - name: db setup
+      uses: docker://pecan/db:ci
 
     - name: Run tests
       run: |
@@ -29,3 +39,6 @@ jobs:
             Rscript "$FILE"
           fi
         done
+
+    - name: Run modular pipeline integration test
+      run: Rscript modules/uncertainty/inst/integrationTests/test.modular.chain.R

--- a/modules/uncertainty/inst/integrationTests/test.modular.chain.R
+++ b/modules/uncertainty/inst/integrationTests/test.modular.chain.R
@@ -1,0 +1,103 @@
+# Integration test: modular trait -> meta-analysis -> parameter-sampling chain
+#
+# Runs the in-memory (Layer 1) pipeline end to end against a live BETYdb and
+# checks only that each step's output is accepted by the next without error and
+# keeps its documented shape. It does not check whether the values are correct
+# or scientifically sensible -- that is the job of the per-package unit tests,
+# not of an integration test.
+#
+# Executed via `Rscript` from .github/workflows/integration-test.yml, inside
+# pecan/base:develop (all PEcAn packages plus JAGS installed) with a BETYdb
+# stood up the same way .github/workflows/test.yml does it.
+
+library(testthat)
+library(PEcAn.DB)
+library(PEcAn.MA)
+library(PEcAn.uncertainty)
+
+test_modular_chain <- function(pft_name, modeltype, trait_names,
+                               iterations    = 3000,
+                               ensemble.size = 10) {
+
+  PEcAn.logger::logger.setUseConsole(TRUE, FALSE)
+  on.exit(PEcAn.logger::logger.setUseConsole(TRUE, TRUE), add = TRUE)
+  PEcAn.logger::logger.setLevel("DEBUG")
+
+  # Connection details come from the Postgres env vars set by the workflow
+  # (PGHOST = postgres); the bety/bety/bety defaults match the pecan/db:ci
+  # image. Override these env vars to point at a different BETY when running
+  # the script locally.
+  con <- PEcAn.DB::db.open(list(
+    driver   = "Postgres",
+    host     = Sys.getenv("PGHOST", "postgres"),
+    user     = Sys.getenv("PGUSER", "bety"),
+    password = Sys.getenv("PGPASSWORD", "bety"),
+    dbname   = Sys.getenv("PGDATABASE", "bety")
+  ))
+  on.exit(PEcAn.DB::db.close(con), add = TRUE)
+
+  withr::with_dir(tempdir(), {
+
+    # ---- Step 1: trait retrieval (queries BETYdb, returns objects) ----
+    trait_step <- PEcAn.DB::get_trait_data_pft(
+      pft_name    = pft_name,
+      modeltype   = modeltype,
+      dbcon       = con,
+      trait_names = trait_names
+    )
+
+    test_that("get_trait_data_pft returns the documented structure", {
+      expect_named(trait_step, c("trait_data", "prior_distns", "pft_info"),
+                   ignore.order = TRUE)
+      expect_type(trait_step$trait_data, "list")
+      expect_s3_class(trait_step$prior_distns, "data.frame")
+    })
+
+    # ---- Step 2: meta-analysis consumes the trait-step output ----
+    ma <- PEcAn.MA::meta_analysis_standalone(
+      trait_data = trait_step$trait_data,
+      priors     = trait_step$prior_distns,
+      iterations = iterations,
+      pft_name   = pft_name
+    )
+
+    test_that("meta_analysis_standalone consumes trait output and returns MA results", {
+      expect_named(ma, c("trait.mcmc", "post.distns", "jagged.data"),
+                   ignore.order = TRUE)
+      expect_s3_class(ma$post.distns, "data.frame")
+      expect_type(ma$trait.mcmc, "list")
+    })
+
+    # ---- Step 3: parameter sampling consumes the meta-analysis output ----
+    # The pure get_parameter_samples() takes the posterior distributions in
+    # prior_distns_list and the MCMC chains in trait_mcmc_list.
+    samples <- PEcAn.uncertainty::get_parameter_samples(
+      pft_names         = pft_name,
+      prior_distns_list = list(ma$post.distns),
+      trait_mcmc_list   = list(ma$trait.mcmc),
+      ensemble.size     = ensemble.size,
+      sa_quantiles      = c(0.025, 0.25, 0.5, 0.75, 0.975),
+      do_ensemble       = TRUE
+    )
+
+    test_that("get_parameter_samples consumes MA output and returns the samples list", {
+      expect_named(
+        samples,
+        c("trait.samples", "sa.samples", "ensemble.samples",
+          "runs.samples", "env.samples"),
+        ignore.order = TRUE
+      )
+      expect_type(samples$trait.samples, "list")
+    })
+  })
+
+  PEcAn.logger::logger.info(
+    "Modular chain integration test passed: trait -> meta-analysis -> samples"
+  )
+}
+
+test_modular_chain(
+  pft_name    = "temperate.deciduous",
+  modeltype   = "SIPNET",
+  trait_names = c("SLA")
+)


### PR DESCRIPTION
Adds an integration test that runs the modular chain end to end (get_trait_data_pft → meta_analysis_standalone → get_parameter_samples) and checks that each step's output feeds the next with the right shape. It doesn't look at whether the numbers are right, just that the objects flow through without errors. The scientific checks stay in the unit tests, as discussed on Slack.

The test is a plain Rscript at modules/uncertainty/inst/integrationTests/test.modular.chain.R, following the same pattern as the data.atmosphere integration tests, and runs from integration-test.yml on the existing weekly cron. The workflow now stands up a BETY in the container the same way test.yml does, since the first step is a live get_trait_data_pft query.

A few notes:
- No stopifnot. A failing test_that already halts the script under Rscript, so the job exits non-zero on its own.
- Using SLA for temperate.deciduous, since the meta-analysis rejects leaf_respiration_rate_m2 against its prior in the CI bety. SLA is one it can actually process, which is all the plumbing test needs.
- Ran it locally end to end against pecan/db:ci + JAGS. Exit 0, all three steps pass.

Depends on #3978 (get_trait_data_pft), so it's branched off that and opened as a draft. The cron and manual runs can only pass once #3978 is merged and base:develop rebuilds. I'll rebase onto develop once that lands, which also clears #3978's files out of this diff.