### PR TITLE
fix(assim.sequential): fix dead-code guard in SDA_OBS_Assembler and deprecated db call in Prep_OBS_SDA

### DIFF
--- a/modules/assim.sequential/R/Prep_OBS_SDA.R
+++ b/modules/assim.sequential/R/Prep_OBS_SDA.R
@@ -20,11 +20,8 @@ Prep_OBS_SDA <- function(settings, out_dir, AGB_dir, Search_Window=30){
   }
   
   #query site info
-  bety <- dplyr::src_postgres(dbname   = settings$database$bety$dbname,
-                              host     = settings$database$bety$host,
-                              user     = settings$database$bety$user,
-                              password = settings$database$bety$password)
-  con <- bety$con
+  con <- PEcAn.DB::db.open(settings$database$bety)
+  on.exit(PEcAn.DB::db.close(con), add = TRUE)
   
   #grab site info
   site_ID <- observations

--- a/modules/assim.sequential/R/SDA_OBS_Assembler.R
+++ b/modules/assim.sequential/R/SDA_OBS_Assembler.R
@@ -70,11 +70,16 @@ SDA_OBS_Assembler <- function(settings){
     
     #if we are dealing with different timestep for different variables.
     if (diff_dates){
-      timestep[[i]] <- Obs_Prep[[i]]$timestep
-      if (!exists("timestep")){
-        PEcAn.logger::logger.error(paste0("Please provide timestep under each variable if you didn't provide timestep under Obs_Prep section!"))
+      # Each variable section must have its own 'timestep' sub-element when no
+      # global Obs_Prep$timestep is defined. Check for this explicitly.
+      if (is.null(Obs_Prep[[i]]$timestep)){
+        PEcAn.logger::logger.error(
+          paste0("Please provide 'timestep' under the '", names(Obs_Prep)[i],
+                 "' variable section of Obs_Prep,",
+                 " since no global Obs_Prep$timestep was found."))
         return(0)
       }
+      timestep[[i]] <- Obs_Prep[[i]]$timestep
       time_points <- obs_timestep2timepoint(Obs_Prep[[i]]$start.date, Obs_Prep[[i]]$end.date, timestep[[i]])
     }else{
       timestep[[i]] <- Obs_Prep$timestep


### PR DESCRIPTION
## Changes

Fixes #4024 
### `modules/assim.sequential/R/SDA_OBS_Assembler.R`
- Replaced unreachable `exists("timestep")` guard (which checked the R variable binding, always TRUE since `timestep` is initialized as `list()` at line 58) with a meaningful `is.null(Obs_Prep[[i]]$timestep)` check that validates the per-variable settings sub-element when `diff_dates == TRUE`.
- - Now gives a clear `logger.error` message identifying which variable section is missing its `timestep` element.
### `modules/assim.sequential/R/Prep_OBS_SDA.R`
- Replaced deprecated `dplyr::src_postgres()` (removed in dplyr 1.0) with `PEcAn.DB::db.open()` + `on.exit(PEcAn.DB::db.close())`, consistent with the rest of the codebase.
## Context

`SDA_OBS_Assembler` is the modern recommended entry point for multi-site, multi-variable SDA observation ingest and alignment. These fixes ensure the pipeline fails with clear diagnostics rather than silently producing incorrect output -- critical for MAGiC calibration and GSOC benchmarking/validation workflows.

## Testing
- Existing `testthat` tests in `modules/assim.sequential/tests/testthat/` continue to pass.
- - The dead-code fix is logic-only (no behavior change for valid inputs); the error path now correctly fires when a per-variable `timestep` element is missing.