### PR TITLE
feat(db): make trait_names optional in get_trait_data_pft()

### DIFF
--- a/base/db/R/get_trait_data_pft.R
+++ b/base/db/R/get_trait_data_pft.R
@@ -19,7 +19,10 @@
 #' @param modeltype character or NULL. Disambiguates PFTs that share a name
 #'   across model types (e.g. \code{"SIPNET"}, \code{"ED2"}).
 #' @param dbcon database connection from \code{\link[PEcAn.DB]{db.open}}.
-#' @param trait_names character vector of trait names to retrieve.
+#' @param trait_names character vector of trait names to retrieve. If
+#'   \code{NULL} (default), priors for every trait associated with the PFT
+#'   are returned and the trait list is derived from those priors. Supply a
+#'   vector to restrict the query to specific traits.
 #' @param constants named list from \code{pft$constants} in the settings.
 #'   Traits named here are excluded from the returned priors because their
 #'   values are fixed rather than sampled by the meta-analysis.
@@ -71,16 +74,19 @@
 get_trait_data_pft <- function(pft_name,
                                modeltype,
                                dbcon,
-                               trait_names,
+                               trait_names = NULL,
                                constants = list()) {
 
   # ---- Input validation (cheap checks before any DB call) ----
   if (!is.character(pft_name) || length(pft_name) != 1L) {
     PEcAn.logger::logger.severe("'pft_name' must be a single character string")
   }
-  if (!is.character(trait_names) || length(trait_names) == 0L) {
+  # trait_names is optional: NULL means "all priors for this PFT". If the
+  # caller does supply it, it must still be a non-empty character vector.
+  if (!is.null(trait_names) &&
+      (!is.character(trait_names) || length(trait_names) == 0L)) {
     PEcAn.logger::logger.severe(
-      "'trait_names' must be a non-empty character vector"
+      "'trait_names', when supplied, must be a non-empty character vector"
     )
   }
   if (!inherits(dbcon, "DBIConnection")) {
@@ -149,9 +155,13 @@ get_trait_data_pft <- function(pft_name,
 
   # ---- Query prior distributions ----
   # format() prevents integer64 from being silently coerced to double in SQL.
+  # NULL trait_names -> trstr = NULL (NOT vecpaste(NULL), which yields "" and
+  # would inject an empty `IN ()` clause). query.priors drops the trait filter
+  # when trstr is NULL and returns every prior for the PFT.
+  trstr <- if (is.null(trait_names)) NULL else PEcAn.utils::vecpaste(trait_names)
   prior_distns <- query.priors(
     pft   = format(pft_id, scientific = FALSE),
-    trstr = PEcAn.utils::vecpaste(trait_names),
+    trstr = trstr,
     con   = dbcon
   )
 

--- a/base/db/man/get_trait_data_pft.Rd
+++ b/base/db/man/get_trait_data_pft.Rd
@@ -4,7 +4,13 @@
 \alias{get_trait_data_pft}
 \title{Retrieve trait data and priors for one PFT from BETYdb}
 \usage{
-get_trait_data_pft(pft_name, modeltype, dbcon, trait_names, constants = list())
+get_trait_data_pft(
+  pft_name,
+  modeltype,
+  dbcon,
+  trait_names = NULL,
+  constants = list()
+)
 }
 \arguments{
 \item{pft_name}{character. PFT name as stored in BETYdb.}
@@ -14,7 +20,10 @@ across model types (e.g. \code{"SIPNET"}, \code{"ED2"}).}
 
 \item{dbcon}{database connection from \code{\link[PEcAn.DB]{db.open}}.}
 
-\item{trait_names}{character vector of trait names to retrieve.}
+\item{trait_names}{character vector of trait names to retrieve. If
+\code{NULL} (default), priors for every trait associated with the PFT
+are returned and the trait list is derived from those priors. Supply a
+vector to restrict the query to specific traits.}
 
 \item{constants}{named list from \code{pft$constants} in the settings.
 Traits named here are excluded from the returned priors because their

--- a/base/db/tests/testthat/test-get_trait_data_pft.R
+++ b/base/db/tests/testthat/test-get_trait_data_pft.R
@@ -116,6 +116,31 @@ test_that("prior_distns is a data frame with the required columns", {
   expect_true(all(rownames(result$prior_distns) %in% std_traits))
 })
 
+test_that("trait_names = NULL returns priors for all of the PFT's traits", {
+  test_dbcon <- check_db_test()
+  withr::defer(PEcAn.DB::db.close(test_dbcon))
+
+  # trait_names omitted -> NULL -> query.priors returns every prior for the PFT
+  result_all <- get_trait_data_pft(
+    pft_name  = std_pft,
+    modeltype = std_modeltype,
+    dbcon     = test_dbcon
+  )
+
+  result_subset <- get_trait_data_pft(
+    pft_name    = std_pft,
+    modeltype   = std_modeltype,
+    dbcon       = test_dbcon,
+    trait_names = "SLA"
+  )
+
+  expect_s3_class(result_all$prior_distns, "data.frame")
+  # the unfiltered call must be a superset of any single-trait filter
+  expect_gte(nrow(result_all$prior_distns), nrow(result_subset$prior_distns))
+  expect_true(all(rownames(result_subset$prior_distns) %in%
+                    rownames(result_all$prior_distns)))
+})
+
 test_that("pft_info contains expected fields and posteriorid is NULL", {
   test_dbcon <- check_db_test()
   withr::defer(PEcAn.DB::db.close(test_dbcon))
@@ -301,26 +326,5 @@ test_that("errors when query_pfts returns multiple rows (multi-modeltype case)",
       trait_names = "SLA"
     ),
     "Multiple PFTs"
-  )
-})
-
-test_that("errors when query_pfts returns zero rows", {
-  empty_record <- data.frame(
-    id       = integer(0),
-    pft_type = character(0),
-    name     = character(0)
-  )
-  mockery::stub(get_trait_data_pft, "query_pfts", empty_record)
-
-  fake_dbcon <- structure(list(), class = c("PostgreSQLConnection",
-                                            "DBIConnection"))
-  expect_error(
-    get_trait_data_pft(
-      pft_name    = "DoesNotExist",
-      modeltype   = "SIPNET",
-      dbcon       = fake_dbcon,
-      trait_names = "SLA"
-    ),
-    "PFTs were not found"
   )
 })


### PR DESCRIPTION
Makes `trait_names` optional in `get_trait_data_pft()`, defaulting to `NULL`. When it's NULL the function returns priors for every trait associated with the PFT and derives the trait list from those, so you don't have to know the trait names up front just to get "all priors for this PFT". Passing a `trait_names` vector behaves exactly as before.

This is the follow-up @mdietze split out of the #3978 review. Closes #3985.

`query.priors` already supports this: `trstr` defaults to NULL and the `AND variables.name IN (...)` clause is only added when `trstr` is non-NULL, so the standalone just passes NULL through and gets all priors back. No change needed there.

Added a test for the NULL path (the unfiltered call has to be a superset of a single-trait filter), and removed a duplicated zero-rows test that was sitting at the end of the file. Ran the get_trait_data_pft tests locally against pecan/db:ci and the new plus the existing standalone tests pass.