### PR TITLE
Pkgdown: use muffleWarning only if available

### DIFF
--- a/scripts/build_pkgdown.R
+++ b/scripts/build_pkgdown.R
@@ -81,7 +81,7 @@ build_quietly <- function(pkg, ...) {
         "⚠️ Warning building pkgdown site for", pkg, ":", w$message
       )
       warns <<- append(warns, w)
-      invokeRestart("muffleWarning")
+      tryInvokeRestart("muffleWarning")
     }
   )
 


### PR DESCRIPTION
Trying to work around error `no 'restart' 'muffleWarning' found` in the [pkgdown CI job](https://github.com/PecanProject/pecan/actions/runs/28045720870/job/83023166467)

Per advice in ?conditions:
> invocation of a "muffleWarning" restart should be optional because the warning might
> have been signalled by the user or from a different package with the stop or message
> protocols. Only use invokeRestart when you have control of the signalling context,
> or when it is a logical error if the restart is not available.

Testing disclosure: Worked for me in a local `./scripts/build_pkgdown.R models/rothc`,
but so did the previous version. I haven't yet found a way to reproduce the failure locally.
