### PR TITLE
ensure deps and Roxygen are up to date before running pkgdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,12 @@ recurse_dir = $(foreach d, $(wildcard $1*), $(call recurse_dir, $d/) $d)
 # For output from recurse_dir this removes all dirs, but in other cases beware.
 drop_parents = $(filter-out $(patsubst %/,%,$(dir $1)), $1)
 
-# Generates a list of regular files at any depth inside its argument
-files_in_dir = $(call drop_parents, $(call recurse_dir, $1))
+# Generates a list of regular files at any depth inside its argument,
+# excluding those in any `docs` folder
+files_in_dir = $(filter-out \
+  ${1}/docs/%, \
+  $(call drop_parents, $(call recurse_dir,$1)))
+
 
 # Git hash + clean status for this directory
 git_rev = $(shell \
@@ -118,9 +122,8 @@ check_modules: $(BASE_I) $(MODULES_C)
 
 document: $(ALL_PKGS_D) .doc/base/all
 
-pkgdocs:
+pkgdocs: $(ALL_PKGS_D) .doc/base/all
 	Rscript scripts/build_pkgdown.R $(ALL_PKGS) base/all || exit 1
-	
 
 install: $(ALL_PKGS_I) .install/base/all
 check: $(ALL_PKGS_C) .check/base/all

--- a/scripts/build_pkgdown.R
+++ b/scripts/build_pkgdown.R
@@ -33,6 +33,7 @@ build_and_copy <- function(pkg, branch, outdir) {
 
   pkgdown::build_site(
     pkg = ".",
+    lazy = TRUE,
     override = list(
       "llm-docs" = FALSE,
       repo = list(url = list(source = url_str)),


### PR DESCRIPTION
* Updates prerequisites for `make pkgdocs` to ensure Roxygen docs are up to date before running pkgdown. Needed because Pkgdown works from existing Rd pages and does not check whether they're in sync with the source comments.
* The above also works to ensure that all dependencies are up to date, fixing the current proximal cause of CI failure in #3788
* Removes each package's `docs/` folder from the list of files considered when checking if `document`, `test`, `check`, or `install` need to run. Otherwise running pkgdown immediately marks everything as needing redocumentation, reinstallation, etc.
* sets `lazy = TRUE` in the `pkgdown::build_site()` call, to avoid recompiling pages that haven't changed since the last pkgdown run.

known pkgdown issues not addressed here:
* Issues with capturing warnings from pkgdown, discussed in #4034 
* `make pkgdocs` currently always rebuilds all package sites, which takes several minutes. It would be nice to refactor it to only update the packages that are out of date.