### PR TITLE
Performance: Fix O(N^2) DB write bottleneck in start_model_runs.R for…

### DIFF
--- a/base/workflow/R/start_model_runs.R
+++ b/base/workflow/R/start_model_runs.R
@@ -321,12 +321,7 @@ start_model_runs <- function(settings, write = TRUE, stop.on.error = TRUE) {
         }
         
         # Write finish time to database
-        #TODO this repeats for every run in `jobids` writing every run's time stamp every time. This actually takes quite a long time with a lot of ensembles and should either 1) not be a for loop (no `for(x in run_list)`) or 2) if `is_modellauncher`, be done outside of the jobids for loop after all jobs are finished.
-        if (is_modellauncher && write) {
-          for (x in run_list) {
-            PEcAn.DB::stamp_finished(con = dbcon, run = x)
-          }
-        } else {
+        if (!is_modellauncher) {
           if (write) {
             PEcAn.DB::stamp_finished(con = dbcon, run = run)
           }
@@ -349,6 +344,12 @@ start_model_runs <- function(settings, write = TRUE, stop.on.error = TRUE) {
       } # End job finished
     }  # end loop over runs
   }  # end while loop checking runs
+  
+  if (is_modellauncher && write) {
+    for (x in run_list) {
+      PEcAn.DB::stamp_finished(con = dbcon, run = x)
+    }
+  }
   
   # Copy data back to local
   if (!is_local) {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->
**Requested Labels:** `Type: Enhancement`, `Type: Performance`

## Description
<!--- Describe your changes in detail -->
This PR refactors the database stamping logic in `start_model_runs.R` for `is_modellauncher` workflows. Previously, a nested `for` loop executing `PEcAn.DB::stamp_finished` for every run in `run_list` was located inside the main job-checking `while` loop. 

This PR removes that heavy database loop from the inner waiting-room loop and defers it. Now, the system waits for the overarching jobs to finish cleanly, and then iterates over `run_list` exactly once at the very end of the function to mark all runs as finished in the database.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is required to solve a massive $O(N^2)$ scaling bottleneck when dealing with large model ensembles. The previous redundant loop overhead would freeze up the workflow engine to query the database tens of thousands of times unnecessarily, adding extreme latency to `modellauncher` workflows. 

**Closes #4044**

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [x] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- #4044 -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [x] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
