### PR TITLE
Add ILAMB scorecard generation and hosting (follow-on to #4038)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 ## Unreleased
 
 ### Added
+- Added `make_scorecard.sh` and documentation to `inst/ilamb/` in PEcAn.benchmark for generating and serving the ILAMB HTML scorecard.
 - New function `PEcAn.utils::netcdf2df()` flattens all dims and vars of a netCDF into a dataframe,
     with units attached as an attribute.
 - New package `PEcAn.RothC` runs the RothC soil carbon model.

--- a/modules/benchmark/inst/ilamb/README.md
+++ b/modules/benchmark/inst/ilamb/README.md
@@ -296,3 +296,21 @@ score relative to the other variables, and the `weight` on each dataset block
 sets how much that dataset counts within its variable. Both are relative
 weights, not percentages. See the inline comments in the config for the full
 per-field reference.
+
+## Generating the scorecard
+
+ILAMB produces an interactive HTML scorecard alongside the numeric scores. To
+generate it for a window, run `make_scorecard.sh` against that window's model
+root (built by the pipeline above):
+
+```bash
+export ILAMB_ROOT=/path/to/ILAMB_ROOT
+./make_scorecard.sh 2012_2014
+./make_scorecard.sh 2015_2023
+```
+
+Each run writes a self-contained static site (`index.html` plus assets) to a
+build directory, which can be served directly by copying it under a web
+server's document root. The scorecard uses the clean model roots, so it lists
+PEcAn alongside the individual CMIP6 and TRENDY models and the ensemble means,
+rather than the 100 individual PEcAn members used for the spread analysis.

--- a/modules/benchmark/inst/ilamb/make_scorecard.sh
+++ b/modules/benchmark/inst/ilamb/make_scorecard.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Generate the ILAMB HTML scorecard for a PEcAn benchmarking window.
+#
+# Runs ilamb-run against a window's model root (PEcAn, the individual CMIP6
+# and TRENDY models, and the ensemble means) to produce the interactive HTML
+# scorecard ILAMB writes to the build directory. This is the public-facing
+# comparison view; it uses the clean model roots (no individual PEcAn members),
+# so the scorecard lists PEcAn alongside the models rather than 100 member rows.
+#
+# Prerequisites:
+#   - ILAMB installed and on PATH (ilamb-run).
+#   - ILAMB_ROOT set, with the benchmark datasets under $ILAMB_ROOT/DATA.
+#   - The window model root already built (see build_window_ensembles.py),
+#     e.g. ilamb_models_2012_2014 / ilamb_models_2015_2023.
+#
+# Usage:
+#   ./make_scorecard.sh <window> [model_root] [build_dir]
+#
+#   window      Required. A label for the run, e.g. 2012_2014 or 2015_2023.
+#   model_root  Optional. Directory of model entities to score.
+#               Default: ilamb_models_<window>.
+#   build_dir   Optional. Output directory for the HTML scorecard.
+#               Default: ilamb_scorecard_<window>.
+#
+# Example:
+#   export ILAMB_ROOT=/path/to/ILAMB_ROOT
+#   ./make_scorecard.sh 2012_2014
+#   ./make_scorecard.sh 2015_2023
+#
+# The generated build directory (index.html plus assets) is a self-contained
+# static site that can be served directly, for example by copying it under a
+# web server's document root.
+
+set -euo pipefail
+
+WINDOW="${1:?usage: make_scorecard.sh <window> [model_root] [build_dir]}"
+MODEL_ROOT="${2:-ilamb_models_${WINDOW}}"
+BUILD_DIR="${3:-ilamb_scorecard_${WINDOW}}"
+CONFIG="$(dirname "$0")/pecan_ilamb.cfg"
+
+if [ -z "${ILAMB_ROOT:-}" ]; then
+  echo "ERROR: ILAMB_ROOT is not set." >&2
+  exit 1
+fi
+if [ ! -d "$MODEL_ROOT" ]; then
+  echo "ERROR: model root '$MODEL_ROOT' not found. Build it first." >&2
+  exit 1
+fi
+
+echo "Generating scorecard for window '$WINDOW'"
+echo "  model root: $MODEL_ROOT"
+echo "  build dir:  $BUILD_DIR"
+
+ilamb-run --config "$CONFIG" \
+  --model_root "$MODEL_ROOT" \
+  --build_dir "$BUILD_DIR" \
+  --regions global
+
+echo "Done. Open $BUILD_DIR/index.html, or serve $BUILD_DIR as a static site."


### PR DESCRIPTION
## Description

Small follow-on to #4038 (merged), which added the multi-model benchmarking pipeline. This adds a script to generate the ILAMB HTML scorecard and documents how to serve it.

What this adds:
- `make_scorecard.sh`: runs ilamb-run against a window model root to produce the interactive ILAMB HTML scorecard (PEcAn against the individual CMIP6 and TRENDY models and the ensemble means.
- README section on generating and serving the scorecard.

The generated scorecard for both windows is hosted at https://co2.aos.wisc.edu/~tdahiya/ilamb/

No tests: this is a thin wrapper around ilamb-run and a documentation addition.

## Motivation and Context

The benchmarking pipeline from #4038 produces the scores; this makes the standard ILAMB HTML scorecard reproducible with a single command and documents how to host it, which was requested as a project deliverable. Follow-on to #4038.

## Review Time Estimate
- [ ] Immediately
- [ ] Within one week
- [x] When possible

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] My name is in the list of CITATION.cff
- [x] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [x] I have updated the CHANGELOG.md.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.