### PR TITLE
Update CCMMF training docs and LandIQ merge / CDL extract helpers

### DIFF
--- a/modules/data.remote/inst/ccmmf/README.md
+++ b/modules/data.remote/inst/ccmmf/README.md
@@ -27,60 +27,69 @@ flowchart TB
   PHENO --> IRR
 ```
 
-| Product | Description | Main source | Session |
-|---------|-------------|-------------|---------|
-| Crop identity | Crop type of each field each season | LandIQ + CDL | 1 |
-| Planting | Crop start date and initial C/N pools | HLS phenology + plant traits | 2 |
-| Harvest | Biomass removal date and fractions | HLS phenology + plant traits | 2 |
-| Phenology | Leaf-on / leaf-off timing | HLS phenology | 2 |
-| Tillage | Soil/residue disturbance in fallow windows | HLS phenology + tillage index | 2 |
-| N fertilization | Synthetic nitrogen applications by crop | California crop guidelines | 3 |
-| Organic amendments | Manure, compost, biochar, and similar applications | Literature-derived amendment rates | 3 |
-| Irrigation | Water applications over the season | Precip (CHIRPS), reference ET (CIMIS), soil water holding (SSURGO) | 3 |
+
+
+
+| Product            | Description                                        | Main source                                                        | Session |
+| ------------------ | -------------------------------------------------- | ------------------------------------------------------------------ | ------- |
+| Crop identity      | Crop type of each field each season                | LandIQ + CDL                                                       | 1       |
+| Planting           | Crop start date and initial C/N pools              | HLS phenology + plant traits                                       | 2       |
+| Harvest            | Biomass removal date and fractions                 | HLS phenology + plant traits                                       | 2       |
+| Phenology          | Leaf-on / leaf-off timing                          | HLS phenology                                                      | 2       |
+| Tillage            | Soil/residue disturbance in fallow windows         | HLS phenology + tillage index                                      | 2       |
+| N fertilization    | Synthetic nitrogen applications by crop            | California crop guidelines                                         | 3       |
+| Organic amendments | Manure, compost, biochar, and similar applications | Literature-derived amendment rates                                 | 3       |
+| Irrigation         | Water applications over the season                 | Precip (CHIRPS), reference ET (CIMIS), soil water holding (SSURGO) | 3       |
+
+
+
 
 ## Run order by session
+
+
 
 ### Session 1 - Crop identity
 
 Why: before we can say how a field was managed, we need to know which fields exist and what crop was grown on each one. LandIQ is California's statewide crop map. This session aligns successive LandIQ years onto stable field IDs and fills missing crop information so the rest of the pipeline can use them.
 
-| Step | Output | Detail |
-|------|--------|--------|
-| Download LandIQ `TARGET_YEAR` | Shapefile under `$LANDIQ_RAW` | [Session 1](documentation/sessions/01-landiq.md) |
-| Harmonize geometry | `$LANDIQ_HARMONIZED` (= cadwr `03-final`) | [cadwr-landuse](https://github.com/ccmmf/cadwr-landuse) |
-| Gap-fill `PRIOR,TARGET` | `$LANDIQ_GAPFILLED` | [landiq-gapfill/README.md](landiq-gapfill/README.md) |
 
-Commands and flags: [Session 1](documentation/sessions/01-landiq.md).
+| Output                                | Source                                                                                 |
+| ------------------------------------- | -------------------------------------------------------------------------------------- |
+| Annual LandIQ shapefiles              | [CNRA Statewide Crop Mapping](https://data.cnra.ca.gov/dataset/statewide-crop-mapping) |
+| Harmonized parcels + multi-year crops | [cadwr-landuse](https://github.com/ccmmf/cadwr-landuse)                                |
+| Gap-filled crop identity              | [landiq-gapfill](landiq-gapfill/README.md)                                             |
+
+
+Commands: [Session 1](documentation/sessions/01-landiq.md).
 
 ### Session 2 - Phenology, planting, harvest, tillage
 
 Why: we also need to know when each field was planted, when leaves came on and off, when it was harvested, and when the soil was disturbed. This session extracts those dates from HLS phenology, sets planting C/N pools and harvest fractions from crop-specific literature, and detects tillage in the fallow period between crop seasons.
 
-| Step | Output | Detail |
-|------|--------|--------|
-| Parcel-tile map (once) | `$HLS_PARCEL_TILEMAP` | [hls/README.md](hls/README.md) |
-| MSLSP extract | under `$PRODUCTS_INVENTORY/phenology/` | [phenology/extract/README.md](phenology/extract/README.md) |
-| Match LandIQ seasons to MSLSP cycles | `$MATCHED_DIR` | [phenology/match/README.md](phenology/match/README.md) |
-| Date gap-fill | gapfill overlays | [phenology/gapfill/README.md](phenology/gapfill/README.md) |
-| Trait lookups (one-time) | `$LOOKUPS_ROOT/plant_traits/` | [traits/README.md](traits/README.md) |
-| Planting / harvest / phenology events | `$PRODUCTS_INVENTORY/event_files/` | [events/README.md](events/README.md) |
-| NDTI extract + tillage events | tillage under inventory + `event_files/` | [tillage/](tillage/), [events/README.md](events/README.md) |
 
-Commands and flags: [Session 2](documentation/sessions/02-phenology.md).
+| Output                                 | Source                                       |
+| -------------------------------------- | -------------------------------------------- |
+| Parcel-tile map                        | [hls](hls/README.md)                         |
+| LandIQ seasons matched to MSLSP cycles | [phenology/match](phenology/match/README.md) |
+| Planting / harvest / phenology events  | [events](events/README.md)                   |
+| Tillage events                         | [events](events/README.md)                   |
+| Plant trait lookups                    | [traits](traits/README.md)                   |
+
+
+Commands: [Session 2](documentation/sessions/02-phenology.md).
 
 ### Session 3 - Fertilizer, organic amendments, and irrigation
 
 Why: finally, we need nitrogen fertilization, organic amendments, and irrigation on each field. Timing for these depends on the phenology from Session 2. This session sets N rates from California crop guidelines, sets organic amendment rates from literature-derived values, and computes irrigation with a simple water-bucket balance from precip, reference ET, and soil water holding capacity.
 
-| Step | Output | Detail |
-|------|--------|--------|
-| N rate / fertilizer lookups | packaged tables in `PEcAn.data.land` | [Session 3](documentation/sessions/03-fertilizer-irrigation.md); PR [#4002](https://github.com/PecanProject/pecan/pull/4002) |
-| Statewide N fertilization events | `$PRODUCTS_INVENTORY/fertilization/` | [Session 3](documentation/sessions/03-fertilizer-irrigation.md); PR [#4003](https://github.com/PecanProject/pecan/pull/4003) `fertilization-statewide` |
-| Organic amendment (NCC) events | `$PRODUCTS_INVENTORY/fertilization/` | Same PR #4003 `ncc-statewide` |
-| Stage CHIRPS / CIMIS / SSURGO | `$CHIRPS_DIR`, `$CIMIS_DIR`, `$SSURGO_DIR` | [Session 3](documentation/sessions/03-fertilizer-irrigation.md) |
-| Parcel climate / soil extracts | preprocess outputs named in irrig YAML | `workflows/irrigation-statewide/preprocessing/` |
-| Irrigation water-balance events | `$PRODUCTS_INVENTORY/irrigation/` | [Session 3](documentation/sessions/03-fertilizer-irrigation.md); `workflows/irrigation-statewide/` |
 
-Commands and config: [Session 3](documentation/sessions/03-fertilizer-irrigation.md).
+| Output                   | Source                                                                                       |
+| ------------------------ | -------------------------------------------------------------------------------------------- |
+| N fertilization events   | [fertilization-statewide](../../../../workflows/fertilization-statewide/README.md)           |
+| Organic amendment events | [ncc-statewide](../../../../workflows/ncc-statewide/README.md)                               |
+| Irrigation events        | [irrigation-statewide](../../../../workflows/irrigation-statewide/README.md)                 |
+
+
+Commands: [Session 3](documentation/sessions/03-fertilizer-irrigation.md).
 
 Together these products give MAGiC a wall-to-wall management record for California cropland: what grew on each field, when it was managed, and what was applied.

--- a/modules/data.remote/inst/ccmmf/documentation/sessions/00-setup.md
+++ b/modules/data.remote/inst/ccmmf/documentation/sessions/00-setup.md
@@ -52,10 +52,10 @@ export CCMMF_BASE=/path/to/workdir
 mkdir -p "$CCMMF_BASE/src"
 cd "$CCMMF_BASE/src"
 
-# pecan -- monitoring branch
-git clone https://github.com/sarahkanee/pecan.git
+# pecan -- develop
+git clone https://github.com/PecanProject/pecan.git
 cd pecan
-git checkout feature/ccmmf-statewide-monitoring-inst
+git checkout develop
 
 # cadwr-landuse -- main
 cd "$CCMMF_BASE/src"
@@ -75,10 +75,10 @@ Activate `pecan-all-1.14`, set the same `$CCMMF_BASE` as in 0.2, pull the repo y
 ```bash
 conda activate <ENV_PATH_OR_NAME>
 
-export CCMMF_BASE=/path/to/workdir   # same value as 0.2
+export CCMMF_BASE=/path/to/workdir   # same as 0.2
 
 # Pull only the repo you are using this session:
-git -C "$CCMMF_BASE/src/pecan" pull origin feature/ccmmf-statewide-monitoring-inst
+git -C "$CCMMF_BASE/src/pecan" pull origin develop
 git -C "$CCMMF_BASE/src/cadwr-landuse" pull origin main
 
 # Optional overrides (only if you do not want the BASE defaults):
@@ -93,8 +93,6 @@ source "$CCMMF_BASE/src/pecan/modules/data.remote/inst/ccmmf/documentation/setup
 
 
 ## 0.4 Workspace (once)
-
-<a id="data-layout"></a>
 
 `setup_env` only stored the path strings. Create these folders once. Later sessions use the vars and assume the tree exists.
 
@@ -116,10 +114,10 @@ $CCMMF_ROOT/
     SSURGO/                           # SSURGO_DIR
   lookups/
     plant_traits/                     # PLANT_TRAITS_DIR
-    fertilization/                    # FERTILIZATION_LOOKUPS (rate tables)
+    fertilization/                    # FERTILIZATION_LOOKUPS
   products/
     inventory/                        # PRODUCTS_INVENTORY
-      phenology/                      # MATCHED_DIR default under here
+      phenology/                      
       tillage/
       fertilization/
       irrigation/

--- a/modules/data.remote/inst/ccmmf/documentation/sessions/00-setup.md
+++ b/modules/data.remote/inst/ccmmf/documentation/sessions/00-setup.md
@@ -6,10 +6,10 @@
 
 ## 0.1 Environment (once)
 
-Activate `pecan-all-1.14` and confirm the packages later sessions need. If either check fails, stop and fix the environment before continuing.
+Use conda env `pecan-all-1.14` for all sessions. Activate it and confirm the packages later sessions need. If either check fails, stop and fix the environment before continuing.
 
 ```bash
-conda activate <ENV_PATH_OR_NAME>
+conda activate <ENV_PATH_OR_NAME>   # pecan-all-1.14
 
 Rscript -e 'stopifnot(
   requireNamespace("arrow"),
@@ -38,13 +38,11 @@ PY
 
 ---
 
-
-
 ## 0.2 Clone (once)
 
 Set `$CCMMF_BASE` to the directory that will hold your clones (`$CCMMF_BASE/src`) and data (`$CCMMF_BASE/ccmmf`).
 
-You also need `pecan-all-1.14` already installed, plus two git repos: PEcAn and [cadwr-landuse](https://github.com/ccmmf/cadwr-landuse). Later sessions assume those repos live at `$CCMMF_BASE/src/pecan` and `$CCMMF_BASE/src/cadwr-landuse`.
+You also need two git repos: PEcAn and [cadwr-landuse](https://github.com/ccmmf/cadwr-landuse). Later sessions assume those repos live at `$CCMMF_BASE/src/pecan` and `$CCMMF_BASE/src/cadwr-landuse`.
 
 **New clones**
 
@@ -68,6 +66,8 @@ git checkout main
 
 **Already cloned elsewhere.** Do not re-clone. Symlink into `$CCMMF_BASE/src/` so Session 0.3 and later path names still work.
 
+`ln -s` takes two paths: **left** = existing clone on disk (edit this); **right** = the name the tutorials expect (leave as-is).
+
 ```bash
 export CCMMF_BASE=/path/to/workdir
 mkdir -p "$CCMMF_BASE/src"
@@ -84,14 +84,12 @@ If a repo is already at `$CCMMF_BASE/src/pecan` or `$CCMMF_BASE/src/cadwr-landus
 
 ---
 
-
-
 ## 0.3 Every new shell
 
-Activate `pecan-all-1.14`, set the same `$CCMMF_BASE` as in 0.2, pull the repo you need, and source `setup_env`.
+Activate the conda env from 0.1, set the same `$CCMMF_BASE` as in 0.2, pull the repo you need, and source `setup_env`.
 
 ```bash
-conda activate <ENV_PATH_OR_NAME>
+conda activate <ENV_PATH_OR_NAME>   # same env as 0.1
 
 export CCMMF_BASE=/path/to/workdir   # same as 0.2
 
@@ -107,8 +105,6 @@ source "$CCMMF_BASE/src/pecan/modules/data.remote/inst/ccmmf/documentation/setup
 ```
 
 ---
-
-
 
 ## 0.4 Workspace (once)
 
@@ -157,8 +153,6 @@ mkdir -p "$PRODUCTS_INVENTORY"/{phenology,tillage,fertilization,irrigation,event
 
 ---
 
-
-
 ## 0.5 Confirm setup
 
 Confirm the code and data roots are real on disk.
@@ -174,8 +168,6 @@ ls "$CCMMF_ROOT"   # data workspace
 If you do not see the directories you made, go back and fix the section above before Session 1.
 
 ---
-
-
 
 ## 0.6 NASA Earthdata
 

--- a/modules/data.remote/inst/ccmmf/documentation/sessions/00-setup.md
+++ b/modules/data.remote/inst/ccmmf/documentation/sessions/00-setup.md
@@ -44,7 +44,9 @@ PY
 
 Set `$CCMMF_BASE` to the directory that will hold your clones (`$CCMMF_BASE/src`) and data (`$CCMMF_BASE/ccmmf`).
 
-You also need `pecan-all-1.14` already installed, plus two git repos: PEcAn and [cadwr-landuse](https://github.com/ccmmf/cadwr-landuse). If a repo is already on disk, skip it.
+You also need `pecan-all-1.14` already installed, plus two git repos: PEcAn and [cadwr-landuse](https://github.com/ccmmf/cadwr-landuse). Later sessions assume those repos live at `$CCMMF_BASE/src/pecan` and `$CCMMF_BASE/src/cadwr-landuse`.
+
+**New clones**
 
 ```bash
 export CCMMF_BASE=/path/to/workdir
@@ -63,6 +65,22 @@ git clone https://github.com/ccmmf/cadwr-landuse.git
 cd cadwr-landuse
 git checkout main
 ```
+
+**Already cloned elsewhere.** Do not re-clone. Symlink into `$CCMMF_BASE/src/` so Session 0.3 and later path names still work.
+
+```bash
+export CCMMF_BASE=/path/to/workdir
+mkdir -p "$CCMMF_BASE/src"
+
+# ln -s <existing clone> <tutorial path>
+ln -s /actual/path/to/pecan          "$CCMMF_BASE/src/pecan"
+ln -s /actual/path/to/cadwr-landuse  "$CCMMF_BASE/src/cadwr-landuse"
+
+ls -l "$CCMMF_BASE/src/pecan" "$CCMMF_BASE/src/cadwr-landuse"
+ls "$CCMMF_BASE/src/pecan/modules/data.remote/inst/ccmmf"
+```
+
+If a repo is already at `$CCMMF_BASE/src/pecan` or `$CCMMF_BASE/src/cadwr-landuse`, skip both the clone and the symlink for that repo.
 
 ---
 

--- a/modules/data.remote/inst/ccmmf/documentation/sessions/00-setup.md
+++ b/modules/data.remote/inst/ccmmf/documentation/sessions/00-setup.md
@@ -128,7 +128,7 @@ Create the dirs:
 
 ```bash
 mkdir -p "$LANDIQ_ROOT"/{raw,gapfilled}
-mkdir -p "$CADWR_WORK_DIR"   # LANDIQ_HARMONIZED -> $CADWR_WORK_DIR/03-final after cadwr
+mkdir -p "$CADWR_WORK_DIR" "$LANDIQ_HARMONIZED"   # 03-final; S3 skip or cadwr both land here
 mkdir -p "$HLS_ROOT"/{imagery,MSLSP}
 mkdir -p "$CDL_DIR"
 mkdir -p "$CLIMATE_ROOT"/{CHIRPS,CIMIS}

--- a/modules/data.remote/inst/ccmmf/documentation/sessions/00-setup.md
+++ b/modules/data.remote/inst/ccmmf/documentation/sessions/00-setup.md
@@ -64,9 +64,7 @@ cd cadwr-landuse
 git checkout main
 ```
 
-**Already cloned elsewhere.** Do not re-clone. Symlink into `$CCMMF_BASE/src/` so Session 0.3 and later path names still work.
-
-`ln -s` takes two paths: **left** = existing clone on disk (edit this); **right** = the name the tutorials expect (leave as-is).
+**Already cloned elsewhere.**
 
 ```bash
 export CCMMF_BASE=/path/to/workdir
@@ -76,11 +74,8 @@ mkdir -p "$CCMMF_BASE/src"
 ln -s /actual/path/to/pecan          "$CCMMF_BASE/src/pecan"
 ln -s /actual/path/to/cadwr-landuse  "$CCMMF_BASE/src/cadwr-landuse"
 
-ls -l "$CCMMF_BASE/src/pecan" "$CCMMF_BASE/src/cadwr-landuse"
-ls "$CCMMF_BASE/src/pecan/modules/data.remote/inst/ccmmf"
+ls -ld "$CCMMF_BASE/src/pecan" "$CCMMF_BASE/src/cadwr-landuse"
 ```
-
-If a repo is already at `$CCMMF_BASE/src/pecan` or `$CCMMF_BASE/src/cadwr-landuse`, skip both the clone and the symlink for that repo.
 
 ---
 

--- a/modules/data.remote/inst/ccmmf/documentation/sessions/01-landiq.md
+++ b/modules/data.remote/inst/ccmmf/documentation/sessions/01-landiq.md
@@ -52,7 +52,7 @@ $CCMMF_ROOT/
   CDL/                                # CDL_DIR -- CDL .tif + parcel fraction .parq
 ```
 
-Walk Secs. 1.1–1.6 in order the first time. A one-shot shortcut for 1.4-1.6 is noted at the end -- use it only after you know what those steps do.
+Walk Secs. 1.1-1.6 in order the first time. A one-shot shortcut for 1.4-1.6 is noted at the end -- use it only after you know what those steps do.
 
 ---
 
@@ -60,7 +60,7 @@ Walk Secs. 1.1–1.6 in order the first time. A one-shot shortcut for 1.4-1.6 is
 
 ## 1.1 Download LandIQ
 
-Get the statewide shapefiles from the [CNRA Statewide Crop Mapping](https://data.cnra.ca.gov/dataset/statewide-crop-mapping) portal (**GIS Shapefile** ZIP). `$LANDIQ_RAW` needs the full series (2016 on), not just the inventory pair. For this training run, pull last year's stack from the S3 bucket, then update the pair from the portal.
+Get the statewide shapefiles from the [CNRA Statewide Crop Mapping](https://data.cnra.ca.gov/dataset/statewide-crop-mapping) portal (**GIS Shapefile** ZIP). `$LANDIQ_RAW` needs the full series (2016 on), not just the inventory pair. For this training run, pull the stack from the S3 bucket, then update the pair from the portal.
 
 From the same portal, also download two PDFs:
 
@@ -68,16 +68,16 @@ From the same portal, also download two PDFs:
 - **Metadata** -- in-depth description of the dataset itself, including what each column in the shapefile attribute table means (`UniqueID`, `CLASS`, `ADOY`, etc).
 
 ```bash
-aws s3 --profile magic sync s3://carb/data/landiq_shapefiles/2016-2023/ "$LANDIQ_RAW/"
+aws s3 --profile magic sync s3://carb/data/landiq_shapefiles/ "$LANDIQ_RAW/"
 ```
 
 Then from the portal, put two years under `$LANDIQ_RAW`:
 
 
-| Year                 | Typical portal status         | Action                                                                                                    |
-| -------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `PRIOR_YEAR` (2023)  | Final (was provisional on S3) | Replace `i15_Crop_Mapping_2023_Provisional_SHP/` with the final folder; drop `_Provisional` from the name |
-| `TARGET_YEAR` (2024) | Provisional                   | Add `i15_Crop_Mapping_2024_Provisional_SHP/`                                                              |
+| Year                 | Typical portal status | Action                                                                                                              |
+| -------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `PRIOR_YEAR` (2023)  | Final                 | Replace `i15_Crop_Mapping_2023_Provisional_SHP/` with the final folder if needed; drop `_Provisional` from the name |
+| `TARGET_YEAR` (2024) | Provisional           | Add `i15_Crop_Mapping_2024_Provisional_SHP/`                                                                        |
 
 
 After that the tree should look like:
@@ -102,7 +102,7 @@ ls "$LANDIQ_RAW"/i15_Crop_Mapping_*/*.shp
 
 ## 1.2 Harmonize geometry
 
-Overlay every year in `$LANDIQ_RAW` into one parcel map and a multi-year crop table. From the cadwr-landuse clone, Session 0 conda env active. Submit the tile overlays as a batch job (~3 hours).
+Overlay every year in `$LANDIQ_RAW` into one parcel map and a multi-year crop table: split the state into tiles, track which polygons persist or change across years under a stable `parcel_id`, then join each year's crop attributes.
 
 The two files that land in `$LANDIQ_HARMONIZED`:
 
@@ -110,10 +110,8 @@ The two files that land in `$LANDIQ_HARMONIZED`:
 | File                        | Role                                                                                |
 | --------------------------- | ----------------------------------------------------------------------------------- |
 | `parcels-consolidated.gpkg` | One geometry per `parcel_id`, with each year's native LandIQ UniqueID               |
-| `crops_all_years.parq`      | Tidy crop attributes: rows for `parcel_id` x `year` x `season` (up to four seasons) |
+| `crops_all_years.parq`      | Long-format crop attributes: rows for `parcel_id` x `year` x `season` (up to four seasons) |
 
-
-From the cadwr-landuse clone, with the Session 0 conda env active. Submit the tile overlays as a batch job (~3 hours).
 
 ```bash
 cd "$CCMMF_BASE/src/cadwr-landuse"
@@ -122,7 +120,7 @@ python scripts/01-split.py \
   --landiq-root-dir "$LANDIQ_RAW" \
   --outdir-root "$CADWR_WORK_DIR"
 
-python scripts/process-tiles-local.py \    # batch job
+python scripts/process-tiles-local.py \    # batch job (~3 hours)
   --outdir-root "$CADWR_WORK_DIR" \
   --ntasks 8 \
   --crs EPSG:3310 \
@@ -135,6 +133,8 @@ python scripts/03b-finalize-crops.py \
   --landiq-root-dir "$LANDIQ_RAW" \
   --outdir-root "$CADWR_WORK_DIR"
 ```
+
+`01-split.py` logs the discovered year list (expect 2016, 2018-2024). If a year you staged is missing from that log, fix `$LANDIQ_RAW` and re-run.
 
 If it was not run in advance, a current version is already on S3 -- pull that into `$LANDIQ_HARMONIZED` and continue on:
 
@@ -193,11 +193,11 @@ Lookup tables are in `$LANDIQ_GAPFILL_ROOT/outputs/`. On a routine update, leave
 **Probability tables** start from fields where both maps exist. For a given field, LandIQ reports a crop in CLASS / SUBCLASS codes and CDL reports a crop in its own integer codes. The tables count those pairs (row-normalized co-occurrence) and become the map between the two legends. Gap-fill uses that map when LandIQ is missing but CDL is present: look up which LandIQ crop usually goes with the CDL mix on that field.
 
 
-| Table                      | File                                  | What it answers                                                   |
-| -------------------------- | ------------------------------------- | ----------------------------------------------------------------- |
-| `P(CDL \| CLASS)`           | `cdl_prob_by_class_*.parquet`         | Given LandIQ CLASS, which CDL codes usually appear on that parcel |
-| `P(CDL \| CLASS::SUBCLASS)` | `cdl_prob_by_subclass_*.parquet`      | Same question at subclass                                         |
-| `P(SUBCLASS \| CLASS)`      | `landiq_subclass_frequency_*.parquet` | How often each subclass occurs inside a CLASS                     |
+| Table | File | What it answers |
+| ----- | ---- | --------------- |
+| `P(CDL \| CLASS)` | `cdl_prob_by_class_*.parquet` | Given LandIQ CLASS, which CDL codes usually appear |
+| `P(CDL \| CLASS::SUBCLASS)` | `cdl_prob_by_subclass_*.parquet` | Given LandIQ CLASS::SUBCLASS, which CDL codes usually appear |
+| `P(SUBCLASS \| CLASS)` | `landiq_subclass_frequency_*.parquet` | Given LandIQ CLASS, which subclasses are most common |
 
 
 **ADOY reference tables** are county and statewide mean observed peak-greenness day by crop, plus a parcel-level history of observed `ADOY`. Gap-fill uses them when `ADOY` is missing or zero: copy a typical day for that crop (and county, when there are enough observations).

--- a/modules/data.remote/inst/ccmmf/documentation/sessions/01-landiq.md
+++ b/modules/data.remote/inst/ccmmf/documentation/sessions/01-landiq.md
@@ -56,6 +56,9 @@ Walk Secs. 1.1-1.6 in order the first time. A one-shot shortcut for 1.4-1.6 is n
 
 ---
 
+> [!IMPORTANT]
+> New terminal? Run [Session 0 Sec. 0.3](00-setup.md) first.
+
 
 
 ## 1.1 Download LandIQ
@@ -107,9 +110,9 @@ Overlay every year in `$LANDIQ_RAW` into one parcel map and a multi-year crop ta
 The two files that land in `$LANDIQ_HARMONIZED`:
 
 
-| File                        | Role                                                                                |
-| --------------------------- | ----------------------------------------------------------------------------------- |
-| `parcels-consolidated.gpkg` | One geometry per `parcel_id`, with each year's native LandIQ UniqueID               |
+| File                        | Role                                                                                       |
+| --------------------------- | ------------------------------------------------------------------------------------------ |
+| `parcels-consolidated.gpkg` | One geometry per `parcel_id`, with each year's native LandIQ UniqueID                      |
 | `crops_all_years.parq`      | Long-format crop attributes: rows for `parcel_id` x `year` x `season` (up to four seasons) |
 
 
@@ -120,11 +123,15 @@ python scripts/01-split.py \
   --landiq-root-dir "$LANDIQ_RAW" \
   --outdir-root "$CADWR_WORK_DIR"
 
-python scripts/process-tiles-local.py \    # batch job (~3 hours)
+python scripts/process-tiles-local.py \    # ~3 hours
   --outdir-root "$CADWR_WORK_DIR" \
   --ntasks 8 \
   --crs EPSG:3310 \
   --precision 10.0
+
+# Or, if you want to submit this step as a batch job:
+# export OUTDIR_ROOT="$CADWR_WORK_DIR"
+# sbatch scripts/process-tiles-local.sh
 
 python scripts/03a-combine-parcels.py \
   --outdir-root "$CADWR_WORK_DIR"
@@ -136,7 +143,7 @@ python scripts/03b-finalize-crops.py \
 
 `01-split.py` logs the discovered year list (expect 2016, 2018-2024). If a year you staged is missing from that log, fix `$LANDIQ_RAW` and re-run.
 
-If it was not run in advance, a current version is already on S3 -- pull that into `$LANDIQ_HARMONIZED` and continue on:
+If this section was not run in advance, a current version is already on S3 -- pull that into `$LANDIQ_HARMONIZED` and continue on:
 
 ```bash
 aws s3 --profile magic cp s3://carb/management/crops/v4.2/parcels-consolidated.gpkg "$LANDIQ_HARMONIZED/"
@@ -169,18 +176,24 @@ Even after harmonization, LandIQ is incomplete on some parcels: the main-season 
 
 ### CDL rasters and fractions
 
-Download both years of CDL (NASS national 30 m GeoTIFF, clipped to California). Submit each extract as a batch job (~40 min/year, one year per job).
+Download both years of CDL (NASS national 30 m GeoTIFF, clipped to California). 
 
 ```bash
-YEARS=${PRIOR_YEAR},${TARGET_YEAR}
 CDL=$LANDIQ_GAPFILL_ROOT/scripts/cdl
 GF=$LANDIQ_GAPFILL_ROOT/scripts/gapfill.R
 
-Rscript $CDL/download_cdl_nass.R $YEARS                        
-Rscript $CDL/extract_cdl_fractions_by_parcel.R $PRIOR_YEAR     # batch job
-Rscript $CDL/extract_cdl_fractions_by_parcel.R $TARGET_YEAR    # batch job
+Rscript $CDL/download_cdl_nass.R ${PRIOR_YEAR},${TARGET_YEAR}
 
-# after both jobs finish:
+# each year takes ~1 hour
+Rscript $CDL/extract_cdl_fractions_by_parcel.R $PRIOR_YEAR    
+Rscript $CDL/extract_cdl_fractions_by_parcel.R $TARGET_YEAR 
+
+# Or, if you want to submit this step as a batch job:
+# export CDL_YEAR=$PRIOR_YEAR
+# sbatch $CDL/extract_cdl_fractions_by_parcel.sh
+# export CDL_YEAR=$TARGET_YEAR
+# sbatch $CDL/extract_cdl_fractions_by_parcel.sh
+
 Rscript -e 'dplyr::glimpse(arrow::read_parquet(file.path(Sys.getenv("CDL_DIR"), paste0("cdl_fractions_year=", Sys.getenv("TARGET_YEAR"), ".parquet"))))'
 ```
 
@@ -193,11 +206,11 @@ Lookup tables are in `$LANDIQ_GAPFILL_ROOT/outputs/`. On a routine update, leave
 **Probability tables** start from fields where both maps exist. For a given field, LandIQ reports a crop in CLASS / SUBCLASS codes and CDL reports a crop in its own integer codes. The tables count those pairs (row-normalized co-occurrence) and become the map between the two legends. Gap-fill uses that map when LandIQ is missing but CDL is present: look up which LandIQ crop usually goes with the CDL mix on that field.
 
 
-| Table | File | What it answers |
-| ----- | ---- | --------------- |
-| `P(CDL \| CLASS)` | `cdl_prob_by_class_*.parquet` | Given LandIQ CLASS, which CDL codes usually appear |
-| `P(CDL \| CLASS::SUBCLASS)` | `cdl_prob_by_subclass_*.parquet` | Given LandIQ CLASS::SUBCLASS, which CDL codes usually appear |
-| `P(SUBCLASS \| CLASS)` | `landiq_subclass_frequency_*.parquet` | Given LandIQ CLASS, which subclasses are most common |
+| Table       | File              | What it answers                       |
+| ----------- | ----------------- | ------------------------------------- |
+| `P(CDL      | CLASS)`           | `cdl_prob_by_class_*.parquet`         |
+| `P(CDL      | CLASS::SUBCLASS)` | `cdl_prob_by_subclass_*.parquet`      |
+| `P(SUBCLASS | CLASS)`           | `landiq_subclass_frequency_*.parquet` |
 
 
 **ADOY reference tables** are county and statewide mean observed peak-greenness day by crop, plus a parcel-level history of observed `ADOY`. Gap-fill uses them when `ADOY` is missing or zero: copy a typical day for that crop (and county, when there are enough observations).
@@ -226,6 +239,7 @@ The current tables were built from 2016-2023 for the CDL x LandIQ map (except 20
 With those tables on disk, the next three commands do the actual fill: crop identity where LandIQ is missing, then peak-greenness day where `ADOY` is missing or zero, then merge both into the product. Run the pair together -- the prior year is now final (updated in Sec. 1.1) and can use the new LandIQ year as neighbor context.
 
 ```bash
+YEARS=${PRIOR_YEAR},${TARGET_YEAR}
 Rscript $GF crop $YEARS    # missing season-2 crop
 Rscript $GF adoy $YEARS    # missing or zero ADOY
 Rscript $GF merge $YEARS   # write $LANDIQ_GAPFILLED product
@@ -258,9 +272,10 @@ Rscript -e 'dplyr::glimpse(arrow::read_parquet(file.path(Sys.getenv("LANDIQ_GAPF
 
 YEARS=${PRIOR_YEAR},${TARGET_YEAR}
 Rscript $LANDIQ_GAPFILL_ROOT/scripts/gapfill.R qc $YEARS
+cat $LANDIQ_GAPFILL_ROOT/outputs/qc_gapfill_report.md
 ```
 
-Open `$LANDIQ_GAPFILL_ROOT/outputs/qc_gapfill_report.md`. For **season 2** in both `PRIOR_YEAR` and `TARGET_YEAR`, note the share of rows with `subclass_source` / `adoy_source` = `observed` vs modelled fill labels. There is no single pass/fail threshold, but you should be able to state those fractions. 
+For **season 2** in both `PRIOR_YEAR` and `TARGET_YEAR`, note the share of rows with `subclass_source` / `adoy_source` = `observed` vs modelled fill labels. There is no single pass/fail threshold, but you should be able to state those fractions.
 
 ---
 
@@ -270,7 +285,7 @@ Open `$LANDIQ_GAPFILL_ROOT/outputs/qc_gapfill_report.md`. For **season 2** in bo
 
 ---
 
-**Note (shortcut after you know the steps):** Secs. 1.4-1.6 can be run in one shot with `run_gapfill.sh` (CDL fraction ensure + crop + adoy + merge + `cover_crop_landiq.R` + qc). Walk 1.4-1.6 by hand the first time. The shell does **not** rebuild the probability / ADOY-ref tables unless you pass the flags.
+**Note (shortcut after you know the steps):** Secs. 1.4-1.6 can be run in one shot with `run_gapfill.sh` (CDL fraction ensure + crop + adoy + merge + cover + qc). Walk 1.4-1.6 by hand the first time. The shell does **not** rebuild the probability / ADOY-ref tables unless you pass the flags.
 
 ```bash
 $LANDIQ_GAPFILL_ROOT/run_gapfill.sh ${PRIOR_YEAR},${TARGET_YEAR}

--- a/modules/data.remote/inst/ccmmf/documentation/sessions/01-landiq.md
+++ b/modules/data.remote/inst/ccmmf/documentation/sessions/01-landiq.md
@@ -143,11 +143,12 @@ python scripts/03b-finalize-crops.py \
 
 `01-split.py` logs the discovered year list (expect 2016, 2018-2024). If a year you staged is missing from that log, fix `$LANDIQ_RAW` and re-run.
 
-If this section was not run in advance, a current version is already on S3 -- pull that into `$LANDIQ_HARMONIZED` and continue on:
+If this section was not run in advance, a current version is already on S3. Put those two files in `$LANDIQ_HARMONIZED` (same directory cadwr would have written -- `$CADWR_WORK_DIR/03-final` after Session 0). CDL extract and gap-fill look for `parcels-consolidated.gpkg` there.
 
 ```bash
 aws s3 --profile magic cp s3://carb/management/crops/v4.2/parcels-consolidated.gpkg "$LANDIQ_HARMONIZED/"
 aws s3 --profile magic cp s3://carb/management/crops/v4.2/crops_all_years.parq "$LANDIQ_HARMONIZED/"
+ls "$LANDIQ_HARMONIZED/parcels-consolidated.gpkg" "$LANDIQ_HARMONIZED/crops_all_years.parq"
 ```
 
 ---
@@ -176,7 +177,10 @@ Even after harmonization, LandIQ is incomplete on some parcels: the main-season 
 
 ### CDL rasters and fractions
 
-Download both years of CDL (NASS national 30 m GeoTIFF, clipped to California). 
+Two steps:
+
+1. **Download** the statewide CDL GeoTIFF for each inventory year (NASS national 30 m, clipped to California) into `$CDL_DIR`.
+2. **Extract parcel fractions.** Using `$LANDIQ_HARMONIZED/parcels-consolidated.gpkg`, overlay each parcel on that year's CDL raster and record the **area fraction** of every CDL crop code inside the polygon (not just the majority class). Write one parquet per year: `CDL_DIR/cdl_fractions_year=YYYY.parquet`.
 
 ```bash
 CDL=$LANDIQ_GAPFILL_ROOT/scripts/cdl
@@ -203,17 +207,17 @@ Rscript -e 'dplyr::glimpse(arrow::read_parquet(file.path(Sys.getenv("CDL_DIR"), 
 
 Lookup tables are in `$LANDIQ_GAPFILL_ROOT/outputs/`. On a routine update, leave them alone.
 
-**Probability tables** start from fields where both maps exist. For a given field, LandIQ reports a crop in CLASS / SUBCLASS codes and CDL reports a crop in its own integer codes. The tables count those pairs (row-normalized co-occurrence) and become the map between the two legends. Gap-fill uses that map when LandIQ is missing but CDL is present: look up which LandIQ crop usually goes with the CDL mix on that field.
+For a given field, LandIQ reports a crop in CLASS / SUBCLASS codes and CDL reports a crop in its own integer codes. The tables count those pairs (row-normalized co-occurrence) and become the map between the two legends. Gap-fill uses that map when LandIQ is missing but CDL is present to look up which LandIQ crop usually goes with the CDL mix on that field.
 
 
-| Table       | File              | What it answers                       |
-| ----------- | ----------------- | ------------------------------------- |
-| `P(CDL      | CLASS)`           | `cdl_prob_by_class_*.parquet`         |
-| `P(CDL      | CLASS::SUBCLASS)` | `cdl_prob_by_subclass_*.parquet`      |
-| `P(SUBCLASS | CLASS)`           | `landiq_subclass_frequency_*.parquet` |
+| Table | File | What it answers |
+| ----- | ---- | --------------- |
+| `P(CDL \| CLASS)` | `cdl_prob_by_class_*.parquet` | Given LandIQ CLASS, which CDL codes usually appear |
+| `P(CDL \| CLASS::SUBCLASS)` | `cdl_prob_by_subclass_*.parquet` | Given LandIQ CLASS::SUBCLASS, which CDL codes usually appear |
+| `P(SUBCLASS \| CLASS)` | `landiq_subclass_frequency_*.parquet` | Given LandIQ CLASS, which subclasses are most common |
 
 
-**ADOY reference tables** are county and statewide mean observed peak-greenness day by crop, plus a parcel-level history of observed `ADOY`. Gap-fill uses them when `ADOY` is missing or zero: copy a typical day for that crop (and county, when there are enough observations).
+ADOY reference tables are county and statewide mean observed peak-greenness day by crop, plus a parcel-level history of observed `ADOY`. Gap-fill uses them when `ADOY` is missing or zero.
 
 
 | File                                           | What it is                            |
@@ -265,13 +269,23 @@ Rscript $LANDIQ_GAPFILL_ROOT/scripts/R/cover_crop_landiq.R
 
 ## 1.6 Inspect / QC
 
-After gap-fill and COVER, skim the product, then summarize provenance for the year pair.
+After gap-fill and COVER, run QC, glimpse the inventory-year product, then read the report.
 
 ```bash
-Rscript -e 'dplyr::glimpse(arrow::read_parquet(file.path(Sys.getenv("LANDIQ_GAPFILLED"), "crops_all_years.parq")))'
-
 YEARS=${PRIOR_YEAR},${TARGET_YEAR}
 Rscript $LANDIQ_GAPFILL_ROOT/scripts/gapfill.R qc $YEARS
+
+# Glimpse inventory years only (PRIOR_YEAR / TARGET_YEAR)
+Rscript -e '
+p <- file.path(Sys.getenv("LANDIQ_GAPFILLED"), "crops_all_years.parq")
+yrs <- as.integer(c(Sys.getenv("PRIOR_YEAR"), Sys.getenv("TARGET_YEAR")))
+ds <- arrow::open_dataset(p) |> dplyr::filter(year %in% yrs)
+print(as.data.frame(ds |> dplyr::count(year) |> dplyr::collect() |> dplyr::arrange(year)))
+dplyr::bind_rows(lapply(yrs, function(y) {
+  ds |> dplyr::filter(year == y) |> dplyr::slice_head(n = 20) |> dplyr::collect()
+})) |> dplyr::glimpse()
+'
+
 cat $LANDIQ_GAPFILL_ROOT/outputs/qc_gapfill_report.md
 ```
 

--- a/modules/data.remote/inst/ccmmf/documentation/sessions/02-phenology.md
+++ b/modules/data.remote/inst/ccmmf/documentation/sessions/02-phenology.md
@@ -52,7 +52,7 @@ flowchart LR
 
 ## Paths for this session
 
-Expect `$LANDIQ_GAPFILLED/crops_all_years.parq` from [Session 1](01-landiq.md) and Earthdata from [Session 0](00-setup.md) section 0.6. Paths come from [setup_env.sh](../setup_env.sh). Finished tree: [Data layout](00-setup.md#data-layout).
+Expect `$LANDIQ_GAPFILLED/crops_all_years.parq` from [Session 1](01-landiq.md) and Earthdata from [Session 0](00-setup.md) section 0.6. Paths come from [setup_env.sh](../setup_env.sh). Finished tree: [Workspace](00-setup.md#04-workspace-once).
 
 To **produce** MSLSP NetCDF / HLS imagery (not only consume existing files), clone [HLS_Phenology](https://github.com/mrinareddy/HLS_Phenology) and follow that repo's download steps into `$MSLSP_NETCDF_ROOT` / `$HLS_IMAGERY_ROOT`.
 
@@ -67,6 +67,9 @@ To **produce** MSLSP NetCDF / HLS imagery (not only consume existing files), clo
 | Lookups | `$LOOKUPS_ROOT/plant_traits` (`$PLANT_TRAITS_DIR`) | Trait CSVs for planting/harvest |
 
 ---
+
+> [!IMPORTANT]
+> New terminal? Run [Session 0 Sec. 0.3](00-setup.md) first.
 
 ## 2.1 Env and demo parcel list
 

--- a/modules/data.remote/inst/ccmmf/documentation/sessions/03-fertilizer-irrigation.md
+++ b/modules/data.remote/inst/ccmmf/documentation/sessions/03-fertilizer-irrigation.md
@@ -48,7 +48,7 @@ Shared contract with Sessions 1-2: LandIQ `parcel_id` (and demo filter when used
 
 ## Paths for this session
 
-Expect `$LANDIQ_GAPFILLED` from [Session 1](01-landiq.md). For irrigation canopy, point YAML `mslsp_path` at `$MATCHED_DIR` (or the matched hive from [Session 2](02-phenology.md)). Paths come from [setup_env.sh](../setup_env.sh). Finished tree: [Data layout](00-setup.md#data-layout).
+Expect `$LANDIQ_GAPFILLED` from [Session 1](01-landiq.md). For irrigation canopy, point YAML `mslsp_path` at `$MATCHED_DIR` (or the matched hive from [Session 2](02-phenology.md)). Paths come from [setup_env.sh](../setup_env.sh). Finished tree: [Workspace](00-setup.md#04-workspace-once).
 
 | Role | Path | Notes |
 |------|------|-------|
@@ -61,6 +61,9 @@ Expect `$LANDIQ_GAPFILLED` from [Session 1](01-landiq.md). For irrigation canopy
 | Out | Prefer `$PRODUCTS_INVENTORY/irrigation/` | Set as irrig `event_output_dir` |
 
 ---
+
+> [!IMPORTANT]
+> New terminal? Run [Session 0 Sec. 0.3](00-setup.md) first.
 
 ## 3.1 N rate and fertilizer lookups
 
@@ -102,7 +105,7 @@ There is **no** `harmonize_fertilization_data.R` on this tree. Packaged tables a
 Parcel-level **N fertilization event** builders are in PEcAn PR
 [#4003](https://github.com/PecanProject/pecan/pull/4003):
 `workflows/fertilization-statewide`. Those directories are **not** under
-`workflows/` on this monitoring branch -- use the PR for statewide event runs.
+`workflows/` on develop -- use the PR for statewide event runs.
 
 | Item | Path / format | Notes |
 |------|---------------|--------|

--- a/modules/data.remote/inst/ccmmf/documentation/sessions/03-fertilizer-irrigation.md
+++ b/modules/data.remote/inst/ccmmf/documentation/sessions/03-fertilizer-irrigation.md
@@ -6,7 +6,7 @@ You can scope either track to a Session 2 demo parcel list when you have one.
 
 **Prerequisite:** [Session 0](00-setup.md); [Session 1](01-landiq.md) gap-filled LandIQ product. For irrigation canopy cover, prefer [Session 2](02-phenology.md) matched phenology (`$MATCHED_DIR`) and optional demo `parcels_10SDH.csv`.
 
-**Where to go deeper:** [tree README](../../README.md); fert lookups in `PEcAn.data.land`; statewide fert/NCC builders in PEcAn PR [#4003](https://github.com/PecanProject/pecan/pull/4003); irrigation under `workflows/irrigation-statewide/` (especially `preprocessing/README.md`).
+**Where to go deeper:** [tree README](../../README.md); fert lookups in `PEcAn.data.land`; statewide fert/NCC builders under `workflows/fertilization-statewide/` and `workflows/ncc-statewide/` (on PEcAn `develop`); irrigation under `workflows/irrigation-statewide/` (especially `preprocessing/README.md`).
 
 ```mermaid
 flowchart LR
@@ -35,12 +35,12 @@ flowchart LR
 | Step | Where |
 |------|--------|
 | N rate / fertilizer component lookups | `PEcAn.data.land` (`look_up_ca_n_rate`, `look_up_fertilizer_components`); data-raw under `modules/data.land/data-raw/` |
-| Packaged rate tables | PEcAn PR [#4002](https://github.com/PecanProject/pecan/pull/4002) (merged) |
-| Statewide N fertilization events | PR [#4003](https://github.com/PecanProject/pecan/pull/4003) `workflows/fertilization-statewide` |
-| Organic amendment (NCC) events | Same PR #4003 `workflows/ncc-statewide` |
+| Packaged rate tables | `PEcAn.data.land` packaged data |
+| Statewide N fertilization events | [fertilization-statewide](../../../../../../workflows/fertilization-statewide/README.md) |
+| Organic amendment (NCC) events | [ncc-statewide](../../../../../../workflows/ncc-statewide/README.md) |
 | Climate / soils staging | `$CHIRPS_DIR`, `$CIMIS_DIR`, `$SSURGO_DIR`; [Session 3](03-fertilizer-irrigation.md) secs. 3.4-3.5 |
-| Parcel climate / soil extracts | `workflows/irrigation-statewide/preprocessing/` |
-| Irrigation water-balance | `workflows/irrigation-statewide/` (`README.md`, `config_paths.yml`) |
+| Parcel climate / soil extracts | [irrigation-statewide/preprocessing](../../../../../../workflows/irrigation-statewide/preprocessing/README.md) |
+| Irrigation water-balance | [irrigation-statewide](../../../../../../workflows/irrigation-statewide/README.md) (`config_paths.yml`) |
 
 Combining Session 2 and Session 3 event files (optional handoff): [events/README.md](../../events/README.md).
 
@@ -55,7 +55,7 @@ Expect `$LANDIQ_GAPFILLED` from [Session 1](01-landiq.md). For irrigation canopy
 | In | `$LANDIQ_GAPFILLED` | Crops table for fert / irrigation |
 | In | `$MATCHED_DIR` | Prefer for irrig `mslsp_path` |
 | Lookups | `$FERTILIZATION_LOOKUPS` | Optional TSV rate tables (`$LOOKUPS_ROOT/fertilization`) |
-| Out | `$PRODUCTS_INVENTORY/fertilization/` | Fert / NCC **event** outputs when PR #4003 builders are available |
+| Out | `$PRODUCTS_INVENTORY/fertilization/` | Fert / NCC **event** outputs from the statewide builders |
 | Staging | `$CHIRPS_DIR`, `$CIMIS_DIR`, `$SSURGO_DIR` | Raw downloads / gdb |
 | Work | irrig preprocess dirs (YAML) | Parcel extracts; may live under staging or another path |
 | Out | Prefer `$PRODUCTS_INVENTORY/irrigation/` | Set as irrig `event_output_dir` |
@@ -75,7 +75,7 @@ On this monitoring tree you can **inspect** rates via `PEcAn.data.land`:
 |-------|------|
 | `PEcAn.data.land::look_up_ca_n_rate()` | Per-crop min/max N from CA rate tables |
 | `PEcAn.data.land::look_up_fertilizer_components()` | Fertilizer component helpers |
-| Packaged rate tables (PR [#4002](https://github.com/PecanProject/pecan/pull/4002)) | Bundled reference data behind the lookups |
+| Packaged rate tables | Bundled reference data behind the lookups (`PEcAn.data.land`) |
 
 ```r
 library(PEcAn.data.land)
@@ -102,15 +102,13 @@ There is **no** `harmonize_fertilization_data.R` on this tree. Packaged tables a
 
 ## 3.2 Statewide N fertilization events
 
-Parcel-level **N fertilization event** builders are in PEcAn PR
-[#4003](https://github.com/PecanProject/pecan/pull/4003):
-`workflows/fertilization-statewide`. Those directories are **not** under
-`workflows/` on develop -- use the PR for statewide event runs.
+Parcel-level **N fertilization event** builders live on PEcAn `develop` under
+`workflows/fertilization-statewide/`.
 
 | Item | Path / format | Notes |
 |------|---------------|--------|
 | Input | `$LANDIQ_GAPFILLED` + packaged N lookups | Same `parcel_id` contract as Sessions 1-2 |
-| Workflow | PR #4003 `workflows/fertilization-statewide` | Not shipped under `workflows/` here |
+| Workflow | `workflows/fertilization-statewide/` | At the PEcAn repo root (not under `inst/ccmmf`) |
 | Output | `$PRODUCTS_INVENTORY/fertilization/` | Prefer this inventory path for event products |
 
 ---
@@ -118,13 +116,13 @@ Parcel-level **N fertilization event** builders are in PEcAn PR
 ## 3.3 Organic amendment (NCC) events
 
 Non-crop carbon amendments (manure, compost, biochar, and similar) use the same
-guideline approach as N fert, with a separate statewide builder in the same PR:
-`workflows/ncc-statewide`.
+guideline approach as N fert, with a separate statewide builder on `develop`:
+`workflows/ncc-statewide/`.
 
 | Item | Path / format | Notes |
 |------|---------------|--------|
 | Input | `$LANDIQ_GAPFILLED` + organic amendment tables | Packaged via data-raw / `$FERTILIZATION_LOOKUPS` |
-| Workflow | PR #4003 `workflows/ncc-statewide` | Not shipped under `workflows/` here |
+| Workflow | `workflows/ncc-statewide/` | At the PEcAn repo root (not under `inst/ccmmf`) |
 | Output | `$PRODUCTS_INVENTORY/fertilization/` | Same inventory folder as N fert events unless you split by convention |
 
 ---

--- a/modules/data.remote/inst/ccmmf/documentation/sessions/sipnet-handoff.md
+++ b/modules/data.remote/inst/ccmmf/documentation/sessions/sipnet-handoff.md
@@ -14,6 +14,9 @@ outputs for MAGIC inventory runs.
 
 ---
 
+> [!IMPORTANT]
+> New terminal? Run [Session 0 Sec. 0.3](00-setup.md) first.
+
 ## Why this step exists
 
 MAGIC annual inventory and scenario runs need agronomic events in the formats
@@ -56,7 +59,7 @@ Column dictionaries: [metadata.md](../metadata.md), [events/README.md](../../eve
 | SIPNET `events.in` | `PEcAn.SIPNET::write.events.SIPNET` | also used from restart drivers |
 | Restart / run drivers | `workflows/sipnet-restart-workflow/` (prepare settings, run) | fuller checkout may include preprocess beside restart |
 
-Stages 1-2 below are **not** under `workflows/` on this monitoring branch. Use a
+Stages 1-2 below are **not** under `workflows/` on develop. Use a
 SIPNET restart workflow checkout that includes
 `workflows/preprocess-event-parquet/` (lab reference: ashiklom
 `sipnet-restart-workflow` tree). This appendix keeps the column map and the

--- a/modules/data.remote/inst/ccmmf/events/README.md
+++ b/modules/data.remote/inst/ccmmf/events/README.md
@@ -11,7 +11,7 @@ Related management layers live in parallel workflows (**Session 3**):
   `PEcAn.data.land` helpers (`look_up_ca_n_rate`, etc.); statewide builders
   `workflows/fertilization-statewide` / `workflows/ncc-statewide` (open PEcAn
   PR [#4003](https://github.com/PecanProject/pecan/pull/4003); not shipped on
-  this monitoring branch)
+  develop)
 - **Irrigation:** [Session 3](../documentation/sessions/03-fertilizer-irrigation.md)
 
 Full product set: [tree README](../README.md).

--- a/modules/data.remote/inst/ccmmf/events/README.md
+++ b/modules/data.remote/inst/ccmmf/events/README.md
@@ -9,9 +9,8 @@ Related management layers live in parallel workflows (**Session 3**):
 - **N fertilization / organic amendments:**
   [Session 3](../documentation/sessions/03-fertilizer-irrigation.md);
   `PEcAn.data.land` helpers (`look_up_ca_n_rate`, etc.); statewide builders
-  `workflows/fertilization-statewide` / `workflows/ncc-statewide` (open PEcAn
-  PR [#4003](https://github.com/PecanProject/pecan/pull/4003); not shipped on
-  develop)
+  `workflows/fertilization-statewide` / `workflows/ncc-statewide` (on PEcAn
+  `develop`)
 - **Irrigation:** [Session 3](../documentation/sessions/03-fertilizer-irrigation.md)
 
 Full product set: [tree README](../README.md).
@@ -182,8 +181,9 @@ Rscript $CCMMF_CODE/events/combine_management_events_pecan.R \
 ```
 
 Fertilization / NCC and irrigation statewide builders:
-[Session 3](../documentation/sessions/03-fertilizer-irrigation.md) and
-[#4003](https://github.com/PecanProject/pecan/pull/4003).
+[Session 3](../documentation/sessions/03-fertilizer-irrigation.md);
+`workflows/fertilization-statewide/`, `workflows/ncc-statewide/`, and
+`workflows/irrigation-statewide/` on PEcAn `develop`.
 
 ## Reference
 

--- a/modules/data.remote/inst/ccmmf/landiq-gapfill/scripts/R/build_landiq_product.R
+++ b/modules/data.remote/inst/ccmmf/landiq-gapfill/scripts/R/build_landiq_product.R
@@ -310,6 +310,38 @@ LANDIQ_SEASONS <- 1:4
   df
 }
 
+#' Harmonize one year slice to the 2021 legend and normalize provenance.
+.finalize_product_year_slice <- function(df, crop_lk) {
+  df %>%
+    dplyr::mutate(
+      CLASS = trimws(as.character(CLASS)),
+      SUBCLASS = trimws(as.character(SUBCLASS))
+    ) %>%
+    harmonize_landiq_subclass_by_year(crop_lk$merge) %>%
+    dplyr::mutate(
+      SUBCLASS = dplyr::if_else(
+        is.na(SUBCLASS) | SUBCLASS == "",
+        "**",
+        SUBCLASS
+      ),
+      SUBCLASS = dplyr::if_else(
+        CLASS == "V" & SUBCLASS == "**",
+        vineyard_fallback_subclass(),
+        SUBCLASS
+      ),
+      subclass_source = normalize_subclass_source(CLASS, SUBCLASS, subclass_source)
+    ) %>%
+    filter_consolidated_parcels()
+}
+
+#' Combine year parquet slices into one file without collecting as R data.frames.
+.combine_year_parquets <- function(year_files, path_out) {
+  tabs <- lapply(year_files, function(f) arrow::read_parquet(f, as_data_frame = FALSE))
+  combined <- do.call(arrow::concat_tables, tabs)
+  arrow::write_parquet(combined, path_out)
+  combined$num_rows
+}
+
 build_landiq_product <- function(
     years = landiq_product_years(),
     source_root = path_landiq_root(),
@@ -332,56 +364,58 @@ build_landiq_product <- function(
 
   crop_lk <- load_landiq_crop_lookup(path_crop_lookup_csv())
   source_parquet <- resolve_landiq_product_source_parquet()
-
-  parts <- vector("list", length(years))
-  for (i in seq_along(years)) {
-    parts[[i]] <- .patch_landiq_year(years[[i]], source_parquet = source_parquet)
-    message("  year ", years[[i]], ": ", nrow(parts[[i]]), " rows")
-  }
-  out <- dplyr::bind_rows(parts)
-
-  other_years <- arrow::open_dataset(source_parquet) %>%
-    dplyr::filter(!year %in% years) %>%
-    dplyr::collect()
-  if (nrow(other_years) > 0L) {
-    message("Appending ", nrow(other_years), " rows outside gap-fill years")
-    out <- dplyr::bind_rows(out, .init_provenance_cols(other_years))
-  }
-
-  message("Harmonizing all SUBCLASS to 2021 RS legend (per calendar year input mapping)")
-  out <- out %>%
-    dplyr::mutate(
-      CLASS = trimws(as.character(CLASS)),
-      SUBCLASS = trimws(as.character(SUBCLASS))
-    ) %>%
-    harmonize_landiq_subclass_by_year(crop_lk$merge) %>%
-    dplyr::mutate(
-      SUBCLASS = dplyr::if_else(
-        is.na(SUBCLASS) | SUBCLASS == "",
-        "**",
-        SUBCLASS
-      )
-    ) %>%
-    dplyr::mutate(
-      # Default missing vineyard subclass to wine grapes; keep observed provenance.
-      SUBCLASS = dplyr::if_else(
-        CLASS == "V" & SUBCLASS == "**",
-        vineyard_fallback_subclass(),
-        SUBCLASS
-      ),
-      subclass_source = normalize_subclass_source(CLASS, SUBCLASS, subclass_source)
-    )
-
+  # Warm consolidated-id cache once (used per year below).
   consolidated_ids <- load_consolidated_parcel_ids()
-  n_before <- nrow(out)
-  out <- filter_consolidated_parcels(out)
+
+  all_years <- arrow::open_dataset(source_parquet) %>%
+    dplyr::distinct(year) %>%
+    dplyr::collect() %>%
+    dplyr::pull(year) %>%
+    as.integer() %>%
+    sort()
+  all_years <- unique(c(all_years, years))
+  all_years <- all_years[!is.na(all_years)]
+
+  tmp_dir <- file.path(out_dir, paste0(".merge_tmp_", Sys.getpid()))
+  if (dir.exists(tmp_dir)) {
+    unlink(tmp_dir, recursive = TRUE)
+  }
+  dir.create(tmp_dir, recursive = TRUE)
+
+  on.exit(unlink(tmp_dir, recursive = TRUE), add = TRUE)
+
   message(
-    "Restricted to consolidated parcels: ", length(consolidated_ids),
-    " parcel_ids (dropped ", n_before - nrow(out), " rows outside consolidated geometry)"
+    "Building product one calendar year at a time (",
+    length(all_years), " years; ", length(consolidated_ids), " consolidated parcels)"
   )
 
-  arrow::write_parquet(out, path_out)
-  message("Wrote ", nrow(out), " rows -> ", path_out)
+  year_files <- character(0)
+  n_total <- 0L
+  for (y in all_years) {
+    message("Building product slice year=", y,
+            if (y %in% years) " mode=gapfill" else " mode=carry")
+    if (y %in% years) {
+      df <- .patch_landiq_year(y, source_parquet = source_parquet)
+    } else {
+      df <- arrow::open_dataset(source_parquet) %>%
+        dplyr::filter(year == y) %>%
+        dplyr::collect() %>%
+        .init_provenance_cols()
+    }
+    message("  Harmonizing SUBCLASS to 2021 RS legend")
+    df <- .finalize_product_year_slice(df, crop_lk)
+    path_y <- file.path(tmp_dir, sprintf("year=%d.parquet", y))
+    arrow::write_parquet(df, path_y)
+    message("  year ", y, ": ", nrow(df), " rows")
+    n_total <- n_total + nrow(df)
+    year_files <- c(year_files, path_y)
+    rm(df)
+    gc(verbose = FALSE)
+  }
+
+  message("Combining ", length(year_files), " year slices -> ", path_out)
+  n_rows <- .combine_year_parquets(year_files, path_out)
+  message("Wrote ", n_rows, " rows -> ", path_out)
 
   product_label <- basename(out_dir)
   meta_path <- file.path(out_dir, "README.md")
@@ -410,5 +444,5 @@ build_landiq_product <- function(
     meta_path
   )
   message("Wrote ", meta_path)
-  invisible(list(path_parquet = path_out, path_gpkg = path_src_gpkg, n_rows = nrow(out)))
+  invisible(list(path_parquet = path_out, path_gpkg = path_src_gpkg, n_rows = as.integer(n_rows)))
 }

--- a/modules/data.remote/inst/ccmmf/landiq-gapfill/scripts/R/paths.R
+++ b/modules/data.remote/inst/ccmmf/landiq-gapfill/scripts/R/paths.R
@@ -42,7 +42,7 @@ path_landiq_root <- function() {
     if (!nzchar(ccmmf)) {
       stop("Set LANDIQ_HARMONIZED or CCMMF_ROOT (source documentation/setup_env.sh).")
     }
-    root <- file.path(ccmmf, "LandIQ", "harmonized")
+    root <- file.path(ccmmf, "LandIQ", "work", "03-final")
   }
   root
 }

--- a/modules/data.remote/inst/ccmmf/landiq-gapfill/scripts/cdl/extract_cdl_fractions_by_parcel.sh
+++ b/modules/data.remote/inst/ccmmf/landiq-gapfill/scripts/cdl/extract_cdl_fractions_by_parcel.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#SBATCH --job-name=cdl-fractions
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=32G
+#SBATCH --time=01:30:00
+#SBATCH --output=cdl-fractions-%j.out
+#SBATCH --error=cdl-fractions-%j.err
+#
+# Slurm wrapper for extract_cdl_fractions_by_parcel.R (one year per job).
+#
+# Before sbatch, activate an env with Rscript (and sf/terra/exactextractr/arrow),
+# and set paths the R script reads (or source setup_env.sh):
+#
+#   export CDL_YEAR=2024
+#   # also need CDL_DIR + LANDIQ_HARMONIZED (or CCMMF_ROOT) for rasters/parcels
+#   sbatch scripts/cdl/extract_cdl_fractions_by_parcel.sh
+#
+# Knobs (submitting shell; Slurm inherits them):
+#   CDL_YEAR or YEAR     -- required calendar year to extract
+#   CDL_DIR              -- CDL GeoTIFFs (or CCMMF_ROOT/CDL)
+#   LANDIQ_HARMONIZED    -- parcels-consolidated.gpkg (or CCMMF_ROOT layout)
+#   CDL_OUT_DIR          -- optional parquet output dir (default: CDL_DIR)
+#   CDL_PATH             -- optional single-year GeoTIFF override
+#   CDL_CHUNK_SIZE       -- optional parcel chunk size
+#
+# Account/partition omitted -> site defaults; add -A / -p if needed.
+# Example: https://docs.urcf.drexel.edu/learning/slurm/writing-job-scripts/
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+R_SCRIPT="$SCRIPT_DIR/extract_cdl_fractions_by_parcel.R"
+
+YEAR="${CDL_YEAR:-${YEAR:-}}"
+if [[ -z "$YEAR" ]]; then
+  echo "ERROR: export CDL_YEAR=YYYY (or YEAR=YYYY) before sbatch" >&2
+  exit 1
+fi
+
+if [[ ! -f "$R_SCRIPT" ]]; then
+  echo "ERROR: missing $R_SCRIPT" >&2
+  exit 1
+fi
+
+command -v Rscript >/dev/null 2>&1 || {
+  echo "ERROR: Rscript not on PATH; activate your R/conda env before sbatch" >&2
+  exit 1
+}
+
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-${SLURM_CPUS_PER_TASK:-8}}"
+
+echo "cdl-fractions: year=$YEAR job=${SLURM_JOB_ID:-local} OMP_NUM_THREADS=$OMP_NUM_THREADS"
+Rscript "$R_SCRIPT" "$YEAR"


### PR DESCRIPTION
## Summary
- Clarify Sessions 0-3 for the year-pair inventory flow (harmonized LandIQ S3 skip, CDL download + parcel fractions, QC order).
- Link Session 3 / tree README sources to the fertilization, NCC, and irrigation statewide workflow READMEs on develop.
- Fix LandIQ year-merge OOM handling and default the harmonized path to cadwr `03-final`; add a CDL parcel-fraction Slurm script.

## Test plan
- [ ] Skim Session 0 mkdir + Session 1 S3 skip / CDL / QC blocks for path consistency
- [ ] Confirm relative links from `inst/ccmmf/README.md` and Session 3 open the three workflow READMEs
- [ ] Spot-check `build_landiq_product.R` merge behavior on a small multi-year crops sample
- [ ] Dry-run or review `extract_cdl_fractions_by_parcel.sh` env requirements (`CDL_YEAR` / `YEAR`)
