### PR TITLE
Add downscaling-error diagnostic (OOB RMSE vs ensemble spread)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 ## Unreleased
 
 ### Added
+- Added a downscaling-error diagnostic to `inst/ilamb/` in PEcAn.benchmark: compares the downscaling random forest's out-of-bag RMSE against the between-member ensemble spread at the SDA sites, quantifying downscaling error the ensemble spread does not represent.
 - Added ensemble calibration diagnostics to `inst/ilamb/` in PEcAn.benchmark (rank histogram, spread-skill ratio, coverage, reliability) for assessing whether an ensemble's spread is well calibrated against observations, complementing the ensemble-mean benchmarking.
 - Added `make_scorecard.sh` and documentation to `inst/ilamb/` in PEcAn.benchmark for generating and serving the ILAMB HTML scorecard.
 - New function `PEcAn.utils::netcdf2df()` flattens all dims and vars of a netCDF into a dataframe,

--- a/modules/benchmark/inst/ilamb/calibration/README_downscaling_error.md
+++ b/modules/benchmark/inst/ilamb/calibration/README_downscaling_error.md
@@ -1,0 +1,59 @@
+# Downscaling error versus ensemble spread
+
+`downscaling_error.R` compares the downscaling model's own predictive error
+against the spread of the SDA ensemble, at the assimilation sites, in each
+variable's own units.
+
+## What it computes
+
+The State Data Assimilation (SDA) produces an ensemble of member fields. Each
+member is downscaled to a 1 km grid by its own random forest, fit to that
+member's values at the pre-selected sites. For a chosen variable and year the
+script reports:
+
+- **between-member spread** — the standard deviation across ensemble members,
+  averaged over sites. This is the uncertainty the ensemble represents.
+- **downscaling OOB RMSE** — the random forest out-of-bag error, averaged over
+  members. This is the downscaling model's own predictive error.
+- **ratio** — OOB RMSE divided by spread.
+
+When the OOB RMSE is larger than the spread, the members agree with each other
+more tightly than the downscaling is actually accurate, so the downscaled maps
+carry error that the ensemble spread does not represent. This is a distinct
+uncertainty source from the ensemble spread itself.
+
+## Inputs
+
+Per variable and year, an `.Rdata` file containing an object named `models`,
+a list of per-member `randomForest` regression objects (as written by the
+downscaling step), found under `<model_dir>/<variable>_<year>/ml_models.Rdata`.
+The out-of-bag RMSE is read from each fit's `mse` vector and the between-member
+spread from each fit's training response `y`.
+
+The default paths reflect one particular SDA setup and are illustrative. Point
+`--model-dir` at your own downscaling output.
+
+## Running
+
+    Rscript downscaling_error.R \
+      --model-dir /path/to/downscale_maps_analysis_lc_ts_noGEDI_rf \
+      --variables AbvGrndWood,TotSoilCarb \
+      --year 2015
+
+Output is one row per variable with the member count, site count, spread,
+OOB RMSE, and ratio. With no arguments the script uses the defaults in the
+`config` block.
+
+## Note on language
+
+The other diagnostics in this directory are Python. This script is R because
+the downscaling models are R `randomForest` objects saved in `.Rdata`, which R
+reads natively; a Python port would only shell out to R to read them.
+
+## Testing
+
+    Rscript test_downscaling_error.R
+
+The test builds small synthetic `randomForest` objects, saves them as `models`,
+and checks the out-of-bag and spread extraction, the ratio, and the error paths
+on data with known structure. It requires the `randomForest` package.

--- a/modules/benchmark/inst/ilamb/calibration/downscaling_error.R
+++ b/modules/benchmark/inst/ilamb/calibration/downscaling_error.R
@@ -1,0 +1,141 @@
+#!/usr/bin/env Rscript
+#
+# downscaling_error.R
+#
+# Compare the downscaling model's own predictive error against the spread of
+# the SDA ensemble, at the assimilation sites, in each variable's own units.
+#
+# The State Data Assimilation (SDA) produces an ensemble of member fields.
+# Each member is downscaled to a 1 km grid by its own random forest, fit to
+# that member's values at the pre-selected sites. For a chosen variable and
+# year this script reports three magnitudes:
+#
+#   - between-member spread: the standard deviation across ensemble members,
+#     averaged over sites. This is the uncertainty the ensemble represents.
+#   - downscaling OOB RMSE: the random forest out-of-bag error, averaged over
+#     members. This is the downscaling model's own predictive error.
+#   - their ratio (OOB RMSE / spread).
+#
+# When the OOB RMSE is larger than the spread, the members agree with each
+# other more tightly than the downscaling is actually accurate, so the
+# downscaled maps carry error that the ensemble spread does not represent.
+#
+# The saved model objects may have been written under the PEcAnAssimSequential
+# namespace; loading still works without it (with a warning), since the script
+# only reads the standard randomForest fields.
+
+suppressWarnings(suppressMessages(
+  try(library(PEcAnAssimSequential), silent = TRUE)
+))
+
+## ---- helpers -------------------------------------------------------------
+
+# OOB RMSE for a single randomForest regression object: the square root of the
+# final out-of-bag MSE (last element of the per-tree mse vector).
+oob_rmse <- function(rf) {
+  if (is.null(rf$mse)) {
+    stop("object has no $mse; is it a randomForest regression fit?")
+  }
+  sqrt(utils::tail(rf$mse, 1))
+}
+
+# Given a list of per-member randomForest objects for one variable and year,
+# return the mean OOB RMSE over members and the between-member spread, both in
+# the variable's own units, plus their ratio.
+#
+# The between-member spread is computed from each member's training target y:
+# stack y across members (sites x members), take the standard deviation across
+# members at each site, then average over sites.
+downscaling_error <- function(models) {
+  if (!length(models)) stop("no models supplied")
+
+  oob <- vapply(models, oob_rmse, numeric(1))
+
+  ylens <- vapply(models, function(m) length(m$y), integer(1))
+  if (length(unique(ylens)) != 1L) {
+    stop("members have differing numbers of training sites; cannot align spread")
+  }
+
+  Y <- vapply(models, function(m) as.numeric(m$y), numeric(ylens[1]))
+  if (is.null(dim(Y))) Y <- matrix(Y, ncol = length(models))  # single-site guard
+
+  persite_sd   <- apply(Y, 1, stats::sd)
+  persite_mean <- apply(Y, 1, mean)
+
+  list(
+    n_members   = length(models),
+    n_sites     = nrow(Y),
+    spread      = mean(persite_sd),
+    mean_level  = mean(persite_mean),
+    oob_rmse    = mean(oob),
+    oob_rmse_sd = stats::sd(oob),
+    ratio       = mean(oob) / mean(persite_sd)
+  )
+}
+
+# Load the per-member models for one variable/year from an .Rdata file that
+# contains an object named `models` (a list of randomForest objects).
+load_models <- function(path) {
+  if (!file.exists(path)) stop(sprintf("model file not found: %s", path))
+  e <- new.env()
+  load(path, envir = e)
+  if (!exists("models", envir = e, inherits = FALSE)) {
+    stop(sprintf("object 'models' not found in %s (found: %s)",
+                 path, paste(ls(e), collapse = ", ")))
+  }
+  get("models", envir = e, inherits = FALSE)
+}
+
+## ---- config --------------------------------------------------------------
+
+# Paths reflect one particular SDA setup and are illustrative; adapt them to
+# your own data. Each variable maps to the .Rdata file holding its per-member
+# random forests for the chosen year, under <model_dir>/<variable>_<year>/.
+DEFAULT_MODEL_DIR <- file.path(
+  "/projectnb/dietzelab/dongchen/anchorSites/NA_runs/SDA_8k_site",
+  "downscale_maps_analysis_lc_ts_noGEDI_rf"
+)
+DEFAULT_VARIABLES <- c("AbvGrndWood", "TotSoilCarb")
+DEFAULT_YEAR      <- 2015
+MODEL_FILE_NAME   <- "ml_models.Rdata"
+
+model_file <- function(model_dir, variable, year) {
+  file.path(model_dir, sprintf("%s_%d", variable, year), MODEL_FILE_NAME)
+}
+
+## ---- driver --------------------------------------------------------------
+
+run <- function(model_dir = DEFAULT_MODEL_DIR,
+                variables  = DEFAULT_VARIABLES,
+                year       = DEFAULT_YEAR) {
+  cat(sprintf("Downscaling error vs ensemble spread  (year %d)\n", year))
+  cat(sprintf("%-14s %8s %8s %10s %10s %8s\n",
+              "variable", "members", "sites", "spread", "OOB_RMSE", "ratio"))
+  for (v in variables) {
+    res <- downscaling_error(load_models(model_file(model_dir, v, year)))
+    cat(sprintf("%-14s %8d %8d %10.3f %10.3f %8.3f\n",
+                v, res$n_members, res$n_sites,
+                res$spread, res$oob_rmse, res$ratio))
+  }
+  invisible(NULL)
+}
+
+## ---- command line --------------------------------------------------------
+# Runs only when the file is executed directly (Rscript downscaling_error.R),
+# not when sourced (e.g. by the test), so the functions can be reused.
+
+if (identical(environment(), globalenv()) && !length(sys.calls())) {
+  args <- commandArgs(trailingOnly = TRUE)
+  get_arg <- function(flag, default) {
+    i <- match(flag, args)
+    if (is.na(i) || i == length(args)) return(default)
+    args[i + 1]
+  }
+  run(
+    model_dir = get_arg("--model-dir", DEFAULT_MODEL_DIR),
+    variables = strsplit(get_arg("--variables",
+                                 paste(DEFAULT_VARIABLES, collapse = ",")),
+                         ",")[[1]],
+    year      = as.integer(get_arg("--year", as.character(DEFAULT_YEAR)))
+  )
+}

--- a/modules/benchmark/inst/ilamb/calibration/downscaling_error.R
+++ b/modules/benchmark/inst/ilamb/calibration/downscaling_error.R
@@ -20,9 +20,10 @@
 # other more tightly than the downscaling is actually accurate, so the
 # downscaled maps carry error that the ensemble spread does not represent.
 #
-# The saved model objects may have been written under the PEcAnAssimSequential
-# namespace; loading still works without it (with a warning), since the script
-# only reads the standard randomForest fields.
+# If the saved model objects were written under a namespace that is not
+# installed (e.g. PEcAnAssimSequential, which wrote the reanalysis forests),
+# loading prints a harmless namespace warning; the script reads only the
+# standard randomForest fields, so it works either way.
 
 suppressWarnings(suppressMessages(
   try(library(PEcAnAssimSequential), silent = TRUE)

--- a/modules/benchmark/inst/ilamb/calibration/test_downscaling_error.R
+++ b/modules/benchmark/inst/ilamb/calibration/test_downscaling_error.R
@@ -1,0 +1,83 @@
+#!/usr/bin/env Rscript
+#
+# Tests for downscaling_error.R.
+#
+# Builds a small ensemble of real randomForest objects on synthetic site data
+# with known structure, saves them as `models`, and checks that the extraction
+# reads the out-of-bag error and the between-member spread correctly, that the
+# ratio is consistent, and that the error paths fire. Mirrors the synthetic-
+# data approach used by test_regional_diagnostics.py.
+#
+# Requires the randomForest package. Run:  Rscript test_downscaling_error.R
+
+suppressWarnings(suppressMessages(library(randomForest)))
+source("downscaling_error.R")
+
+set.seed(42)
+
+n_sites   <- 60
+n_members <- 6
+
+# Each member is a slightly shifted realization of the same site pattern, so
+# the members disagree (non-zero between-member spread) while each is a valid
+# regression the forest can partially fit (non-zero, finite OOB).
+make_member <- function(shift) {
+  x <- data.frame(a = rnorm(n_sites), b = rnorm(n_sites))
+  y <- 3 * x$a - 2 * x$b + shift + rnorm(n_sites, sd = 0.5)
+  randomForest(x = x, y = y, ntree = 100)
+}
+models <- lapply(seq_len(n_members), function(i) make_member(shift = i * 2))
+
+# --- oob_rmse: positive finite scalar, and equals sqrt of final mse ---------
+o1 <- oob_rmse(models[[1]])
+stopifnot(is.numeric(o1), length(o1) == 1L, is.finite(o1), o1 > 0)
+stopifnot(abs(o1 - sqrt(tail(models[[1]]$mse, 1))) < 1e-12)
+
+# --- downscaling_error: shapes and consistency ------------------------------
+res <- downscaling_error(models)
+stopifnot(res$n_members == n_members)
+stopifnot(res$n_sites   == n_sites)
+stopifnot(is.finite(res$spread),   res$spread   > 0)
+stopifnot(is.finite(res$oob_rmse), res$oob_rmse > 0)
+# ratio is exactly oob_rmse / spread
+stopifnot(abs(res$ratio - res$oob_rmse / res$spread) < 1e-12)
+# mean OOB equals the mean of per-member OOB computed independently
+oob_each <- vapply(models, oob_rmse, numeric(1))
+stopifnot(abs(res$oob_rmse - mean(oob_each)) < 1e-12)
+# spread equals mean over sites of the per-site SD across members
+Y <- vapply(models, function(m) as.numeric(m$y), numeric(n_sites))
+stopifnot(abs(res$spread - mean(apply(Y, 1, sd))) < 1e-12)
+
+# --- load_models: round-trip from an .Rdata file ----------------------------
+tmp <- tempfile(fileext = ".Rdata")
+save(models, file = tmp)
+loaded <- load_models(tmp)
+stopifnot(length(loaded) == n_members)
+stopifnot(abs(downscaling_error(loaded)$ratio - res$ratio) < 1e-12)
+
+# --- error path: file present but no 'models' object ------------------------
+# (inherits = FALSE in load_models means a 'models' in the caller's scope must
+#  not mask a genuinely missing object in the file)
+tmp2 <- tempfile(fileext = ".Rdata")
+other <- 1
+save(other, file = tmp2)
+err <- tryCatch({ load_models(tmp2); "NO ERROR" },
+                error = function(e) "errored")
+stopifnot(identical(err, "errored"))
+
+# --- error path: object without $mse ----------------------------------------
+bad <- structure(list(y = rnorm(10)), class = "randomForest")
+err2 <- tryCatch({ oob_rmse(bad); "NO ERROR" },
+                 error = function(e) "errored")
+stopifnot(identical(err2, "errored"))
+
+# --- error path: members with differing site counts -------------------------
+mismatched <- list(models[[1]],
+                   randomForest(x = data.frame(a = rnorm(n_sites + 5),
+                                               b = rnorm(n_sites + 5)),
+                                y = rnorm(n_sites + 5), ntree = 50))
+err3 <- tryCatch({ downscaling_error(mismatched); "NO ERROR" },
+                 error = function(e) "errored")
+stopifnot(identical(err3, "errored"))
+
+cat("all tests passed\n")


### PR DESCRIPTION
## Description
Adds a small diagnostic that compares the downscaling model's own predictive error against the spread of the SDA ensemble, at the assimilation sites, in each variable's own units.

Each SDA ensemble member is downscaled to a 1 km grid by its own random forest. This reads the saved per-member forests and reports, per variable and year, the between-member spread (standard deviation across members, averaged over sites), the downscaling out-of-bag RMSE (averaged over members), and their ratio. When the OOB RMSE exceeds the spread, the members agree with each other more tightly than the downscaling is actually accurate, so the downscaled maps carry error the ensemble spread does not represent. This complements the ensemble-calibration and regional diagnostics already in this directory.

Contents (in modules/benchmark/inst/ilamb/calibration/):
- downscaling_error.R computes the OOB RMSE, the between-member spread, and the ratio from the saved per-member randomForest objects. Paths are parameterized (--model-dir, --variables, --year); the defaults are illustrative.
- test_downscaling_error.R builds small synthetic randomForest objects and checks the extraction, the ratio, and the error paths.
- README_downscaling_error.md documents the inputs, how to run it, and the language choice.

Note on language: the other diagnostics in this directory are Python; this one is R because the downscaling models are R randomForest objects saved in .Rdata, which R reads natively.

## Motivation and Context
The ensemble-calibration work showed the ensemble is overconfident relative to independent benchmarks. One contributing mechanism is the downscaling step: the random forest emulator shares structure across members, so the members can agree closely while all being similarly off from truth. This diagnostic makes that quantitative by putting the downscaling's own error next to the between-member spread.

## Review Time Estimate
- [ ] Immediately
- [ ] Within one week
- [x] When possible

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] My name is in the list of CITATION.cff
- [x] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [x] I have updated the CHANGELOG.md.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.