### PR TITLE
add params needed by Sipnet 2.2

### DIFF
--- a/models/sipnet/NEWS.md
+++ b/models/sipnet/NEWS.md
@@ -25,8 +25,8 @@
   litterWFracInit, microbeInit, m_ballBerry) from being set when using v2 templates.
 * Removed workarounds for column naming bugs in output from long-outdated legacy
   Sipnet version `sipnet.unk`.
-* Added trait to parameter mappings for 13 nitrogen cycle parameters in `write.config.SIPNET`,
-  including tissue C:N ratios, N volatilization/leaching, fixation, and methane rates.
+* Added trait to parameter mappings for nitrogen cycle parameters in `write.config.SIPNET`,
+  including tissue C:N ratios, N volatilization/leaching/resorption, fixation, and methane rates.
 * `segment_dataframe()` now returns an empty dataframe when date filtering removes all crop-cycle segments, instead of a single row with NA columns that caused downstream segment config errors (#4007).
   
 

--- a/models/sipnet/inst/template.param_v2
+++ b/models/sipnet/inst/template.param_v2
@@ -4,6 +4,7 @@ litterInit		280
 soilInit		10000
 soilWFracInit	0.5
 snowInit		1.0
+plantStorageNInit 0.0
 fineRootFrac	0.200000
 coarseRootFrac	0.200000
 aMax			112.0
@@ -61,6 +62,7 @@ soilOrgNInit	135.0
 litterOrgNInit	14.0
 nVolatilizationFrac	0.1
 nLeachingFrac	0.25
+leafNResorptionFrac 0.5
 leafCN			20.0
 woodCN			100.0
 fineRootCN		40.0


### PR DESCRIPTION
Note that this retains the existing design of one parameter template for all runs using any Sipnet v2.x, so runs using Sipnet 2.1 will now emit an info about unrecognized params. That seems fine to me -- I think there are maybe three of us currently using Sipnet 2.1 and we're all about to upgrade.