### PR TITLE
Make fert/NCC phenology inputs configurable

### DIFF
--- a/workflows/fertilization-statewide/01-build-parcel-design.R
+++ b/workflows/fertilization-statewide/01-build-parcel-design.R
@@ -110,7 +110,8 @@ yr_list <- paste(years, collapse = ",")
 # season structure is mostly NA-padded, keep rows carrying a crop class
 crops <- DBI::dbGetQuery(con, sprintf(
   "SELECT CAST(parcel_id AS INTEGER) AS parcel_id, CAST(\"year\" AS INTEGER) AS yr,
-          CAST(season AS INTEGER) AS season, CLASS, CAST(SUBCLASS AS INTEGER) AS SUBCLASS
+          CAST(season AS INTEGER) AS season, CLASS,
+          TRY_CAST(NULLIF(NULLIF(TRIM(CAST(SUBCLASS AS VARCHAR)), '**'), '') AS INTEGER) AS SUBCLASS
    FROM read_parquet('%s') WHERE \"year\" IN (%s) AND CLASS IS NOT NULL",
   config[["crops_path"]], yr_list)) |>
   dplyr::rename(year = "yr") |>
@@ -120,13 +121,32 @@ crops <- DBI::dbGetQuery(con, sprintf(
 # green-up for most double-crop parcels, so rank green-ups within a parcel-year
 # and match the nth crop cycle to the nth green-up rather than collapsing to the
 # earliest. phenology_source is carried through for audit.
-phen <- DBI::dbGetQuery(con, sprintf(
-  "SELECT CAST(site_id AS INTEGER) AS parcel_id, CAST(\"year\" AS INTEGER) AS yr,
-          CAST(leafonday AS DATE) AS dt, phenology_source,
-          row_number() OVER (PARTITION BY site_id, \"year\" ORDER BY leafonday) AS phen_rank
-   FROM read_parquet('%s/phenology_statewide_*.parquet') WHERE \"year\" IN (%s)",
-  config[["phen_dir"]], yr_list)) |>
-  dplyr::rename(year = "yr", date = "dt")
+phen_anchor_col <- config[["phen_anchor_col"]]
+phen_raw <- DBI::dbGetQuery(con, sprintf(
+  "SELECT * FROM read_parquet('%s') WHERE \"year\" IN (%s)",
+  file.path(config[["phen_dir"]], config[["phen_glob"]]), yr_list))
+phen_id_col <- if ("parcel_id" %in% names(phen_raw)) "parcel_id" else "site_id"
+phen_source_col <- if ("phenology_source" %in% names(phen_raw)) {
+  "phenology_source"
+} else if ("gapfill_date_source" %in% names(phen_raw)) {
+  "gapfill_date_source"
+} else {
+  NA_character_
+}
+phen <- phen_raw |>
+  dplyr::transmute(
+    parcel_id = as.integer(.data[[phen_id_col]]),
+    year = as.integer(.data$year),
+    date = as.Date(.data[[phen_anchor_col]]),
+    phenology_source = if (is.na(phen_source_col)) {
+      NA_character_
+    } else {
+      as.character(.data[[phen_source_col]])
+    }
+  ) |>
+  dplyr::filter(!is.na(.data$date)) |>
+  dplyr::arrange(.data$parcel_id, .data$year, .data$date) |>
+  dplyr::mutate(phen_rank = dplyr::row_number(), .by = c("parcel_id", "year"))
 
 # where a parcel-year has fewer green-ups than crop cycles, the later cycles
 # reuse the last available one

--- a/workflows/fertilization-statewide/README.md
+++ b/workflows/fertilization-statewide/README.md
@@ -10,6 +10,8 @@ Configuration parameters live in `config.yml`. Most setups only need:
 
 - `crops_path`: the harmonized CADWR Land Use crops parquet. Override with `CCMMF_CROPS_PATH`
 - `phen_dir`: the gap-filled phenology (green-up) directory. Override with `CCMMF_PHEN_DIR`
+- `phen_glob`: file glob under `phen_dir` (default `phenology_statewide_*.parquet`). Override with `CCMMF_PHEN_GLOB`
+- `phen_anchor_col`: phenology date column (default `leafonday`). Override with `CCMMF_PHEN_ANCHOR_COL`
 - `crosswalk_path`: the CADWR to FREP to UC ANR crop name crosswalk TSV, versioned in this folder
 - `output_dir`: output directory for parquet shards
 - `n_parcels`, `n_ensemble`, `batch_size`, `workers`: settings per profile

--- a/workflows/fertilization-statewide/config.yml
+++ b/workflows/fertilization-statewide/config.yml
@@ -13,6 +13,8 @@ default:
   # these is pending ccmmf/organization#257
   crops_path: !expr path.expand(Sys.getenv("CCMMF_CROPS_PATH", "/projectnb/dietzelab/ccmmf/LandIQ-harmonized-v4.1/crops_all_years.parq"))
   phen_dir: !expr path.expand(Sys.getenv("CCMMF_PHEN_DIR", "/projectnb/dietzelab/ccmmf/usr/akash/phen_v2"))
+  phen_glob: !expr Sys.getenv("CCMMF_PHEN_GLOB", "phenology_statewide_*.parquet")
+  phen_anchor_col: !expr Sys.getenv("CCMMF_PHEN_ANCHOR_COL", "leafonday")
   crosswalk_path: workflows/fertilization-statewide/crop_name_crosswalk.tsv
   output_dir: !expr path.expand(Sys.getenv("CCMMF_FERT_OUT", "/projectnb/dietzelab/ccmmf/usr/akash/event_files/fertilization"))
   batch_size: 100

--- a/workflows/ncc-statewide/01-build-parcel-design.R
+++ b/workflows/ncc-statewide/01-build-parcel-design.R
@@ -47,7 +47,8 @@ yr_list <- paste(years, collapse = ",")
 # season structure is mostly NA-padded, keep rows carrying a crop class
 crops <- DBI::dbGetQuery(con, sprintf(
   "SELECT CAST(parcel_id AS INTEGER) AS parcel_id, CAST(\"year\" AS INTEGER) AS yr,
-          CAST(season AS INTEGER) AS season, CLASS, CAST(SUBCLASS AS INTEGER) AS SUBCLASS
+          CAST(season AS INTEGER) AS season, CLASS,
+          TRY_CAST(NULLIF(NULLIF(TRIM(CAST(SUBCLASS AS VARCHAR)), '**'), '') AS INTEGER) AS SUBCLASS
    FROM read_parquet('%s') WHERE \"year\" IN (%s) AND CLASS IS NOT NULL",
   config[["crops_path"]], yr_list)) |>
   dplyr::rename(year = "yr") |>
@@ -57,13 +58,32 @@ crops <- DBI::dbGetQuery(con, sprintf(
 # green-up for most double-crop parcels, so rank green-ups within a parcel-year
 # and match the nth crop cycle to the nth green-up rather than collapsing to the
 # earliest. phenology_source is carried through for audit.
-phen <- DBI::dbGetQuery(con, sprintf(
-  "SELECT CAST(site_id AS INTEGER) AS parcel_id, CAST(\"year\" AS INTEGER) AS yr,
-          CAST(leafonday AS DATE) AS anchor, phenology_source,
-          row_number() OVER (PARTITION BY site_id, \"year\" ORDER BY leafonday) AS phen_rank
-   FROM read_parquet('%s/phenology_statewide_*.parquet') WHERE \"year\" IN (%s)",
-  config[["phen_dir"]], yr_list)) |>
-  dplyr::rename(year = "yr")
+phen_anchor_col <- config[["phen_anchor_col"]]
+phen_raw <- DBI::dbGetQuery(con, sprintf(
+  "SELECT * FROM read_parquet('%s') WHERE \"year\" IN (%s)",
+  file.path(config[["phen_dir"]], config[["phen_glob"]]), yr_list))
+phen_id_col <- if ("parcel_id" %in% names(phen_raw)) "parcel_id" else "site_id"
+phen_source_col <- if ("phenology_source" %in% names(phen_raw)) {
+  "phenology_source"
+} else if ("gapfill_date_source" %in% names(phen_raw)) {
+  "gapfill_date_source"
+} else {
+  NA_character_
+}
+phen <- phen_raw |>
+  dplyr::transmute(
+    parcel_id = as.integer(.data[[phen_id_col]]),
+    year = as.integer(.data$year),
+    anchor = as.Date(.data[[phen_anchor_col]]),
+    phenology_source = if (is.na(phen_source_col)) {
+      NA_character_
+    } else {
+      as.character(.data[[phen_source_col]])
+    }
+  ) |>
+  dplyr::filter(!is.na(.data$anchor)) |>
+  dplyr::arrange(.data$parcel_id, .data$year, .data$anchor) |>
+  dplyr::mutate(phen_rank = dplyr::row_number(), .by = c("parcel_id", "year"))
 
 # where a parcel-year has fewer green-ups than crop cycles, the later cycles
 # reuse the last available one

--- a/workflows/ncc-statewide/README.md
+++ b/workflows/ncc-statewide/README.md
@@ -12,6 +12,8 @@ Configuration parameters in `config.yml`:
 
 - `crops_path`: the harmonized CADWR Land Use crops parquet. Override with `CCMMF_CROPS_PATH`
 - `phen_dir`: the gap-filled phenology (green-up) directory. Override with `CCMMF_PHEN_DIR`
+- `phen_glob`: file glob under `phen_dir` (default `phenology_statewide_*.parquet`). Override with `CCMMF_PHEN_GLOB`
+- `phen_anchor_col`: phenology date column (default `leafonday`). Override with `CCMMF_PHEN_ANCHOR_COL`
 - `cadwr_pfts_path`: the CADWR class/subclass to PFT map. Override with `CCMMF_CADWR_PFTS`
 - `output_dir`: output directory for parquet shards
 - `n_parcels`, `n_ensemble`, `batch_size`, `workers`: settings per profile

--- a/workflows/ncc-statewide/config.yml
+++ b/workflows/ncc-statewide/config.yml
@@ -8,6 +8,8 @@ default:
   # these is pending ccmmf/organization#257
   crops_path: !expr path.expand(Sys.getenv("CCMMF_CROPS_PATH", "/projectnb/dietzelab/ccmmf/LandIQ-harmonized-v4.1/crops_all_years.parq"))
   phen_dir: !expr path.expand(Sys.getenv("CCMMF_PHEN_DIR", "/projectnb/dietzelab/ccmmf/usr/akash/phen_v2"))
+  phen_glob: !expr Sys.getenv("CCMMF_PHEN_GLOB", "phenology_statewide_*.parquet")
+  phen_anchor_col: !expr Sys.getenv("CCMMF_PHEN_ANCHOR_COL", "leafonday")
   cadwr_pfts_path: !expr path.expand(Sys.getenv("CCMMF_CADWR_PFTS", "/projectnb/dietzelab/abv1/ccmmf/cadwr-landuse/data/cadwr_pfts.csv"))
 
   # probability of compost amendment per crop cycle per ensemble member, so a


### PR DESCRIPTION
Depends on #4077.

## Summary
- Fert and NCC can take a file glob and date column under `phen_dir`, so they are not stuck on `phenology_statewide_*.parquet` / `leafonday`.
- Phenology id can be `parcel_id` or `site_id`; source audit still works when a source column is there.
- LandIQ `SUBCLASS` values like `**` no longer blow up the integer cast.