### PR TITLE
Make NCC compost timing crop specific and align both event workflows on the latest version monitoring

### DIFF
--- a/workflows/fertilization-statewide/01-build-parcel-design.R
+++ b/workflows/fertilization-statewide/01-build-parcel-design.R
@@ -89,10 +89,10 @@ code_lookup <- code_map |>
 PEcAn.logger::logger.info(sprintf("Resolved %d CADWR codes via crosswalk", nrow(code_lookup)))
 
 # the event date is the anchor itself; this workflow applies no offset. the
-# anchor comes from the gap-filled LandIQ to MSLSP match, which keys every
+# anchor transition is chosen per PFT so annuals are timed to planting and
+# perennials to leaf-on, matching the split the monitoring event products use.
+# both come from the gap-filled LandIQ to MSLSP match, which keys every
 # transition by (parcel_id, year, season), so cycles join on a real season key.
-# same product the ncc workflow reads, so both sides agree on when a season
-# starts.
 
 years <- config[["years"]]
 PEcAn.logger::logger.info("Reading crops and gap-filled phenology for years: ",
@@ -115,21 +115,78 @@ crops <- DBI::dbGetQuery(con, sprintf(
   dplyr::rename(year = "yr") |>
   dplyr::mutate(code = paste0(.data$CLASS, .data$SUBCLASS))
 
-phen_anchor_col <- config[["phen_anchor_col"]]
+pft_anchor <- unlist(config[["pft_anchor"]])
+anchor_cols <- sort(unique(pft_anchor))
+
+# "**" is the LandIQ sentinel for subclass not specified. it becomes NA on both
+# sides of the join, so those rows land on the class-level fallback
+pft_lookup <- readr::read_csv(config[["pft_lookup_path"]],
+                              show_col_types = FALSE) |>
+  dplyr::filter(!is.na(.data$PFT))
+pft_by_code <- pft_lookup |>
+  dplyr::transmute(CLASS = .data$CLASS,
+                   SUBCLASS = as.integer(dplyr::na_if(as.character(.data$SUBCLASS), "**")),
+                   pft_group = .data$PFT) |>
+  dplyr::distinct()
+pft_by_class <- pft_lookup |>
+  dplyr::count(.data$CLASS, .data$PFT) |>
+  dplyr::slice_max(.data$n, n = 1, by = "CLASS", with_ties = FALSE) |>
+  dplyr::transmute(CLASS = .data$CLASS, pft_group_class = .data$PFT)
+
 phen <- DBI::dbGetQuery(con, sprintf(
   "SELECT CAST(parcel_id AS INTEGER) AS parcel_id, CAST(\"year\" AS INTEGER) AS year,
-          CAST(season AS INTEGER) AS season, gapfill_date_source, %s AS date
+          CAST(season AS INTEGER) AS season, gapfill_date_source, %s
    FROM read_parquet('%s') WHERE \"year\" IN (%s)",
-  phen_anchor_col, file.path(config[["phen_dir"]], config[["phen_glob"]]), yr_list))
+  paste(anchor_cols, collapse = ", "),
+  file.path(config[["phen_dir"]], config[["phen_glob"]]), yr_list))
+
+missing_cols <- setdiff(anchor_cols, names(phen))
+if (length(missing_cols) > 0) {
+  PEcAn.logger::logger.severe(
+    "phenology product has no column(s) named in pft_anchor: ",
+    paste(missing_cols, collapse = ", "))
+}
 
 # a cycle with no matched phenology row has no anchor, and is dropped rather
 # than given a substitute date
 plant <- crops |>
-  dplyr::inner_join(phen, by = c("parcel_id", "year", "season"))
+  dplyr::inner_join(phen, by = c("parcel_id", "year", "season")) |>
+  dplyr::left_join(pft_by_code, by = c("CLASS", "SUBCLASS")) |>
+  dplyr::left_join(pft_by_class, by = "CLASS") |>
+  dplyr::mutate(pft_group = dplyr::coalesce(.data$pft_group, .data$pft_group_class))
 PEcAn.logger::logger.info(sprintf(
   "Anchored %d of %d crop cycles (%.1f%%) across %d parcels",
   nrow(plant), nrow(crops), 100 * nrow(plant) / nrow(crops),
   dplyr::n_distinct(plant$parcel_id)))
+
+# non-crop pfts have no anchor rule. report them so a crop type missing a rule
+# is visible rather than silently absent
+dropped <- plant |>
+  dplyr::filter(!.data$pft_group %in% names(pft_anchor)) |>
+  dplyr::count(.data$pft_group, sort = TRUE)
+if (nrow(dropped) > 0) {
+  PEcAn.logger::logger.info(sprintf(
+    "Dropping %d cycles whose pft has no anchor rule:", sum(dropped$n)))
+  for (i in seq_len(nrow(dropped))) {
+    PEcAn.logger::logger.info(sprintf("  %s: %d cycles",
+                                      dropped$pft_group[i], dropped$n[i]))
+  }
+}
+plant <- plant |> dplyr::filter(.data$pft_group %in% names(pft_anchor))
+
+# index a numeric matrix so the anchor stays config driven, not a branch per pft
+anchor_idx <- cbind(seq_len(nrow(plant)),
+                    match(pft_anchor[plant$pft_group], anchor_cols))
+anchor_num <- do.call(cbind, lapply(plant[anchor_cols], as.numeric))
+plant$date <- as.Date(anchor_num[anchor_idx], origin = "1970-01-01")
+
+# a matched row is expected to carry every transition, so a NULL anchor means the
+# product changed rather than a cycle being legitimately undated
+no_anchor <- sum(is.na(plant$date))
+if (no_anchor > 0) {
+  PEcAn.logger::logger.severe(sprintf(
+    "%d cycles have a NULL anchor in the gap-filled product", no_anchor))
+}
 
 ## subsample
 # parcel set is sampled once and applied to all years so the same parcels
@@ -204,7 +261,7 @@ for (i in seq_len(nrow(src))) {
 }
 
 design <- kept |>
-  dplyr::select("parcel_id", "year", "season", "date", "code",
+  dplyr::select("parcel_id", "year", "season", "date", "code", "pft_group",
                 "min_n_lbs_acre", "max_n_lbs_acre") |>
   # fixed row order so the per row draws in 02 are reproducible under the seed
   dplyr::arrange(.data$parcel_id, .data$year, .data$season)

--- a/workflows/fertilization-statewide/01-build-parcel-design.R
+++ b/workflows/fertilization-statewide/01-build-parcel-design.R
@@ -88,13 +88,11 @@ code_lookup <- code_map |>
 
 PEcAn.logger::logger.info(sprintf("Resolved %d CADWR codes via crosswalk", nrow(code_lookup)))
 
-# the event date is anchored to green-up (leafonday) from the gap-filled
-# phenology product, observed where the satellite retrieval succeeded and
-# crop-calendar filled otherwise, so this covers the full ~600k ag universe
-# instead of the ~377k strict-matched subset. crop class per season comes
-# from the CADWR Land Use crops product. the crops product's own emergence
-# date is empty statewide, so the gap-filled green-up is the only populated
-# anchor available.
+# the event date is the anchor itself; this workflow applies no offset. the
+# anchor comes from the gap-filled LandIQ to MSLSP match, which keys every
+# transition by (parcel_id, year, season), so cycles join on a real season key.
+# same product the ncc workflow reads, so both sides agree on when a season
+# starts.
 
 years <- config[["years"]]
 PEcAn.logger::logger.info("Reading crops and gap-filled phenology for years: ",
@@ -117,50 +115,21 @@ crops <- DBI::dbGetQuery(con, sprintf(
   dplyr::rename(year = "yr") |>
   dplyr::mutate(code = paste0(.data$CLASS, .data$SUBCLASS))
 
-# the phenology product has no season key, but from 2018 on it carries a second
-# green-up for most double-crop parcels, so rank green-ups within a parcel-year
-# and match the nth crop cycle to the nth green-up rather than collapsing to the
-# earliest. phenology_source is carried through for audit.
 phen_anchor_col <- config[["phen_anchor_col"]]
-phen_raw <- DBI::dbGetQuery(con, sprintf(
-  "SELECT * FROM read_parquet('%s') WHERE \"year\" IN (%s)",
-  file.path(config[["phen_dir"]], config[["phen_glob"]]), yr_list))
-phen_id_col <- if ("parcel_id" %in% names(phen_raw)) "parcel_id" else "site_id"
-phen_source_col <- if ("phenology_source" %in% names(phen_raw)) {
-  "phenology_source"
-} else if ("gapfill_date_source" %in% names(phen_raw)) {
-  "gapfill_date_source"
-} else {
-  NA_character_
-}
-phen <- phen_raw |>
-  dplyr::transmute(
-    parcel_id = as.integer(.data[[phen_id_col]]),
-    year = as.integer(.data$year),
-    date = as.Date(.data[[phen_anchor_col]]),
-    phenology_source = if (is.na(phen_source_col)) {
-      NA_character_
-    } else {
-      as.character(.data[[phen_source_col]])
-    }
-  ) |>
-  dplyr::filter(!is.na(.data$date)) |>
-  dplyr::arrange(.data$parcel_id, .data$year, .data$date) |>
-  dplyr::mutate(phen_rank = dplyr::row_number(), .by = c("parcel_id", "year"))
+phen <- DBI::dbGetQuery(con, sprintf(
+  "SELECT CAST(parcel_id AS INTEGER) AS parcel_id, CAST(\"year\" AS INTEGER) AS year,
+          CAST(season AS INTEGER) AS season, gapfill_date_source, %s AS date
+   FROM read_parquet('%s') WHERE \"year\" IN (%s)",
+  phen_anchor_col, file.path(config[["phen_dir"]], config[["phen_glob"]]), yr_list))
 
-# where a parcel-year has fewer green-ups than crop cycles, the later cycles
-# reuse the last available one
-phen_max <- phen |>
-  dplyr::summarize(max_rank = max(.data$phen_rank), .by = c("parcel_id", "year"))
-
+# a cycle with no matched phenology row has no anchor, and is dropped rather
+# than given a substitute date
 plant <- crops |>
-  dplyr::mutate(season_rank = dplyr::dense_rank(.data$season),
-                .by = c("parcel_id", "year")) |>
-  dplyr::inner_join(phen_max, by = c("parcel_id", "year")) |>
-  dplyr::mutate(phen_rank = pmin(.data$season_rank, .data$max_rank)) |>
-  dplyr::inner_join(phen, by = c("parcel_id", "year", "phen_rank"))
-PEcAn.logger::logger.info(sprintf("Loaded %d cycles across %d parcels (phenology anchored)",
-                                  nrow(plant), dplyr::n_distinct(plant$parcel_id)))
+  dplyr::inner_join(phen, by = c("parcel_id", "year", "season"))
+PEcAn.logger::logger.info(sprintf(
+  "Anchored %d of %d crop cycles (%.1f%%) across %d parcels",
+  nrow(plant), nrow(crops), 100 * nrow(plant) / nrow(crops),
+  dplyr::n_distinct(plant$parcel_id)))
 
 ## subsample
 # parcel set is sampled once and applied to all years so the same parcels
@@ -226,11 +195,11 @@ if (nrow(zero_env) > 0) {
 }
 
 kept <- design |> dplyr::filter(.data$rate_source == "crosswalk")
-src <- kept |> dplyr::count(.data$phenology_source, sort = TRUE)
-PEcAn.logger::logger.info("Anchor provenance (phenology_source):")
+src <- kept |> dplyr::count(.data$gapfill_date_source, sort = TRUE)
+PEcAn.logger::logger.info("Anchor provenance (gapfill_date_source):")
 for (i in seq_len(nrow(src))) {
   PEcAn.logger::logger.info(sprintf("  %s: %d cycles (%.1f%%)",
-                                    src$phenology_source[i], src$n[i],
+                                    src$gapfill_date_source[i], src$n[i],
                                     100 * src$n[i] / nrow(kept)))
 }
 

--- a/workflows/fertilization-statewide/README.md
+++ b/workflows/fertilization-statewide/README.md
@@ -9,13 +9,13 @@ Source: California Department of Water Resources. (2016-2023). Statewide Crop Ma
 Configuration parameters live in `config.yml`. Most setups only need:
 
 - `crops_path`: the harmonized CADWR Land Use crops parquet. Override with `CCMMF_CROPS_PATH`
-- `phen_dir`: the gap-filled phenology (green-up) directory. Override with `CCMMF_PHEN_DIR`
-- `phen_glob`: file glob under `phen_dir` (default `phenology_statewide_*.parquet`). Override with `CCMMF_PHEN_GLOB`
-- `phen_anchor_col`: phenology date column (default `leafonday`). Override with `CCMMF_PHEN_ANCHOR_COL`
+- `phen_dir`: the gap-filled LandIQ to MSLSP match directory, the same product the ncc workflow reads. Override with `CCMMF_PHEN_DIR`
+- `phen_glob`: file glob under `phen_dir` (default `assigned_year=*_gapfilled.parquet`). Override with `CCMMF_PHEN_GLOB`
+- `phen_anchor_col`: phenology transition used as the anchor (default `mslsp_50PCGI`, leaf-on). Override with `CCMMF_PHEN_ANCHOR_COL`
 - `crosswalk_path`: the CADWR to FREP to UC ANR crop name crosswalk TSV, versioned in this folder
 - `output_dir`: output directory for parquet shards
 - `n_parcels`, `n_ensemble`, `batch_size`, `workers`: settings per profile
-- `nh4_fraction`: share of total synthetic N going to ammonium; the rest goes to nitrate (default 0.5 for a 50/50 split)
+- `nh4_fraction`: share of total synthetic N going to ammonium; the rest goes to nitrate (default 1, all ammonium)
 
 # Run
 
@@ -38,15 +38,15 @@ Events carry no organic C or N: these are synthetic mineral fertilizer applicati
 
 # Known limitations
 
-- The phenology product has no season key, so crop cycles are matched to green-ups by
-  rank: the nth cycle of a parcel-year takes the nth green-up. From 2018 on the product
-  carries a second green-up for most double-crop parcels, so this resolves the majority
-  of them. Where a parcel-year has fewer green-ups than cycles, the later cycles reuse
-  the last available green-up. 2016 is the exception, carrying one green-up per parcel
-  year, so its multi-season cycles all share an anchor.
-- The event date is the green-up date itself; this workflow applies no offset. Dates
-  outside the configured crop years occur because the phenology product itself assigns
-  some green-ups to the previous calendar year.
+- A crop cycle with no matched phenology row gets no anchor and is dropped. About 70%
+  of crop cycles carry a matched row.
+- The event date is the anchor itself; this workflow applies no offset. Dates outside
+  the configured crop years occur because the phenology product itself assigns some
+  transitions to an adjacent calendar year.
+- `ca_n_application_rate` is an annual total per crop, so the whole season's N budget
+  is applied as one event rather than split across pre-plant, side-dress and
+  fertigation. The date is therefore a single anchored placeholder for a schedule, not
+  a measured application date.
 - Only crop codes present in the crosswalk resolve to an N rate envelope. Cycles whose
   code does not resolve are dropped and reported at run time.
 

--- a/workflows/fertilization-statewide/README.md
+++ b/workflows/fertilization-statewide/README.md
@@ -11,7 +11,8 @@ Configuration parameters live in `config.yml`. Most setups only need:
 - `crops_path`: the harmonized CADWR Land Use crops parquet. Override with `CCMMF_CROPS_PATH`
 - `phen_dir`: the gap-filled LandIQ to MSLSP match directory, the same product the ncc workflow reads. Override with `CCMMF_PHEN_DIR`
 - `phen_glob`: file glob under `phen_dir` (default `assigned_year=*_gapfilled.parquet`). Override with `CCMMF_PHEN_GLOB`
-- `phen_anchor_col`: phenology transition used as the anchor (default `mslsp_50PCGI`, leaf-on). Override with `CCMMF_PHEN_ANCHOR_COL`
+- `pft_lookup_path`: crop code to PFT table, the same one the monitoring products use. Override with `CCMMF_PFT_LOOKUP`
+- `pft_anchor`: phenology transition used as the anchor, per PFT. See Application timing
 - `crosswalk_path`: the CADWR to FREP to UC ANR crop name crosswalk TSV, versioned in this folder
 - `output_dir`: output directory for parquet shards
 - `n_parcels`, `n_ensemble`, `batch_size`, `workers`: settings per profile
@@ -38,11 +39,28 @@ Events carry no organic C or N: these are synthetic mineral fertilizer applicati
 
 # Known limitations
 
-- A crop cycle with no matched phenology row gets no anchor and is dropped. About 70%
-  of crop cycles carry a matched row.
+- A crop cycle with no matched phenology row gets no anchor and is dropped. Against the
+  gap-filled LandIQ table this is about 99% of cycles.
 - The event date is the anchor itself; this workflow applies no offset. Dates outside
   the configured crop years occur because the phenology product itself assigns some
   transitions to an adjacent calendar year.
+
+# Application timing
+
+The anchor transition is chosen per PFT, so annuals are timed to planting and perennials
+to leaf-on. This matches the split the monitoring event products use: they report planting
+for annuals and leaf-on for perennials, not both for both.
+
+| PFT | anchor | transition means |
+|---|---|---|
+| row | `mslsp_OGI` | onset of greenness increase, 15%, used as planting |
+| rice | `mslsp_OGI` | as above |
+| hay | `mslsp_50PCGI` | 50% greenness increase, leaf-on |
+| woody | `mslsp_50PCGI` | as above |
+
+The event date is the anchor itself. Unlike the compost workflow there is no offset window,
+because `ca_n_application_rate` is an annual total per crop rather than an application
+schedule.
 - `ca_n_application_rate` is an annual total per crop, so the whole season's N budget
   is applied as one event rather than split across pre-plant, side-dress and
   fertigation. The date is therefore a single anchored placeholder for a schedule, not

--- a/workflows/fertilization-statewide/config.yml
+++ b/workflows/fertilization-statewide/config.yml
@@ -8,16 +8,29 @@ default:
   nh4_fraction: 1
   seed: 42
   years: [2016, 2018, 2019, 2020, 2021, 2022, 2023]
+  # crops is the gap-filled LandIQ table (v4.1.2), the same inventory the
+  # phenology match is built against. v4.1 is the ungapfilled table and covers
+  # parcels the match does not.
   # large inputs are not distributed with the repo. the defaults resolve on SCC;
   # set the matching environment variable to run anywhere else. final home for
   # these is pending ccmmf/organization#257
-  crops_path: !expr path.expand(Sys.getenv("CCMMF_CROPS_PATH", "/projectnb/dietzelab/ccmmf/LandIQ-harmonized-v4.1/crops_all_years.parq"))
-  # gap-filled LandIQ to MSLSP match, the same product the ncc workflow reads.
-  # mslsp_50PCGI is the transition the previous leafonday column was derived from,
-  # so the anchor is unchanged; only its source and the season key are new
+  crops_path: !expr path.expand(Sys.getenv("CCMMF_CROPS_PATH", "/projectnb/dietzelab/ccmmf/LandIQ-harmonized-v4.1.2/crops_all_years.parq"))
+  # gap-filled LandIQ to MSLSP match, the same product the ncc workflow reads
   phen_dir: !expr path.expand(Sys.getenv("CCMMF_PHEN_DIR", "/projectnb/dietzelab/ccmmf/management/phenology/matched_landiq_mslsp_v4.1.2/gapfill_dates"))
   phen_glob: !expr Sys.getenv("CCMMF_PHEN_GLOB", "assigned_year=*_gapfilled.parquet")
-  phen_anchor_col: !expr Sys.getenv("CCMMF_PHEN_ANCHOR_COL", "mslsp_50PCGI")
+
+  # crop code to PFT. same table the monitoring products use
+  pft_lookup_path: !expr path.expand(Sys.getenv("CCMMF_PFT_LOOKUP", "/projectnb/dietzelab/ccmmf/management/LandIQ_cropCode_lookup_table.csv"))
+
+  # anchor transition per PFT. annuals are timed to planting and perennials to
+  # leaf-on, matching the annual/perennial split the monitoring event products
+  # use: they report planting for annuals and leaf-on for perennials, not both
+  # for both. the event date is the anchor itself, this workflow applies no offset
+  pft_anchor:
+    row: mslsp_OGI
+    rice: mslsp_OGI
+    hay: mslsp_50PCGI
+    woody: mslsp_50PCGI
   crosswalk_path: workflows/fertilization-statewide/crop_name_crosswalk.tsv
   # versioned alongside ncc: v2.0 is the pass built on the v4.1.2 monitoring
   # products. bump rather than writing over

--- a/workflows/fertilization-statewide/config.yml
+++ b/workflows/fertilization-statewide/config.yml
@@ -12,11 +12,16 @@ default:
   # set the matching environment variable to run anywhere else. final home for
   # these is pending ccmmf/organization#257
   crops_path: !expr path.expand(Sys.getenv("CCMMF_CROPS_PATH", "/projectnb/dietzelab/ccmmf/LandIQ-harmonized-v4.1/crops_all_years.parq"))
-  phen_dir: !expr path.expand(Sys.getenv("CCMMF_PHEN_DIR", "/projectnb/dietzelab/ccmmf/usr/akash/phen_v2"))
-  phen_glob: !expr Sys.getenv("CCMMF_PHEN_GLOB", "phenology_statewide_*.parquet")
-  phen_anchor_col: !expr Sys.getenv("CCMMF_PHEN_ANCHOR_COL", "leafonday")
+  # gap-filled LandIQ to MSLSP match, the same product the ncc workflow reads.
+  # mslsp_50PCGI is the transition the previous leafonday column was derived from,
+  # so the anchor is unchanged; only its source and the season key are new
+  phen_dir: !expr path.expand(Sys.getenv("CCMMF_PHEN_DIR", "/projectnb/dietzelab/ccmmf/management/phenology/matched_landiq_mslsp_v4.1.2/gapfill_dates"))
+  phen_glob: !expr Sys.getenv("CCMMF_PHEN_GLOB", "assigned_year=*_gapfilled.parquet")
+  phen_anchor_col: !expr Sys.getenv("CCMMF_PHEN_ANCHOR_COL", "mslsp_50PCGI")
   crosswalk_path: workflows/fertilization-statewide/crop_name_crosswalk.tsv
-  output_dir: !expr path.expand(Sys.getenv("CCMMF_FERT_OUT", "/projectnb/dietzelab/ccmmf/usr/akash/event_files/fertilization"))
+  # versioned alongside ncc: v2.0 is the pass built on the v4.1.2 monitoring
+  # products. bump rather than writing over
+  output_dir: !expr path.expand(Sys.getenv("CCMMF_FERT_OUT", "/projectnb/dietzelab/ccmmf/usr/akash/event_files/fertilization/v2.0"))
   batch_size: 100
   workers: 1
 

--- a/workflows/ncc-statewide/01-build-parcel-design.R
+++ b/workflows/ncc-statewide/01-build-parcel-design.R
@@ -10,28 +10,39 @@ dir.create(staging_dir, showWarnings = FALSE, recursive = TRUE)
 
 options(arrow.unsafe_metadata = TRUE)
 
-# the event date is anchored to green-up (leafonday) from the gap-filled
-# phenology product. it carries a green-up for every ag parcel, observed
-# where the satellite retrieval succeeded and crop-calendar filled
-# otherwise, so this covers the full ~600k ag universe instead of the ~377k
-# strict-matched subset. crop class per season comes from the CADWR Land Use
-# crops product; pft is derived from class/subclass via cadwr_pfts. the crops
-# product's own emergence date is empty statewide, so the gap-filled green-up
-# is the only populated anchor available. phenology_source is carried through
-# so filled vs observed anchors stay auditable downstream.
+# the anchor transition is chosen per PFT: compost is timed against planting for
+# row and rice, leaf-on for woody, harvest for hay. the gap-filled match carries
+# every transition keyed (parcel_id, year, season), so cycles join their anchor
+# on a real season key rather than by rank. pft comes from the same crop code
+# table the monitoring products use, so a rule keyed on PFT means the same thing
+# on both sides.
 
-# pft_group by (class, subclass); a class-level fallback covers rows whose
-# subclass is not specified, since cadwr resolves those by class alone
-cadwr <- readr::read_csv(config[["cadwr_pfts_path"]], show_col_types = FALSE) |>
-  dplyr::filter(!is.na(.data$pft_group))
-pft_by_code <- cadwr |>
-  dplyr::transmute(CLASS = .data$class,
-                   SUBCLASS = as.integer(.data$subclass),
-                   pft_group = .data$pft_group)
-pft_by_class <- cadwr |>
-  dplyr::count(.data$class, .data$pft_group) |>
-  dplyr::slice_max(.data$n, n = 1, by = "class", with_ties = FALSE) |>
-  dplyr::transmute(CLASS = .data$class, pft_group_class = .data$pft_group)
+# one table drives both timing and rate, so adding a PFT is a config change
+timing <- purrr::map_dfr(config[["pft_timing"]], tibble::as_tibble,
+                         .id = "pft_group")
+required_timing <- c("anchor_col", "offset_min", "offset_max", "crop_structure")
+if (!all(required_timing %in% names(timing))) {
+  PEcAn.logger::logger.severe(
+    "pft_timing entries must define: ", paste(required_timing, collapse = ", "))
+}
+if (any(timing$offset_min > timing$offset_max)) {
+  PEcAn.logger::logger.severe("pft_timing has an offset window with min > max")
+}
+
+# "**" is the LandIQ sentinel for subclass not specified. it becomes NA on both
+# sides of the join, so those rows land on the class-level fallback
+pft_lookup <- readr::read_csv(config[["pft_lookup_path"]],
+                              show_col_types = FALSE) |>
+  dplyr::filter(!is.na(.data$PFT))
+pft_by_code <- pft_lookup |>
+  dplyr::transmute(CLASS = .data$CLASS,
+                   SUBCLASS = as.integer(dplyr::na_if(as.character(.data$SUBCLASS), "**")),
+                   pft_group = .data$PFT) |>
+  dplyr::distinct()
+pft_by_class <- pft_lookup |>
+  dplyr::count(.data$CLASS, .data$PFT) |>
+  dplyr::slice_max(.data$n, n = 1, by = "CLASS", with_ties = FALSE) |>
+  dplyr::transmute(CLASS = .data$CLASS, pft_group_class = .data$PFT)
 
 years <- config[["years"]]
 PEcAn.logger::logger.info("Reading crops and gap-filled phenology for years: ",
@@ -54,54 +65,61 @@ crops <- DBI::dbGetQuery(con, sprintf(
   dplyr::rename(year = "yr") |>
   dplyr::mutate(code = paste0(.data$CLASS, .data$SUBCLASS))
 
-# the phenology product has no season key, but from 2018 on it carries a second
-# green-up for most double-crop parcels, so rank green-ups within a parcel-year
-# and match the nth crop cycle to the nth green-up rather than collapsing to the
-# earliest. phenology_source is carried through for audit.
-phen_anchor_col <- config[["phen_anchor_col"]]
-phen_raw <- DBI::dbGetQuery(con, sprintf(
-  "SELECT * FROM read_parquet('%s') WHERE \"year\" IN (%s)",
-  file.path(config[["phen_dir"]], config[["phen_glob"]]), yr_list))
-phen_id_col <- if ("parcel_id" %in% names(phen_raw)) "parcel_id" else "site_id"
-phen_source_col <- if ("phenology_source" %in% names(phen_raw)) {
-  "phenology_source"
-} else if ("gapfill_date_source" %in% names(phen_raw)) {
-  "gapfill_date_source"
-} else {
-  NA_character_
+anchor_cols <- sort(unique(timing$anchor_col))
+phen_glob <- file.path(config[["phen_dir"]], config[["phen_glob"]])
+phen <- DBI::dbGetQuery(con, sprintf(
+  "SELECT CAST(parcel_id AS INTEGER) AS parcel_id, CAST(\"year\" AS INTEGER) AS year,
+          CAST(season AS INTEGER) AS season, gapfill_date_source, %s
+   FROM read_parquet('%s') WHERE \"year\" IN (%s)",
+  paste(anchor_cols, collapse = ", "), phen_glob, yr_list))
+
+missing_cols <- setdiff(anchor_cols, names(phen))
+if (length(missing_cols) > 0) {
+  PEcAn.logger::logger.severe(
+    "phenology product has no column(s) named in pft_timing$anchor_col: ",
+    paste(missing_cols, collapse = ", "))
 }
-phen <- phen_raw |>
-  dplyr::transmute(
-    parcel_id = as.integer(.data[[phen_id_col]]),
-    year = as.integer(.data$year),
-    anchor = as.Date(.data[[phen_anchor_col]]),
-    phenology_source = if (is.na(phen_source_col)) {
-      NA_character_
-    } else {
-      as.character(.data[[phen_source_col]])
-    }
-  ) |>
-  dplyr::filter(!is.na(.data$anchor)) |>
-  dplyr::arrange(.data$parcel_id, .data$year, .data$anchor) |>
-  dplyr::mutate(phen_rank = dplyr::row_number(), .by = c("parcel_id", "year"))
 
-# where a parcel-year has fewer green-ups than crop cycles, the later cycles
-# reuse the last available one
-phen_max <- phen |>
-  dplyr::summarize(max_rank = max(.data$phen_rank), .by = c("parcel_id", "year"))
-
+# a cycle with no matched phenology row has no anchor, and is dropped rather
+# than given a substitute date
 plant <- crops |>
-  dplyr::mutate(season_rank = dplyr::dense_rank(.data$season),
-                .by = c("parcel_id", "year")) |>
-  dplyr::inner_join(phen_max, by = c("parcel_id", "year")) |>
-  dplyr::mutate(phen_rank = pmin(.data$season_rank, .data$max_rank)) |>
-  dplyr::inner_join(phen, by = c("parcel_id", "year", "phen_rank")) |>
+  dplyr::inner_join(phen, by = c("parcel_id", "year", "season")) |>
   dplyr::left_join(pft_by_code, by = c("CLASS", "SUBCLASS")) |>
   dplyr::left_join(pft_by_class, by = "CLASS") |>
   dplyr::mutate(pft_group = dplyr::coalesce(.data$pft_group, .data$pft_group_class))
 
-PEcAn.logger::logger.info(sprintf("Loaded %d cycles across %d parcels (phenology anchored)",
-                                  nrow(plant), dplyr::n_distinct(plant$parcel_id)))
+PEcAn.logger::logger.info(sprintf(
+  "Anchored %d of %d crop cycles (%.1f%%); %d had no matched phenology row",
+  nrow(plant), nrow(crops), 100 * nrow(plant) / nrow(crops),
+  nrow(crops) - nrow(plant)))
+
+# non-crop pfts have no timing rule. report them so a crop type missing a rule
+# is visible rather than silently absent
+dropped <- plant |>
+  dplyr::filter(!.data$pft_group %in% timing$pft_group) |>
+  dplyr::count(.data$pft_group, sort = TRUE)
+if (nrow(dropped) > 0) {
+  PEcAn.logger::logger.info(sprintf(
+    "Dropping %d cycles whose pft has no timing rule:", sum(dropped$n)))
+  for (i in seq_len(nrow(dropped))) {
+    PEcAn.logger::logger.info(sprintf("  %s: %d cycles",
+                                      dropped$pft_group[i], dropped$n[i]))
+  }
+}
+plant <- plant |> dplyr::inner_join(timing, by = "pft_group")
+
+# index a numeric matrix so the anchor stays config driven, not a branch per pft
+anchor_idx <- cbind(seq_len(nrow(plant)), match(plant$anchor_col, anchor_cols))
+anchor_num <- do.call(cbind, lapply(plant[anchor_cols], as.numeric))
+plant$anchor <- as.Date(anchor_num[anchor_idx], origin = "1970-01-01")
+
+# a matched row is expected to carry every transition, so a NULL anchor means the
+# product changed rather than a cycle being legitimately undated
+no_anchor <- sum(is.na(plant$anchor))
+if (no_anchor > 0) {
+  PEcAn.logger::logger.severe(sprintf(
+    "%d cycles have a NULL anchor in the gap-filled product", no_anchor))
+}
 
 ## subsample
 n_parcels <- config[["n_parcels"]]
@@ -118,33 +136,10 @@ if (!is.null(n_parcels) && n_parcels < dplyr::n_distinct(plant$parcel_id)) {
                                     length(picked), n_parcels))
 }
 
-pft_family <- function(pft) {
-  dplyr::case_when(
-    pft %in% c("row", "hay", "rice") ~ "annual",
-    pft == "woody" ~ "perennial",
-    TRUE ~ NA_character_
-  )
-}
-
 design <- plant |>
-  dplyr::mutate(pft_family = pft_family(.data$pft_group))
-
-# non-crop classes (idle, urban, water) resolve to no pft and drop out here
-unknown <- design |> dplyr::filter(is.na(.data$pft_family))
-if (nrow(unknown) > 0) {
-  by_class <- unknown |> dplyr::count(.data$CLASS, sort = TRUE)
-  PEcAn.logger::logger.info(sprintf(
-    "Dropping %d cycles with no crop pft (non-crop classes):", nrow(unknown)))
-  for (i in seq_len(nrow(by_class))) {
-    PEcAn.logger::logger.info(sprintf("  CLASS=%s: %d cycles",
-                                      by_class$CLASS[i], by_class$n[i]))
-  }
-}
-
-design <- design |>
-  dplyr::filter(!is.na(.data$pft_family)) |>
-  dplyr::select("parcel_id", "year", "season", "anchor", "code",
-                "pft_family", "phenology_source") |>
+  dplyr::select("parcel_id", "year", "season", "anchor", "code", "pft_group",
+                "anchor_col", "crop_structure", "offset_min", "offset_max",
+                "gapfill_date_source") |>
   # fixed row order so the per row draws in 02 are reproducible under the seed
   dplyr::arrange(.data$parcel_id, .data$year, .data$season)
 
@@ -152,14 +147,20 @@ PEcAn.logger::logger.info(sprintf("Design table: %d cycles, %d parcels, %d years
                                   nrow(design),
                                   dplyr::n_distinct(design$parcel_id),
                                   dplyr::n_distinct(design$year)))
-PEcAn.logger::logger.info(sprintf("PFT family split: annual=%d, perennial=%d",
-                                  sum(design$pft_family == "annual"),
-                                  sum(design$pft_family == "perennial")))
-src <- design |> dplyr::count(.data$phenology_source, sort = TRUE)
-PEcAn.logger::logger.info("Anchor provenance (phenology_source):")
+
+pft_n <- design |> dplyr::count(.data$pft_group, sort = TRUE)
+PEcAn.logger::logger.info("Cycles per PFT:")
+for (i in seq_len(nrow(pft_n))) {
+  PEcAn.logger::logger.info(sprintf("  %s: %d cycles (%.1f%%)",
+                                    pft_n$pft_group[i], pft_n$n[i],
+                                    100 * pft_n$n[i] / nrow(design)))
+}
+
+src <- design |> dplyr::count(.data$gapfill_date_source, sort = TRUE)
+PEcAn.logger::logger.info("Anchor provenance (gapfill_date_source):")
 for (i in seq_len(nrow(src))) {
   PEcAn.logger::logger.info(sprintf("  %s: %d cycles (%.1f%%)",
-                                    src$phenology_source[i], src$n[i],
+                                    src$gapfill_date_source[i], src$n[i],
                                     100 * src$n[i] / nrow(design)))
 }
 

--- a/workflows/ncc-statewide/02-sample-ncc-events.R
+++ b/workflows/ncc-statewide/02-sample-ncc-events.R
@@ -56,26 +56,31 @@ if (nrow(unmatched) > 0L) {
   )
 }
 
-# annuals draw the row crop rate, perennials the orchard rate. every material is
-# eligible for both families: SIPNET already slows decomposition of high C:N
-# material through the litter C:N term in calcCNEffect, so screening materials
+# which rate applies is a property of the pft, not of a binary annual/perennial
+# split. every material is eligible for every structure: SIPNET already slows
+# decomposition of high C:N material through calcCNEffect, so screening materials
 # out here would double count what the model does
-family_structure <- c(annual = "rows", perennial = "trees")
+structures <- sort(unique(design$crop_structure))
+unknown_structure <- setdiff(structures, amendments$crop_structure)
+if (length(unknown_structure) > 0) {
+  PEcAn.logger::logger.severe(
+    "crop_structure in pft_timing has no rows in ca_organic_amendment_app_rate: ",
+    paste(unknown_structure, collapse = ", "))
+}
 
-# group each family's rows by material. drawing the joined rows directly would
+# group each structure's rows by material. drawing the joined rows directly would
 # weight a material by how many sources report it, so the three two-source
 # materials would come up twice as often as any other
-pool_by_material <- function(family) {
-  rows <- which(amendments$crop_structure == family_structure[[family]])
+pool_by_material <- function(structure) {
+  rows <- which(amendments$crop_structure == structure)
   split(rows, amendments$material[rows])
 }
-families <- stats::setNames(names(family_structure), names(family_structure))
-pools <- lapply(families, pool_by_material)
+pools <- lapply(stats::setNames(structures, structures), pool_by_material)
 
 # uniform over materials, then uniform over that material's sources, so source
 # disagreement stays in the ensemble without biasing which material is picked.
-# drawn per family in one pass: a closure per event row costs millions of calls
-# at statewide scale
+# drawn per structure in one pass: a closure per event row costs millions of
+# calls at statewide scale
 draw_material_rows <- function(pool, n) {
   n_source <- lengths(pool)
   flat <- unlist(pool, use.names = FALSE)
@@ -86,9 +91,9 @@ draw_material_rows <- function(pool, n) {
 }
 
 events$mat_idx <- NA_integer_
-for (fam in names(pools)) {
-  sel <- which(events$pft_family == fam)
-  events$mat_idx[sel] <- draw_material_rows(pools[[fam]], length(sel))
+for (structure in structures) {
+  sel <- which(events$crop_structure == structure)
+  events$mat_idx[sel] <- draw_material_rows(pools[[structure]], length(sel))
 }
 
 mat_cols <- amendments[events$mat_idx,
@@ -98,26 +103,17 @@ mat_cols <- amendments[events$mat_idx,
                          "cn_min", "cn_max")]
 events <- dplyr::bind_cols(events, mat_cols)
 
-# date offset windows are working assumptions: perennials get fall/winter
-# application (Niederholzer 2019, UCCE), annuals get a wider pre planting
-# window (Fulford et al 2023, CA processing tomatoes)
-ANNUAL_OFFSET_MIN <- 14L
-ANNUAL_OFFSET_MAX <- 180L
-PERENNIAL_OFFSET_MIN <- 30L
-PERENNIAL_OFFSET_MAX <- 210L
-
+# signed offsets let a rule place the event before the anchor or after it.
+# discrete uniform, inclusive of both bounds
 events <- events |>
   dplyr::mutate(
     u_rate = stats::runif(dplyr::n()),
     u_cn = stats::runif(dplyr::n()),
     app_rate_lb_acre = .data$app_rate_min + .data$u_rate * (.data$app_rate_max - .data$app_rate_min),
     cn_ratio = .data$cn_min + .data$u_cn * (.data$cn_max - .data$cn_min),
-    date_offset_days = ifelse(
-      .data$pft_family == "annual",
-      sample(ANNUAL_OFFSET_MIN:ANNUAL_OFFSET_MAX, dplyr::n(), replace = TRUE),
-      sample(PERENNIAL_OFFSET_MIN:PERENNIAL_OFFSET_MAX, dplyr::n(), replace = TRUE)
-    ),
-    date = .data$anchor - .data$date_offset_days,
+    date_offset_days = .data$offset_min +
+      floor(stats::runif(dplyr::n()) * (.data$offset_max - .data$offset_min + 1)),
+    date = .data$anchor + .data$date_offset_days,
     ens_id = sprintf("ens_%03d", .data$ensemble_member)
   )
 
@@ -127,6 +123,19 @@ PEcAn.logger::logger.info(sprintf(
   min(events[["app_rate_lb_acre"]]), max(events[["app_rate_lb_acre"]]),
   min(events[["n_pct"]]), max(events[["n_pct"]]),
   min(events[["cn_ratio"]]), max(events[["cn_ratio"]])))
+
+# realized windows show each rule was applied as configured
+win <- events |>
+  dplyr::summarize(n = dplyr::n(),
+                   min_off = min(.data$date_offset_days),
+                   max_off = max(.data$date_offset_days),
+                   .by = "pft_group")
+PEcAn.logger::logger.info("Realized offset window per PFT (days from anchor):")
+for (i in seq_len(nrow(win))) {
+  PEcAn.logger::logger.info(sprintf("  %s: %d to %d over %d events",
+                                    win$pft_group[i], win$min_off[i],
+                                    win$max_off[i], win$n[i]))
+}
 
 staging_file <- file.path(staging_dir, "_staging_02_events.rds")
 saveRDS(events, staging_file)

--- a/workflows/ncc-statewide/README.md
+++ b/workflows/ncc-statewide/README.md
@@ -86,7 +86,7 @@ carbon to flooded, anaerobic soil raises different concerns than a dry seedbed.
   seasons receives two independent draws and an effective annual probability of
   `1-(1-p)^2`. Compost is more naturally a per parcel-year decision; this is open.
 - A crop cycle with no matched phenology row gets no anchor and is dropped with a count
-  reported at run time. About 70% of crop cycles carry a matched row.
+  reported at run time. Against the gap-filled LandIQ table this is about 99% of cycles.
 - `mslsp_50PCGI` resolves leaf-on well for deciduous orchards but not for vineyards or
   citrus. Measured 2020 interquartile ranges are 11 days for almond against 89 for
   vineyard and 77 for citrus, and the vineyard figure is from observed rather than filled

--- a/workflows/ncc-statewide/README.md
+++ b/workflows/ncc-statewide/README.md
@@ -4,17 +4,17 @@ NCC is project shorthand for organic amendments like compost and manure. This wo
 
 Source: California Department of Water Resources. (2016-2023). Statewide Crop Mapping. California Natural Resources Agency Open Data. https://data.cnra.ca.gov/dataset/statewide-crop-mapping
 
-Material properties (%N, C:N, PAN, CalRecycle class) come from `PEcAn.data.land::ca_organic_amendment_properties`; application rates come from `PEcAn.data.land::ca_organic_amendment_app_rate`, which splits row crop and orchard rates. The two join on `material` and `source`. Annuals draw the `rows` rate, perennials the `trees` rate.
+Material properties (%N, C:N, PAN, CalRecycle class) come from `PEcAn.data.land::ca_organic_amendment_properties`; application rates come from `PEcAn.data.land::ca_organic_amendment_app_rate`, which splits row crop and orchard rates. The two join on `material` and `source`. Which rate a PFT draws is set by `crop_structure` in `pft_timing`.
 
 # Config
 
 Configuration parameters in `config.yml`:
 
 - `crops_path`: the harmonized CADWR Land Use crops parquet. Override with `CCMMF_CROPS_PATH`
-- `phen_dir`: the gap-filled phenology (green-up) directory. Override with `CCMMF_PHEN_DIR`
-- `phen_glob`: file glob under `phen_dir` (default `phenology_statewide_*.parquet`). Override with `CCMMF_PHEN_GLOB`
-- `phen_anchor_col`: phenology date column (default `leafonday`). Override with `CCMMF_PHEN_ANCHOR_COL`
-- `cadwr_pfts_path`: the CADWR class/subclass to PFT map. Override with `CCMMF_CADWR_PFTS`
+- `phen_dir`: the gap-filled LandIQ to MSLSP match directory. Override with `CCMMF_PHEN_DIR`
+- `phen_glob`: file glob under `phen_dir` (default `assigned_year=*_gapfilled.parquet`). Override with `CCMMF_PHEN_GLOB`
+- `pft_lookup_path`: crop code to PFT table, the same one the monitoring products use. Override with `CCMMF_PFT_LOOKUP`
+- `pft_timing`: per PFT, the anchor transition, signed offset window, and `crop_structure`. See Compost timing
 - `output_dir`: output directory for parquet shards
 - `n_parcels`, `n_ensemble`, `batch_size`, `workers`: settings per profile
 - `p_apply_default`: probability of compost per crop cycle per ensemble member (default 0.10); see Sampling design
@@ -27,10 +27,10 @@ Select a profile (`default`, `medium`, `all`) and run from PEcAn project root:
 NCC_PROJECT=default bash workflows/ncc-statewide/run-statewide.sh
 ```
 
-01 builds a design table and tags each PFT as annual (row, hay, rice) or perennial (woody). 02 runs Bernoulli gate, picks a material per fired row from the joined amendment tables, using the application rate that matches the family (row crop or orchard), and draws app rate and C:N from that material's envelope. Materials are drawn uniformly, then a source is drawn uniformly among the materials reported by more than one source, so source disagreement enters the ensemble without biasing which material is selected. 03 converts units, carries all N as organic N, and writes parcel range sharded parquet.
+01 builds a design table, resolving each crop cycle's PFT and the anchor date its PFT is timed against. 02 runs a Bernoulli gate, picks a material per fired row from the joined amendment tables using the application rate matching that PFT's `crop_structure`, and draws app rate, C:N and a signed date offset. Materials are drawn uniformly, then a source is drawn uniformly among the materials reported by more than one source, so source disagreement enters the ensemble without biasing which material is selected. 03 converts units, carries all N as organic N, and writes parcel range sharded parquet.
 
 `check-result.R` reads the output back, asserts the invariants listed under Checks, and
-prints a summary.
+prints a summary including the realized timing window per PFT.
 
 # Sampling design
 
@@ -47,33 +47,52 @@ not established distributions.
 | source, where a material is reported by more than one | uniform over that material's sources | keeps disagreement between sources in the ensemble instead of averaging it away |
 | application rate | uniform on `[app_rate_min, app_rate_max]` | sources report an envelope, not a distribution |
 | C:N | uniform on `[cn_min, cn_max]` | sources report an envelope, not a distribution |
-| date offset before green-up | uniform on the family window, 14 to 180 days for annuals and 30 to 210 for perennials | working assumption consistent with the broad direction in the literature, fall application for perennials and pre plant for annuals |
+| date offset from the anchor | discrete uniform on `[offset_min, offset_max]` for the PFT, inclusive | working assumption per crop type, see Compost timing |
 
-Because applications precede green-up by up to 210 days, a crop cycle in year Y can carry
-an event dated Y-1. Event dates therefore span one year earlier than the configured crop
-years, and include 2017 even though 2017 has no crop cycles of its own.
+Offsets are signed, so an event can fall outside its anchor's calendar year in either
+direction: row reaches 120 days before a planting date that may already sit in the prior
+year, and hay reaches 14 days after a senescence date that may already sit in the
+following one.
+Event dates therefore span one year on each side of the configured crop years.
 
-The only rule applied before the material draw is the rate lookup: annuals draw the row
-crop rate and perennials the orchard rate, matching the `crop_structure` split in
-`ca_organic_amendment_app_rate`. Every material is eligible for both families, with no
-screening by `material_class` or C:N.
+Every material is eligible for every `crop_structure`, with no screening by
+`material_class` or C:N.
 
 SIPNET represents the effect of a high C:N amendment itself. Litter breakdown is scaled by
 `calcCNEffect(kCN, litterC, litterN) = kCN / (kCN + C:N)`, so a material that raises the
 litter pool C:N decomposes, and releases N, more slowly. At `kCN = 80` wood chips at C:N
 300 break down at roughly a quarter the rate of poultry litter at C:N 12.5.
 
+# Compost timing
+
+Compost is applied at different points of the season depending on the crop, so the anchor
+is chosen per PFT rather than shared. Anchors are MSLSP phenology transitions carried on
+the gap-filled LandIQ to MSLSP match, which keys them by `(parcel_id, year, season)`:
+
+| PFT | anchor | transition means | offset window |
+|---|---|---|---|
+| row | `mslsp_OGI` | onset of greenness increase, 15%, used as planting | 120 to 90 days before |
+| rice | `mslsp_OGI` | as above | 90 to 60 days before |
+| woody | `mslsp_50PCGI` | 50% greenness increase, leaf-on | 30 days before to 14 days after |
+| hay | `mslsp_OGD` | onset of greenness decrease, 10%, used as harvest | 0 to 14 days after |
+
+The windows are working assumptions, not fitted values, and live in `config.yml` so they
+can be revised without a code change. Rice is separated from row because applying labile
+carbon to flooded, anaerobic soil raises different concerns than a dry seedbed.
+
 # Known limitations
 
 - The application probability is drawn per crop cycle, so a parcel-year with two crop
   seasons receives two independent draws and an effective annual probability of
   `1-(1-p)^2`. Compost is more naturally a per parcel-year decision; this is open.
-- The phenology product has no season key, so crop cycles are matched to green-ups by
-  rank: the nth cycle of a parcel-year takes the nth green-up. From 2018 on the product
-  carries a second green-up for most double-crop parcels, so this resolves the majority
-  of them. Where a parcel-year has fewer green-ups than cycles, the later cycles reuse
-  the last available green-up. 2016 is the exception, carrying one green-up per parcel
-  year, so its multi-season cycles all share an anchor.
+- A crop cycle with no matched phenology row gets no anchor and is dropped with a count
+  reported at run time. About 70% of crop cycles carry a matched row.
+- `mslsp_50PCGI` resolves leaf-on well for deciduous orchards but not for vineyards or
+  citrus. Measured 2020 interquartile ranges are 11 days for almond against 89 for
+  vineyard and 77 for citrus, and the vineyard figure is from observed rather than filled
+  retrievals. Citrus is evergreen, so its greenness transition is not a leaf-on; vineyard
+  retrievals are affected by the interrow floor within a 30 m pixel. The woody window is
+  narrower than that spread for those two classes.
 - SIPNET has no immobilization flux, so a high C:N amendment that would show negative
   first year plant available N still yields small positive net mineralization.
 - All organic C enters the single litter pool, so compost is not represented as more
@@ -89,12 +108,3 @@ litter pool C:N decomposes, and releases N, more slowly. At `kCN = 80` wood chip
 - `material`: diagnostic column for `check-result.R` only. Cleaner strips it before union so it never reaches SIPNET
 
 Downstream, `workflows/preprocess-event-parquet/01c-clean-fertilization.R` unions these with synthetic N rows from fertilization workflow and writes one `fertilization.parquet`. SIPNET handles both under same FERT event type.
-
-# Compost timing
-
-Anchor is the gap-filled green-up date (`leafonday`). For annuals that's close to but not exactly planting date (emergence lags planting by a few days to weeks). For perennials it's bud break. Date offset is uniform within a family window:
-
-- annuals (row, hay, rice): 14 to 180 days before green up
-- perennials (woody): 30 to 210 days before green up
-
-These are working assumptions consistent with broad direction in literature (fall application for perennials, pre plant for annuals).

--- a/workflows/ncc-statewide/check-result.R
+++ b/workflows/ncc-statewide/check-result.R
@@ -129,14 +129,47 @@ if (dplyr::n_distinct(dat$ens_id) != n_ens) {
                dplyr::n_distinct(dat$ens_id), n_ens))
 }
 
-# events are anchored up to 210 days before green-up, so a cycle in year Y can place its
-# application in Y-1. that includes 2017, which carries no crop cycles of its own
+# offsets are signed, so an event can fall outside its anchor's calendar year in
+# either direction: row reaches 120 days before a planting date that may already sit
+# in the prior year, and hay reaches 14 days after a senescence date that may already
+# sit in the following one. one year of slack on each side covers both
 expected_years <- as.integer(config[["years"]])
-allowed_years <- seq(min(expected_years) - 1L, max(expected_years))
+allowed_years <- seq(min(expected_years) - 1L, max(expected_years) + 1L)
 extra_years <- setdiff(unique(lubridate::year(dat$date)), allowed_years)
 if (length(extra_years) > 0) {
   fail("event dates outside the configured years: ",
        paste(sort(extra_years), collapse = ", "))
+}
+
+# the parquet carries the delivered date but not the anchor it was measured from,
+# so the per PFT timing rule is asserted against the staged events, where both are
+# present. this is the check that a rule was applied as configured rather than
+# defaulting to another PFT's window
+events_file <- file.path(out_path, "_staging", "_staging_02_events.rds")
+if (!file.exists(events_file)) {
+  fail("Stage 02 output not found: ", events_file,
+       ". Timing rules cannot be verified without it.")
+}
+staged <- readRDS(events_file)
+delta <- as.integer(staged$date - staged$anchor)
+out_of_window <- delta < staged$offset_min | delta > staged$offset_max
+if (any(out_of_window)) {
+  worst <- staged[which(out_of_window)[1], ]
+  fail(sprintf("%d events fall outside their PFT's offset window, e.g. %s at %d days against %d to %d",
+               sum(out_of_window), worst$pft_group,
+               as.integer(worst$date - worst$anchor),
+               worst$offset_min, worst$offset_max))
+}
+
+realized <- staged |>
+  dplyr::summarize(min_off = min(as.integer(.data$date - .data$anchor)),
+                   max_off = max(as.integer(.data$date - .data$anchor)),
+                   .by = c("pft_group", "anchor_col"))
+PEcAn.logger::logger.info("Timing rule per PFT (days from anchor):")
+for (i in seq_len(nrow(realized))) {
+  PEcAn.logger::logger.info(sprintf("  %s anchored on %s: %d to %d",
+                                    realized$pft_group[i], realized$anchor_col[i],
+                                    realized$min_off[i], realized$max_off[i]))
 }
 
 PEcAn.logger::logger.info("All checks passed")

--- a/workflows/ncc-statewide/config.yml
+++ b/workflows/ncc-statewide/config.yml
@@ -3,10 +3,13 @@ default:
   n_ensemble: 20
   seed: 42
   years: [2016, 2018, 2019, 2020, 2021, 2022, 2023]
+  # crops is the gap-filled LandIQ table (v4.1.2), the same inventory the
+  # phenology match is built against. v4.1 is the ungapfilled table and covers
+  # parcels the match does not.
   # large inputs are not distributed with the repo. the defaults resolve on SCC;
   # set the matching environment variable to run anywhere else. final home for
   # these is pending ccmmf/organization#257
-  crops_path: !expr path.expand(Sys.getenv("CCMMF_CROPS_PATH", "/projectnb/dietzelab/ccmmf/LandIQ-harmonized-v4.1/crops_all_years.parq"))
+  crops_path: !expr path.expand(Sys.getenv("CCMMF_CROPS_PATH", "/projectnb/dietzelab/ccmmf/LandIQ-harmonized-v4.1.2/crops_all_years.parq"))
 
   # gap-filled LandIQ to MSLSP match. carries every phenology transition as a
   # DATE keyed (parcel_id, year, season), so crop cycles join on a real season

--- a/workflows/ncc-statewide/config.yml
+++ b/workflows/ncc-statewide/config.yml
@@ -7,10 +7,42 @@ default:
   # set the matching environment variable to run anywhere else. final home for
   # these is pending ccmmf/organization#257
   crops_path: !expr path.expand(Sys.getenv("CCMMF_CROPS_PATH", "/projectnb/dietzelab/ccmmf/LandIQ-harmonized-v4.1/crops_all_years.parq"))
-  phen_dir: !expr path.expand(Sys.getenv("CCMMF_PHEN_DIR", "/projectnb/dietzelab/ccmmf/usr/akash/phen_v2"))
-  phen_glob: !expr Sys.getenv("CCMMF_PHEN_GLOB", "phenology_statewide_*.parquet")
-  phen_anchor_col: !expr Sys.getenv("CCMMF_PHEN_ANCHOR_COL", "leafonday")
-  cadwr_pfts_path: !expr path.expand(Sys.getenv("CCMMF_CADWR_PFTS", "/projectnb/dietzelab/abv1/ccmmf/cadwr-landuse/data/cadwr_pfts.csv"))
+
+  # gap-filled LandIQ to MSLSP match. carries every phenology transition as a
+  # DATE keyed (parcel_id, year, season), so crop cycles join on a real season
+  # key rather than by rank
+  phen_dir: !expr path.expand(Sys.getenv("CCMMF_PHEN_DIR", "/projectnb/dietzelab/ccmmf/management/phenology/matched_landiq_mslsp_v4.1.2/gapfill_dates"))
+  phen_glob: !expr Sys.getenv("CCMMF_PHEN_GLOB", "assigned_year=*_gapfilled.parquet")
+
+  # crop code to PFT. same table the monitoring products use, so timing rules
+  # keyed on PFT mean the same thing on both sides
+  pft_lookup_path: !expr path.expand(Sys.getenv("CCMMF_PFT_LOOKUP", "/projectnb/dietzelab/ccmmf/management/LandIQ_cropCode_lookup_table.csv"))
+
+  # per PFT: which transition anchors the event, and the signed offset window
+  # around it in days. negative is before the anchor. windows are working
+  # assumptions, see Sampling design in the README. crop_structure selects the
+  # application rate column in ca_organic_amendment_app_rate
+  pft_timing:
+    row:
+      anchor_col: mslsp_OGI
+      offset_min: -120
+      offset_max: -90
+      crop_structure: rows
+    rice:
+      anchor_col: mslsp_OGI
+      offset_min: -90
+      offset_max: -60
+      crop_structure: rows
+    woody:
+      anchor_col: mslsp_50PCGI
+      offset_min: -30
+      offset_max: 14
+      crop_structure: trees
+    hay:
+      anchor_col: mslsp_OGD
+      offset_min: 0
+      offset_max: 14
+      crop_structure: rows
 
   # probability of compost amendment per crop cycle per ensemble member, so a
   # parcel year with two cycles gets two draws. scenario parameter, useful range
@@ -18,7 +50,9 @@ default:
   # cycle or the parcel year level is still open
   p_apply_default: 0.10
 
-  output_dir: !expr path.expand(Sys.getenv("CCMMF_NCC_OUT", "/projectnb/dietzelab/ccmmf/usr/akash/event_files/ncc"))
+  # versioned: v1.0 is the binary annual/perennial timing, v2.0 the per PFT rules.
+  # bumping this rather than writing over
+  output_dir: !expr path.expand(Sys.getenv("CCMMF_NCC_OUT", "/projectnb/dietzelab/ccmmf/usr/akash/event_files/ncc/v2.0"))
   batch_size: 100
   workers: 1
 

--- a/workflows/preprocess-event-parquet/01c-clean-fertilization.R
+++ b/workflows/preprocess-event-parquet/01c-clean-fertilization.R
@@ -11,9 +11,9 @@
 # so a different output_dir in either workflow config does not require
 # editing this file
 fert_path <- Sys.getenv("FERT_RAW_DIR",
-                        unset = "/projectnb/dietzelab/ccmmf/usr/akash/event_files/fertilization")
+                        unset = "/projectnb/dietzelab/ccmmf/usr/akash/event_files/fertilization/v2.0")
 ncc_path  <- Sys.getenv("NCC_RAW_DIR",
-                        unset = "/projectnb/dietzelab/ccmmf/usr/akash/event_files/ncc")
+                        unset = "/projectnb/dietzelab/ccmmf/usr/akash/event_files/ncc/v2.0")
 
 outdir <- "_output"
 dir.create(outdir, showWarnings = FALSE, recursive = TRUE)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
NCC timed compost by a binary annual/perennial split, with the offset always subtracted from a single green-up anchor. This makes the rule per PFT and allows an event to fall after its anchor.

Both workflows now read the gap-filled LandIQ to MSLSP match, which carries every phenology transition keyed `(parcel_id, year, season)`. Crop cycles join on the season key instead of by rank.

Fertilization changes are included for input consistency, on adopting latest version of monitoring. Its timing is unchanged, date is still anchor itself, and `mslsp_50PCGI` is transition `leafonday` was derived from.

## Changes

- Per PFT anchor, signed offset window and rate structure, set in `config.yml`. Row and rice on `mslsp_OGI`, woody on `mslsp_50PCGI`, hay on `mslsp_OGD`
- Crop code to PFT now comes from `LandIQ_cropCode_lookup_table.csv`, the table the monitoring products use. Alfalfa and pasture move from `row` to `hay`, `G6`/`G7` from `hay` to `row`
- `check-result.R` asserts each event falls inside its PFT's window. The year bound now allows a year on each side, since signed offsets can leave the anchor's year in either direction
- Output paths versioned to `v2.0`
- Few doc fixes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
