### PR TITLE
Add repository guards to scheduled workflows on forks. Fixes #4095

### DIFF
--- a/.github/workflows/ci-weekly.yml
+++ b/.github/workflows/ci-weekly.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'PecanProject/pecan' || github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:
@@ -22,6 +23,7 @@ jobs:
     secrets: inherit
 
   check:
+    if: github.repository == 'PecanProject/pecan' || github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:
@@ -36,6 +38,7 @@ jobs:
     secrets: inherit
 
   sipnet:
+    if: github.repository == 'PecanProject/pecan' || github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-stack-sipnet.yml
+++ b/.github/workflows/docker-stack-sipnet.yml
@@ -8,6 +8,7 @@ on :
   - cron: '30 4 * * 1,3,5'
 jobs:
   sipnet:
+    if: github.repository == 'PecanProject/pecan' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,15 +42,17 @@ jobs:
   # As an ugly workaround, we assign it to a job output instead.
   # ----------------------------------------------------------------------
   rversion:
-    # Every build job below needs this job, so gating it here skips the whole
-    # push-based Docker stack for pull requests opened from forks. Forks get a
-    # read-only GITHUB_TOKEN and cannot push to ghcr.io/pecanproject, so those
-    # jobs always failed at the push step. Fork PRs are instead built (without
-    # pushing) by docker-build-pr.yml. Non-fork events (push, merge_group,
-    # schedule, workflow_dispatch) and same-repo PRs still run the full stack.
+    # Every build job below needs this job, so gating it here:
+    # 1. Skips scheduled builds on forks where GITHUB_TOKEN has no push access
+    #    to ghcr.io/pecanproject and runner minutes would be wasted.
+    # 2. Skips the push-based Docker stack for pull requests opened from forks.
+    #    Fork PRs are instead built (without pushing) by docker-build-pr.yml.
+    # Non-fork events (push, merge_group, schedule, workflow_dispatch) and
+    # same-repo PRs still run the full stack.
     if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      (github.repository == 'PecanProject/pecan' || github.event_name != 'schedule') &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - id: mon

--- a/.github/workflows/download-met-data.yml
+++ b/.github/workflows/download-met-data.yml
@@ -16,6 +16,7 @@ env:
         
 jobs:
   met-data-download:
+    if: github.repository == 'PecanProject/pecan' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,6 +8,7 @@ on :
   - cron: '30 4 * * 4'
 jobs:
   test:
+    if: github.repository == 'PecanProject/pecan' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
 
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - Added statewide synthetic fertilization and compost amendment event workflows for CA ag parcels. Outputs share an ensemble naming so a downstream cleaner unions them into one fertilization event type for SIPNET.
 
 ### Fixed
+- Added repository guards to scheduled workflows to skip execution on forks by default and documented how to enable them for active fork development (#4095).
 - Building package documentation sites via `scripts/build_pkgdown.R` no longer exits early when any package gives a build warning (#4034).
 - The median run's manifest row went in with the literal strings `"NA"` for pft and trait, which `read.csv` turns into real `NA`, so `read.sa.output` never matched the median quantile and `splinefun` silently dropped that knot. Sensitivity analysis output changes as a result: partial variances shift slightly, though rankings are unaffected in the cases checked.
 - Docker GHA workflow no longer fails on pull requests opened from forks (#3618).

--- a/DEV-INTRO.md
+++ b/DEV-INTRO.md
@@ -33,6 +33,14 @@ cd pecan
 # git clone https://github.com/PecanProject/pecan
 ```
 
+### GitHub Actions on Forks
+
+Scheduled workflows (such as weekly checks and nightly Docker builds) are configured to skip scheduled runs on forks by default (`if: github.repository == 'PecanProject/pecan' || github.event_name != 'schedule'`). This avoids consuming GitHub Actions runner minutes on personal accounts and prevents alerts from failed container push steps.
+
+If you want these scheduled workflows to run automatically on your personal fork:
+1. Update the repository check in the workflow files (`.github/workflows/*.yml`) to match your fork (for example, change `'PecanProject/pecan'` to `'<your-username>/pecan'`), or remove the repository condition on your working branch.
+2. Alternatively, you can trigger any workflow manually from your fork at any time via the GitHub Actions UI (**Actions** tab > select workflow > **Run workflow**).
+
 ## Developing in Docker
 
 The use of Docker in PEcAn is described in detail in the [PEcAn documentation](https://pecanproject.github.io/pecan-documentation/latest/docker-index.html). This is intended as a quick start.


### PR DESCRIPTION
## Description

This pull request adds repository guards to scheduled workflows so they only run on the upstream `PecanProject/pecan` repository by default. It also adds a section to `DEV-INTRO.md` explaining how developers can re-enable scheduled runs on personal forks if desired.

Workflows updated with the guard:
- `.github/workflows/ci-weekly.yml`
- `.github/workflows/docker-stack-sipnet.yml`
- `.github/workflows/docker.yml`
- `.github/workflows/integration-test.yml`
- `.github/workflows/download-met-data.yml`

Manual execution through `workflow_dispatch` remains unaffected on all forks.

## Motivation and Context

Fixes #4095.

Scheduled workflows on contributor forks consume personal GitHub Actions runner minutes when forks sit idle. In addition, container push jobs in `docker.yml` fail on forks without repository secrets, generating recurring failure alerts.

Adding this guard aligns these workflows with existing patterns in `check-links.yml` and `stale.yml`. Following discussion with @mdietze and @infotroph on #4095, the guards are enabled by default and documented for active fork developers.

## Review Time Estimate
- [ ] Immediately
- [x] Within one week
- [ ] When possible

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number: #4095 -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [x] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [x] I have updated the CHANGELOG.md.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
