### PR TITLE
build_pkgdown.R: use withCallingHandlers to muffle and collect warnings (#4034)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - Added statewide synthetic fertilization and compost amendment event workflows for CA ag parcels. Outputs share an ensemble naming so a downstream cleaner unions them into one fertilization event type for SIPNET.
 
 ### Fixed
-- In `scripts/build_pkgdown.R`, `build_quietly()` now uses `withCallingHandlers` to capture and muffle warnings in the signalling context without prematurely aborting package documentation builds (#4034).
+- Building package documentation sites via `scripts/build_pkgdown.R` no longer exits early when any package gives a build warning (#4034).
 - The median run's manifest row went in with the literal strings `"NA"` for pft and trait, which `read.csv` turns into real `NA`, so `read.sa.output` never matched the median quantile and `splinefun` silently dropped that knot. Sensitivity analysis output changes as a result: partial variances shift slightly, though rankings are unaffected in the cases checked.
 - Docker GHA workflow no longer fails on pull requests opened from forks (#3618).
 - Removed unused `grid2netcdf()` from `PEcAn.data.remote` and fixed R CMD check reference notes for `download.LandTrendr.AGB()` (#2758).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - Added statewide synthetic fertilization and compost amendment event workflows for CA ag parcels. Outputs share an ensemble naming so a downstream cleaner unions them into one fertilization event type for SIPNET.
 
 ### Fixed
+- In `scripts/build_pkgdown.R`, `build_quietly()` now uses `withCallingHandlers` to capture and muffle warnings in the signalling context without prematurely aborting package documentation builds (#4034).
 - The median run's manifest row went in with the literal strings `"NA"` for pft and trait, which `read.csv` turns into real `NA`, so `read.sa.output` never matched the median quantile and `splinefun` silently dropped that knot. Sensitivity analysis output changes as a result: partial variances shift slightly, though rankings are unaffected in the cases checked.
 - Docker GHA workflow no longer fails on pull requests opened from forks (#3618).
 - Removed unused `grid2netcdf()` from `PEcAn.data.remote` and fixed R CMD check reference notes for `download.LandTrendr.AGB()` (#2758).

--- a/scripts/build_pkgdown.R
+++ b/scripts/build_pkgdown.R
@@ -68,21 +68,23 @@ build_quietly <- function(pkg, ...) {
   warns <- list()
 
   tryCatch(
-    build_and_copy(pkg = pkg, ...),
+    withCallingHandlers(
+      build_and_copy(pkg = pkg, ...),
+      # Use withCallingHandlers so warnings are captured in the signalling
+      # context without aborting the build, and can be muffled properly
+      warning = function(w) {
+        w$message <- paste(
+          "⚠️ Warning building pkgdown site for", pkg, ":", w$message
+        )
+        warns <<- append(warns, list(w))
+        tryInvokeRestart("muffleWarning")
+      }
+    ),
     error = function(e) {
       e$message <- paste(
         "❌ Error building pkgdown site for", pkg, ":", e$message
       )
       err <<- e
-    },
-    # TODO this branch doesn't ever seem to run.
-    # Seems like pkgdown reports warnings as they happen, before returning
-    warning = function(w) {
-      w$message <- paste(
-        "⚠️ Warning building pkgdown site for", pkg, ":", w$message
-      )
-      warns <<- append(warns, w)
-      tryInvokeRestart("muffleWarning")
     }
   )
 
@@ -133,8 +135,9 @@ writeLines(
 build_warns <- purrr::map_lgl(build_results, \(x) length(x$warnings) > 0)
 if (any(build_warns)) {
   logger("⚠️ Warnings found in package(s)", packages[build_warns], ":")
-  purrr::map(build_results[build_warns], "warnings") |>
-    purrr::walk(rlang::warn)
+  purrr::walk(build_results[build_warns], \(res) {
+    purrr::walk(res$warnings, \(w) rlang::warn(conditionMessage(w)))
+  })
 }
 
 build_err <- purrr::map_lgl(build_results, \(x) !is.null(x$error))


### PR DESCRIPTION
## Description
Refactors `build_quietly()` in `scripts/build_pkgdown.R` to collect warnings using `withCallingHandlers` instead of an exiting `tryCatch` handler.

## Motivation and Context
Closes #4034.

Previously, `build_quietly()` caught warnings via `tryCatch(..., warning = function(w) {...})`. Because `tryCatch` warning handlers are exiting handlers:
1. Control unwinds to the `tryCatch` frame before the handler executes, so the `muffleWarning` restart is no longer in scope (causing `tryInvokeRestart("muffleWarning")` to be a no-op or error with `no 'restart' 'muffleWarning' found`).
2. Returning from the handler abandons `build_and_copy()` instead of allowing subsequent build steps to finish.

By using `withCallingHandlers` for the `warning` branch nested inside `tryCatch` for `error`:
- Warnings are handled in the signalling context, allowing `tryInvokeRestart("muffleWarning")` to muffle duplicate console printing.
- `build_and_copy()` continues executing to completion.
- Warnings are safely appended to `warns` as intact condition objects.
- Downstream warning logging in `scripts/build_pkgdown.R` safely calls `conditionMessage(w)` for each warning condition across packages.
- Reconciled the stale `# TODO this branch doesn't ever seem to run` comment.

## Review Time Estimate
- [x] When possible

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) <!-- #4034 -->

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [x] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.