### PR TITLE
Add fertilization prediction workflow

### DIFF
--- a/modules/data.remote/inst/ccmmf/documentation/projections/05-fertilization_predictions.md
+++ b/modules/data.remote/inst/ccmmf/documentation/projections/05-fertilization_predictions.md
@@ -1,0 +1,962 @@
+# Projection Session - Fertilization
+
+What this session is for: This workflow projects fertilization events from 2024-2045 using the derived historical fertilization product, projected crop identity, projected planting dates, and the MAGiC BAU/NBS scenario tables.
+it starts from the completed historical monitoring product and learns historical fertilization behavior from those derived events.
+
+The projection has two main components:
+
+1. **Synthetic N fertilization**
+   - estimated from historical synthetic fertilizer events;
+   - conditioned on crop identity and county when data are available;
+   - shared between BAU and NBS.
+
+2. **Organic amendment / compost**
+   - statewide adoption and N/C application rates come from the BAU/NBS MAGiC scenario tables;
+   - historical monitoring determines which parcels are more likely to receive compost and how amendment N is partitioned.
+
+Final annual output columns are:
+
+```text
+event_type
+parcel_id
+date
+nh4_n_kg_m2
+org_n_kg_m2
+org_c_kg_m2
+```
+
+The workflow assumes that crop and planting projections have already been completed.
+
+```mermaid
+flowchart LR
+    HIST["Historical fertilization<br/>2018-2023"] --> LOOK["Historical lookups"]
+
+    LOOK --> SYN["Synthetic N<br/>county + crop / crop / class"]
+    LOOK --> ORG["Organic propensity<br/>and N partitioning"]
+
+    CROPS["Crop projections<br/>2024-2045"] --> FUT["Future parcel-year crops"]
+    PLANT["Planting projections<br/>2024-2045"] --> FUT
+
+    FUT --> SYNOUT["Synthetic N events"]
+    SYN --> SYNOUT
+
+    TARGET["BAU / NBS<br/>compost targets"] --> COMPOST["Compost events"]
+    ORG --> COMPOST
+    FUT --> COMPOST
+
+    SYNOUT --> OUT["Annual fertilization parquets"]
+    COMPOST --> OUT
+```
+
+---
+
+## Paths for this session
+
+Most users should only need to change `work_root`:
+
+```r
+work_root = "/path/to/your/folder"
+```
+
+Shared CCMMF data remain under:
+
+```r
+ccmmf_root = "/projectnb/dietzelab/ccmmf"
+```
+
+The expected user directory is:
+
+```text
+<work_root>/
+├── crops_full_counties.csv
+│   OR crop_year_states_cleaned.csv
+│
+├── crop_predictions/
+│   ├── crop_identity_statewide_2024.parquet
+│   ├── ...
+│   └── crop_identity_statewide_2045.parquet
+│
+├── planting_projections/
+│   ├── planting_statewide_2024.parquet
+│   ├── ...
+│   └── planting_statewide_2045.parquet
+│
+├── MAGiC_scenarios_FINAL/
+│   ├── BAU_Targets.csv
+│   └── NBS_Targets.csv
+│
+└── fertilization_projections/
+    ├── BAU_Targets/
+    └── NBS_Targets/
+```
+
+The main shared inputs are:
+
+```text
+/projectnb/dietzelab/ccmmf/
+├── LandIQ-harmonized-v4.1.2/
+│   └── crops_all_years.parq
+├── management/
+│   └── LandIQ_cropCode_lookup_table.csv
+└── usr/akash/event_files/combined/v2.0/_output/
+    └── fertilization.parquet
+```
+
+---
+
+## 1. Setup and required inputs
+
+The script uses:
+
+```r
+hist_years = 2018:2023
+pred_years = 2024:2045
+```
+
+Required R packages are:
+
+```text
+data.table
+arrow
+bit64
+dplyr
+PEcAn.utils
+```
+
+Before running, confirm that the following exist:
+
+```bash
+ls "<work_root>/crop_predictions"
+ls "<work_root>/planting_projections"
+ls "<work_root>/MAGiC_scenarios_FINAL"
+```
+
+There should be one crop prediction and one planting projection for every year from 2024 through 2045.
+
+The script also requires parcel acreage from either:
+
+```text
+<work_root>/crops_full_counties.csv
+```
+
+or:
+
+```text
+<work_root>/crop_year_states_cleaned.csv
+```
+
+If both exist, the first available file is used.
+
+Parcel acreage is estimated as the median positive historical acreage for each parcel. Acreage is important because compost targets are allocated by **acres**, not by number of parcels.
+
+Historical county assignment comes from:
+
+```text
+LandIQ-harmonized-v4.1.2/crops_all_years.parq
+```
+
+For each parcel, the latest county assignment available through 2023 is used.
+
+County names are normalized to avoid future formatting errors. For example, values such as:
+
+```text
+Fresno County
+Fresno
+```
+
+both become:
+
+```text
+fresno
+```
+
+---
+
+## 2. Historical fertilization product
+
+The historical reference product is:
+
+```text
+/projectnb/dietzelab/ccmmf/usr/akash/event_files/combined/v2.0/_output/fertilization.parquet
+```
+
+This is the **derived monitoring product** used as the basis for the future projection.
+
+The script reads the required historical fields and accepts several common aliases:
+
+```text
+parcel_id OR site_id
+crop_code OR code
+event_member_id OR ens_id
+```
+
+Historical event fields are standardized to:
+
+```text
+parcel_id
+date
+crop_code
+event_member_id
+nh4_n_kg_m2
+no3_n_kg_m2
+org_n_kg_m2
+org_c_kg_m2
+```
+
+Historical events are classified as organic if either:
+
+```text
+org_n_kg_m2 > 0
+```
+
+or:
+
+```text
+org_c_kg_m2 > 0
+```
+
+Otherwise they are treated as synthetic fertilization.
+
+During the run, inspect:
+
+```text
+Historical fertilization rows: ...
+Historical county match: ...%
+```
+
+The county-match percentage should be high. A low match usually indicates that the fertilization and LandIQ products are using incompatible parcel identifiers.
+
+---
+
+## 3. Historical fertilization lookups
+
+Three pieces of historical information are carried into the future projection:
+
+1. synthetic N amount;
+2. probability of historical organic amendment use;
+3. partitioning of amendment N between mineral and organic N.
+
+### Synthetic N
+
+Historical synthetic fertilizer can contain both:
+
+```text
+nh4_n_kg_m2
+no3_n_kg_m2
+```
+
+The projection first reconstructs total historical inorganic N:
+
+```r
+inorg_n = nh4_n_kg_m2 + no3_n_kg_m2
+```
+
+For example:
+
+```text
+NH4 = 0.010 kg N/m2
+NO3 = 0.010 kg N/m2
+
+total inorganic N = 0.020 kg N/m2
+```
+
+Historical mean synthetic N is then calculated using the following fallback hierarchy:
+
+```text
+county + crop_code
+        ↓
+crop_code
+        ↓
+crop CLASS
+        ↓
+statewide/global mean
+```
+
+The most specific available value is used for each future crop.
+
+This allows the projection to retain spatial and crop-specific historical behavior without failing when a particular county/crop combination is sparse.
+
+### Organic amendment propensity
+
+Historical records are also used to estimate how often a fertilized crop received an organic amendment.
+
+The same fallback hierarchy is used:
+
+```text
+county + crop
+    ↓
+crop
+    ↓
+class
+    ↓
+global
+```
+
+This probability does **not** determine statewide compost adoption. It only helps determine which future parcels are more likely to receive compost once the scenario target is known.
+
+### Organic N partitioning
+
+For historical organic events, the script calculates:
+
+```r
+pan_frac = nh4 / (nh4 + org_n)
+```
+
+bounded between 0 and 1.
+
+This historical fraction is later used to divide scenario compost N into:
+
+```text
+mineral N
+organic N
+```
+
+using the same county/crop → crop → class → global fallback structure.
+
+---
+
+## 4. Future crop and planting design
+
+Future crop identity comes from:
+
+```text
+<work_root>/crop_predictions/
+```
+
+Each annual crop file must contain:
+
+```text
+parcel_id
+COUNTY
+CLASS
+SUBCLASS
+```
+
+If a `season` column is present, the current workflow requires:
+
+```text
+season = 2
+```
+
+because the current projection represents the dominant annual crop cycle.
+
+`CLASS` and `SUBCLASS` are combined to recreate the LandIQ crop code used in the historical fertilization product.
+
+Examples:
+
+```text
+CLASS = D
+SUBCLASS = 1
+-> D1
+```
+
+and:
+
+```text
+CLASS = D
+SUBCLASS = NA
+-> D
+```
+
+The current fertilization projection excludes:
+
+```text
+X
+I
+```
+
+and missing crop classes.
+
+There must be only one active future crop per:
+
+```text
+parcel_id + year
+```
+
+The script stops if duplicate parcel-year crop predictions are found.
+
+### Planting anchors
+
+Future planting dates come from:
+
+```text
+<work_root>/planting_projections/
+```
+
+with one file per year.
+
+The planting lookup is matched using:
+
+```text
+parcel_id
+year
+crop_code
+```
+
+and provides:
+
+```text
+anchor = projected planting date
+```
+
+Every active future crop must have a valid planting anchor.
+
+The crop lookup table is also used to classify crops broadly as:
+
+```text
+annual
+perennial
+```
+
+for compost timing.
+
+---
+
+## 5. Synthetic N projection
+
+Synthetic N is projected once and shared between BAU and NBS.
+
+For each future parcel-year:
+
+```text
+future crop identity
++
+county
++
+historical synthetic-N lookup
++
+projected planting date
+```
+
+produces one synthetic fertilization event.
+
+The event date is:
+
+```text
+date = planting anchor
+```
+
+The historical total inorganic N amount is stored in:
+
+```text
+nh4_n_kg_m2
+```
+
+while:
+
+```text
+org_n_kg_m2 = 0
+org_c_kg_m2 = 0
+```
+
+The final projection does not carry a separate NO3 column. Historical NH4 + NO3 are combined before projection so that the total historical inorganic N amount is retained.
+
+Synthetic N is currently **not scenario-specific**.
+
+For the same future parcel, crop, and year:
+
+```text
+BAU synthetic N = NBS synthetic N
+```
+
+Scenario differences enter through compost rather than synthetic fertilizer.
+
+---
+
+## 6. BAU/NBS compost projection
+
+The scenario files are:
+
+```text
+BAU_Targets.csv
+NBS_Targets.csv
+```
+
+The script reads these columns:
+
+```text
+Year
+Acres_Total
+Compost acres (CPS 808)
+Compost N (lbs per acre)
+Compost C (lbs per acre)
+```
+
+For each year, it calculates:
+
+```r
+compost_share =
+  total compost acres /
+  total scenario acres
+```
+
+Compost N and C rates are acreage-weighted when multiple scenario rows contribute to the annual target, then converted from:
+
+```text
+lb/acre
+```
+
+to:
+
+```text
+kg/m2
+```
+
+### Selecting parcels
+
+The scenario controls the amount of acreage receiving compost.
+
+Historical organic-amendment propensity controls which parcels are more likely to be selected.
+
+Each future parcel receives a reproducible weighted random ranking:
+
+```r
+rank_key = -log(rand) / p_org
+```
+
+Higher historical organic propensity generally makes a parcel more likely to appear earlier in the ranking.
+
+The script orders parcels by this ranking and adds parcel acreage until the scenario target acreage is reached.
+
+Because parcels cannot be divided, realized compost acreage may be slightly larger than the exact target.
+
+During the run the script reports:
+
+```text
+target=...% | realized=...% | organic parcels=...
+```
+
+### Compost timing and chemistry
+
+Compost timing is relative to the projected planting date.
+
+Current timing ranges are:
+
+| Crop type | Compost timing |
+|---|---:|
+| Annual | 14-180 days before planting |
+| Perennial | 30-210 days before planting |
+
+For each selected parcel:
+
+```r
+date = planting anchor - offset_days
+```
+
+The scenario provides total compost N and C.
+
+Historical `pan_frac` divides compost N into:
+
+```r
+nh4_n_kg_m2 =
+  compost_n_kg_m2 * pan_frac
+
+org_n_kg_m2 =
+  compost_n_kg_m2 * (1 - pan_frac)
+
+org_c_kg_m2 =
+  compost_c_kg_m2
+```
+
+Therefore:
+
+```text
+Scenario table
+    -> statewide compost acreage + total N/C rates
+
+Historical monitoring
+    -> parcel propensity + N partitioning
+```
+
+---
+
+## 7. Run the workflow
+
+After setting:
+
+```r
+work_root
+```
+
+run the script from the PEcAn/CCMMF environment.
+
+For example:
+
+```bash
+Rscript fertilization_projection.R
+```
+
+Replace the filename if the script is stored under another name.
+
+A successful run should look approximately like:
+
+```text
+Historical fertilization rows: ...
+Historical county match: ...%
+
+Shared synthetic events/year average: ...
+
+Processing BAU_Targets
+2024: target=...% | realized=...% | organic parcels=...
+...
+2045: target=...% | realized=...% | organic parcels=...
+Finished BAU_Targets
+
+Processing NBS_Targets
+2024: target=...% | realized=...% | organic parcels=...
+...
+2045: target=...% | realized=...% | organic parcels=...
+Finished NBS_Targets
+
+Fertilization projection complete: ...
+```
+
+The random seed is fixed in the configuration:
+
+```r
+seed = 42L
+```
+
+so the same inputs and seed should reproduce the same parcel allocation and event timing.
+
+---
+
+## 8. Outputs
+
+Outputs are written separately by scenario:
+
+```text
+fertilization_projections/
+├── BAU_Targets/
+│   ├── fertilization_statewide_2024.parquet
+│   ├── ...
+│   └── fertilization_statewide_2045.parquet
+│
+└── NBS_Targets/
+    ├── fertilization_statewide_2024.parquet
+    ├── ...
+    └── fertilization_statewide_2045.parquet
+```
+
+There should be:
+
+```text
+22 BAU files
+22 NBS files
+```
+
+Each annual file contains:
+
+| Column | Description |
+|---|---|
+| `event_type` | `"fertilization"` |
+| `parcel_id` | Harmonized parcel ID stored as int64 |
+| `date` | Projected fertilization event date |
+| `nh4_n_kg_m2` | Mineral N addition |
+| `org_n_kg_m2` | Organic N addition |
+| `org_c_kg_m2` | Organic C addition |
+
+Internal projection variables such as:
+
+```text
+year
+crop_code
+p_org
+pan_frac
+rank_key
+```
+
+are intentionally not written to the final event files.
+
+A parcel-year can have more than one row. For example, the same parcel can receive:
+
+```text
+one synthetic fertilizer event
++
+one compost event
+```
+
+These are separate management events and should remain separate rows.
+
+---
+
+## 9. Quality control
+
+After the workflow finishes, inspect both scenarios before handing the products downstream.
+
+### File count
+
+```r
+length(list.files(
+  file.path(
+    work_root,
+    "fertilization_projections",
+    "BAU_Targets"
+  ),
+  pattern = "\\.parquet$"
+))
+
+length(list.files(
+  file.path(
+    work_root,
+    "fertilization_projections",
+    "NBS_Targets"
+  ),
+  pattern = "\\.parquet$"
+))
+```
+
+Expected:
+
+```text
+22
+22
+```
+
+### Inspect one year
+
+```r
+library(arrow)
+library(dplyr)
+
+x = read_parquet(
+  file.path(
+    work_root,
+    "fertilization_projections",
+    "BAU_Targets",
+    "fertilization_statewide_2030.parquet"
+  )
+)
+
+glimpse(x)
+summary(x)
+```
+
+Check that:
+
+```text
+parcel_id is int64
+dates are valid
+N/C values are non-negative
+required columns contain no NA values
+```
+
+### Synthetic vs compost rows
+
+Synthetic rows should normally have:
+
+```text
+org_n_kg_m2 = 0
+org_c_kg_m2 = 0
+```
+
+Compost rows should contain organic N and/or organic C.
+
+For example:
+
+```r
+x |>
+  mutate(
+    type = if_else(
+      org_n_kg_m2 > 0 | org_c_kg_m2 > 0,
+      "compost",
+      "synthetic"
+    )
+  ) |>
+  count(type)
+```
+
+### BAU/NBS synthetic N
+
+Synthetic N is intended to be shared between scenarios.
+
+For the same year, synthetic-only rows should therefore be identical between BAU and NBS.
+
+### Compost target vs realized share
+
+Watch the console output:
+
+```text
+target = ...
+realized = ...
+```
+
+The realized value should be close to the scenario target.
+
+A small overshoot is expected because acreage is allocated using whole parcels.
+
+A large difference should be investigated.
+
+### Calendar dates
+
+Compost events are assigned before planting.
+
+For crops planted early in a year, a compost event can therefore occur in the previous calendar year even though it belongs to that projected crop year's output file.
+
+This is expected and should not automatically be treated as an error.
+
+---
+
+## 10. Common problems
+
+### `object 'work_root' not found`
+
+Set the required user path at the top of the script:
+
+```r
+work_root = "/path/to/your/folder"
+```
+
+---
+
+### `Could not find crops_full_counties.csv or crop_year_states_cleaned.csv`
+
+The workflow cannot find parcel acreage.
+
+Confirm that one of those files exists directly under:
+
+```text
+<work_root>/
+```
+
+---
+
+### `No historical synthetic fertilizer events found`
+
+No usable synthetic events were found in the historical 2018-2023 product.
+
+Check:
+
+```text
+historical year range
+fertilization product path
+NH4/NO3 columns
+organic-event classification
+```
+
+---
+
+### `No historical organic amendment events found`
+
+The historical product contains no rows with positive organic N or C.
+
+The current compost projection needs historical organic events to estimate:
+
+```text
+organic propensity
+N partitioning
+```
+
+---
+
+### `Future crop predictions contain duplicate parcel-year rows`
+
+The current projection expects one dominant future crop for each parcel-year.
+
+Inspect the crop projection before continuing.
+
+---
+
+### `Future crop parcels are missing valid acreage`
+
+Projected parcel IDs could not be matched to positive historical acreage.
+
+Check parcel-ID consistency between crop projections and the acreage table.
+
+---
+
+### `Active future crop rows missing planting anchors`
+
+The crop projection could not be matched to the planting projection using:
+
+```text
+parcel_id
+year
+crop_code
+```
+
+Check crop-code formatting and whether the planting projection contains the affected parcel/year.
+
+---
+
+### `invalid STATEWIDE annual compost share`
+
+At least one scenario year produced:
+
+```text
+compost acres / total acres
+```
+
+outside the range 0-1.
+
+Inspect the source MAGiC scenario table.
+
+---
+
+### `<scenario> missing target year <year>`
+
+The scenario CSV does not contain all years required by:
+
+```text
+2024:2045
+```
+
+---
+
+### `<scenario> <year> contains incomplete events`
+
+One or more final events contain missing required values.
+
+Trace the affected row back through:
+
+```text
+future crop
+planting anchor
+historical lookup
+scenario target
+```
+
+rather than filling missing values after event generation.
+
+---
+
+## 11. Current assumptions and future extensions
+
+The current fertilization projection is intended to be a transparent MVP rather than a deterministic prediction of management on individual farms.
+
+Important current assumptions are:
+
+- future crop identity is based on the dominant projected crop cycle;
+- synthetic N is estimated from the derived historical fertilization product;
+- historical means are used rather than drawing a new fertilizer-rate ensemble;
+- synthetic N is shared between BAU and NBS;
+- BAU/NBS scenario tables directly control compost adoption and compost N/C rates;
+- historical organic-amendment behavior influences spatial allocation of compost;
+- one reproducible parcel-level realization is generated using a fixed random seed.
+
+The projected parcel assignments should therefore be interpreted as a plausible downscaling ofaggregate future management behavior, not as predictions 
+that individual farms will follow a specific future fertilization schedule.
+
+Future versions could add ensemble realizations for uncertainty in:
+
+```text
+crop identity
+synthetic N amount
+organic amendment probability
+N partitioning
+compost timing
+```
+
+The broader projection principle is:
+
+```text
+derived monitoring product
+        +
+future crop / timing products
+        +
+scenario constraints
+        ↓
+future management events
+```
+
+This keeps the projection workflows consistent with the monitoring products while avoiding duplication of the full upstream Inventory algorithms.

--- a/modules/data.remote/inst/fertilization.R
+++ b/modules/data.remote/inst/fertilization.R
@@ -1,0 +1,411 @@
+## Fertilization projections
+## BAU/NBS targets control statewide annual compost adoption + compost N/C rates.
+## Historical derived fertilization controls synthetic N, crop/county propensity, and organic N partitioning.
+##
+## Final output:
+## event_type, parcel_id, date, nh4_n_kg_m2, org_n_kg_m2, org_c_kg_m2
+
+pacman::p_load(data.table, arrow, bit64, dplyr, PEcAn.utils)
+
+# ---- set up ----
+#REQUIRED: Choose a folder to define work_root, where you want this framework to save intermediate and output files
+#Uncomment the line below and replace the example path.
+#work_root = "/path/to/your/folder"
+
+#Shared Data: Shared project data, most users should not need to change this. 
+ccmmf_root = "/projectnb/dietzelab/ccmmf"
+
+config = list(seed = 42L, hist_years = 2018:2023, pred_years = 2024:2045,
+
+  ##the historicla fertilization info the predictions will build off of             
+  fert_path = file.path(ccmmf_root, "usr", "akash", "event_files", "combined", "v2.0", "_output", "fertilization.parquet"),
+  
+  ##crop, date, and target scenario information used for fertilization predictions
+  landiq_path = file.path(ccmmf_root, "LandIQ-harmonized-v4.1.2", "crops_all_years.parq"),
+  crop_lookup_path = file.path(ccmmf_root, "management", "LandIQ_cropCode_lookup_table.csv"),
+  crop_prediction_dir = file.path(work_root, "crop_predictions"),
+  planting_dir = file.path(work_root, "planting_projections"),
+  scenario_dir = file.path(work_root, "MAGiC_scenarios_FINAL"),
+  
+  ##folder your prediction parquets are going to be stored 
+  output_root = file.path(work_root, "fertilization_projections")
+)
+
+scenario_files = c(BAU_Targets = file.path(config$scenario_dir, "BAU_Targets.csv"),
+  NBS_Targets = file.path(config$scenario_dir, "NBS_Targets.csv"))
+
+assert_cols = function(x, req, label) {
+  miss = setdiff(req, names(x))
+  if (length(miss)) stop(label, " missing: ", paste(miss, collapse = ", "))
+}
+
+safe_mean = function(x) {
+  x = as.numeric(x); x = x[is.finite(x)]
+  if (length(x)) mean(x) else NA_real_
+}
+
+safe_wmean = function(x, w) {
+  x = as.numeric(x); w = as.numeric(w)
+  ok = is.finite(x) & is.finite(w) & w > 0
+  if (any(ok)) weighted.mean(x[ok], w[ok]) else NA_real_
+}
+
+pick_col = function(nms, choices, label, required = TRUE) {
+  hit = intersect(choices, nms)
+  if (length(hit)) return(hit[1])
+  if (required) stop(label, " missing all of: ", paste(choices, collapse = ", "))
+  NA_character_
+}
+
+norm_county = function(x) {
+  x = trimws(tolower(as.character(x)))
+  sub("\\s+county$", "", x)
+}
+
+norm_subclass = function(x) {
+  x = trimws(as.character(x)); x = sub("\\.0+$", "", x)
+  x[x %chin% c("", "NA", "NaN", "NULL")] = NA_character_
+  x
+}
+
+make_code = function(class, subclass) {
+  class = trimws(as.character(class)); subclass = norm_subclass(subclass)
+  fifelse(is.na(subclass), class, paste0(class, subclass))
+}
+
+get_class = function(code) sub("[0-9*].*$", "", as.character(code))
+
+# ---- parcel acreage ----
+acre_candidates = c(file.path(work_root, "crops_full_counties.csv"),
+  file.path(work_root, "crop_year_states_cleaned.csv"))
+
+acre_path = acre_candidates[file.exists(acre_candidates)][1]
+if (is.na(acre_path)) stop("Could not find crops_full_counties.csv or crop_year_states_cleaned.csv.")
+
+acre_hist = fread(acre_path, integer64 = "character")
+acre_col = pick_col(names(acre_hist), c("ACRES", "acres", "Acres"), "Crop history")
+assert_cols(acre_hist, "parcel_id", "Crop history")
+
+acre_hist[, `:=`(parcel_id = as.character(parcel_id), ACRES_TMP = as.numeric(get(acre_col)))]
+parcel_acres = acre_hist[is.finite(ACRES_TMP) & ACRES_TMP > 0,
+                         .(ACRES = median(ACRES_TMP, na.rm = TRUE)), by = parcel_id]
+
+# ---- parcel county set up ----
+landiq = open_dataset(config$landiq_path) |>
+  dplyr::select(parcel_id, COUNTY, year) |>
+  dplyr::filter(year <= 2023) |>
+  dplyr::collect() |>
+  as.data.table()
+
+landiq[, `:=`(parcel_id = as.character(parcel_id), year = as.integer(year))]
+parcel_county = landiq[!is.na(COUNTY), .SD[which.max(year)], by = parcel_id][,
+                                                                             .(parcel_id, county = norm_county(COUNTY))]
+
+if (parcel_county[, anyDuplicated(parcel_id)]) stop("Parcel county lookup contains duplicates.")
+
+# ---- historical combined fertilization ----
+#note: fertilization.parquet is a partitioned dataset directory - Arrow detects event_member_id automatically. 
+#Do not need to edit to specify partitioning.
+
+hist_ds = open_dataset(config$fert_path)
+hist_names = hist_ds$schema$names
+
+id_col = pick_col(hist_names, c("parcel_id", "site_id"), "Historical fertilization")
+crop_col = pick_col(hist_names, c("crop_code", "code"), "Historical fertilization")
+member_col = pick_col(hist_names, c("event_member_id", "ens_id"), "Historical fertilization", FALSE)
+
+wanted = unique(c(id_col, crop_col, member_col, "date", "nh4_n_kg_m2",
+                  "no3_n_kg_m2", "org_n_kg_m2", "org_c_kg_m2"))
+wanted = wanted[!is.na(wanted) & wanted %in% hist_names]
+
+hist = hist_ds |>
+  dplyr::select(dplyr::all_of(wanted)) |>
+  dplyr::collect() |>
+  as.data.table()
+
+setnames(hist, id_col, "parcel_id")
+setnames(hist, crop_col, "crop_code")
+if (!is.na(member_col)) setnames(hist, member_col, "event_member_id")
+if (!"event_member_id" %in% names(hist)) hist[, event_member_id := "ens_001"]
+if (!"no3_n_kg_m2" %in% names(hist)) hist[, no3_n_kg_m2 := 0]
+
+assert_cols(hist, c("parcel_id", "date", "crop_code", "nh4_n_kg_m2",
+                    "org_n_kg_m2", "org_c_kg_m2"), "Historical fertilization")
+
+hist[, `:=`(
+  parcel_id = as.character(parcel_id), date = as.IDate(date),
+  crop_code = trimws(as.character(crop_code)),
+  nh4 = fifelse(is.finite(as.numeric(nh4_n_kg_m2)), as.numeric(nh4_n_kg_m2), 0),
+  no3 = fifelse(is.finite(as.numeric(no3_n_kg_m2)), as.numeric(no3_n_kg_m2), 0),
+  org_n = fifelse(is.finite(as.numeric(org_n_kg_m2)), as.numeric(org_n_kg_m2), 0),
+  org_c = fifelse(is.finite(as.numeric(org_c_kg_m2)), as.numeric(org_c_kg_m2), 0)
+)]
+
+hist[, `:=`(
+  year = as.integer(format(date, "%Y")), CLASS = get_class(crop_code),
+  event_kind = fifelse(org_n > 0 | org_c > 0, "organic", "synthetic")
+)]
+
+hist = hist[year %in% config$hist_years & !is.na(date) & !is.na(crop_code)]
+hist = merge(hist, parcel_county, by = "parcel_id", all.x = TRUE)
+
+message("Historical fertilization rows: ", format(nrow(hist), big.mark = ","))
+message("Historical county match: ", round(100 * mean(!is.na(hist$county)), 1), "%")
+
+# ---- synthetic N lookups ----
+# Final output drops NO3, so preserve total historical inorganic N as NH4.
+
+syn = hist[event_kind == "synthetic"]
+syn[, inorg_n := nh4 + no3]
+if (!nrow(syn)) stop("No historical synthetic fertilizer events found.")
+
+syn_county = syn[!is.na(county), .(syn_n = safe_mean(inorg_n)), by = .(county, crop_code)]
+syn_crop = syn[, .(syn2_n = safe_mean(inorg_n)), by = crop_code]
+syn_class = syn[, .(syn3_n = safe_mean(inorg_n)), by = CLASS]
+syn_global = safe_mean(syn$inorg_n)
+
+# ---- historical organic properties ----
+
+org = hist[event_kind == "organic"]
+if (!nrow(org)) stop("No historical organic amendment events found.")
+
+org[, pan_frac := fifelse(nh4 + org_n > 0, nh4 / (nh4 + org_n), NA_real_)]
+org[, pan_frac := pmin(1, pmax(0, pan_frac))]
+
+pan_county = org[!is.na(county), .(pan1 = safe_mean(pan_frac)), by = .(county, crop_code)]
+pan_crop = org[, .(pan2 = safe_mean(pan_frac)), by = crop_code]
+pan_class = org[, .(pan3 = safe_mean(pan_frac)), by = CLASS]
+pan_global = safe_mean(org$pan_frac)
+if (!is.finite(pan_global)) pan_global = 0
+
+syn_base = unique(syn[, .(parcel_id, year, event_member_id, county, crop_code, CLASS)])
+org_keys = unique(org[, .(parcel_id, year, event_member_id)])
+syn_base[, has_org := FALSE]
+syn_base[org_keys, has_org := TRUE, on = .(parcel_id, year, event_member_id)]
+
+prop_county = syn_base[!is.na(county), .(p1 = mean(has_org)), by = .(county, crop_code)]
+prop_crop = syn_base[, .(p2 = mean(has_org)), by = crop_code]
+prop_class = syn_base[, .(p3 = mean(has_org)), by = CLASS]
+p_global = mean(syn_base$has_org)
+
+# ---- future crops ----
+
+read_future_crop = function(yy) {
+  path = file.path(config$crop_prediction_dir, paste0("crop_identity_statewide_", yy, ".parquet"))
+  if (!file.exists(path)) stop("Missing: ", path)
+  
+  x = as.data.table(read_parquet(path))
+  assert_cols(x, c("parcel_id", "COUNTY", "CLASS", "SUBCLASS"), basename(path))
+  
+  if ("season" %in% names(x)) {
+    x[, season := as.integer(season)]
+    if (x[!is.na(season) & season != 2L, .N]) stop(path, " contains non-season-2 rows.")
+  }
+  
+  x[, .(
+    parcel_id = as.character(parcel_id),
+    year = as.integer(yy),
+    county = norm_county(COUNTY),
+    CLASS = trimws(as.character(CLASS)),
+    SUBCLASS = norm_subclass(SUBCLASS)
+  )]
+}
+
+future = rbindlist(lapply(config$pred_years, read_future_crop), fill = TRUE)
+future[, crop_code := make_code(CLASS, SUBCLASS)]
+future = future[!CLASS %chin% c("X", "I") & !is.na(CLASS)]
+
+if (future[, .N, by = .(parcel_id, year)][N > 1, .N])
+  stop("Future crop predictions contain duplicate parcel-year rows.")
+
+future = merge(future, parcel_acres, by = "parcel_id", all.x = TRUE)
+if (future[is.na(ACRES) | ACRES <= 0, .N])
+  stop("Future crop parcels are missing valid acreage.")
+
+# ---- future planting anchors ----
+
+read_future_plant = function(yy) {
+  path = file.path(config$planting_dir, paste0("planting_statewide_", yy, ".parquet"))
+  if (!file.exists(path)) stop("Missing: ", path)
+  
+  x = as.data.table(read_parquet(path))
+  
+  id_col = pick_col(names(x), c("parcel_id", "site_id"), basename(path))
+  code_col = pick_col(names(x), c("crop_code", "code", "CLASS_SUBCLASS"), basename(path))
+  date_col = pick_col(names(x), c("date", "planting_date"), basename(path))
+  
+  data.table(
+    parcel_id = as.character(x[[id_col]]),
+    year = as.integer(yy),
+    crop_code = trimws(as.character(x[[code_col]])),
+    anchor = as.IDate(x[[date_col]])
+  )
+}
+
+plant = rbindlist(lapply(config$pred_years, read_future_plant), fill = TRUE)
+plant = plant[!is.na(anchor), .(anchor = min(anchor)), by = .(parcel_id, year, crop_code)]
+
+future = merge(future, plant, by = c("parcel_id", "year", "crop_code"), all.x = TRUE)
+if (future[is.na(anchor), .N]) stop("Active future crop rows missing planting anchors.")
+
+# ---- PFT family for compost timing ----
+
+crop_lookup = fread(config$crop_lookup_path)
+pft_col = pick_col(names(crop_lookup), c("PFT", "landiq_PFT"), "Crop lookup")
+assert_cols(crop_lookup, c("CLASS", "SUBCLASS"), "Crop lookup")
+
+crop_lookup[, crop_code := make_code(CLASS, SUBCLASS)]
+pft_lookup = unique(crop_lookup[, .(
+  crop_code,
+  pft_family = fifelse(tolower(as.character(get(pft_col))) == "woody", "perennial", "annual")
+)], by = "crop_code")
+
+future = merge(future, pft_lookup, by = "crop_code", all.x = TRUE)
+future[is.na(pft_family), pft_family := "annual"]
+
+# ---- synthetic future events ----
+
+synthetic = copy(future)
+synthetic = merge(synthetic, syn_county, by = c("county", "crop_code"), all.x = TRUE)
+synthetic = merge(synthetic, syn_crop, by = "crop_code", all.x = TRUE)
+synthetic = merge(synthetic, syn_class, by = "CLASS", all.x = TRUE)
+synthetic[, nh4_n_kg_m2 := fcoalesce(syn_n, syn2_n, syn3_n, syn_global)]
+
+synthetic = synthetic[is.finite(nh4_n_kg_m2) & nh4_n_kg_m2 > 0,
+                      .(parcel_id, year, date = anchor, nh4_n_kg_m2, org_n_kg_m2 = 0, org_c_kg_m2 = 0)]
+
+message("Shared synthetic events/year average: ",
+        round(nrow(synthetic) / length(config$pred_years)))
+
+# ---- organic parcel propensity ----
+
+organic_base = copy(future)
+organic_base = merge(organic_base, prop_county, by = c("county", "crop_code"), all.x = TRUE)
+organic_base = merge(organic_base, prop_crop, by = "crop_code", all.x = TRUE)
+organic_base = merge(organic_base, prop_class, by = "CLASS", all.x = TRUE)
+organic_base = merge(organic_base, pan_county, by = c("county", "crop_code"), all.x = TRUE)
+organic_base = merge(organic_base, pan_crop, by = "crop_code", all.x = TRUE)
+organic_base = merge(organic_base, pan_class, by = "CLASS", all.x = TRUE)
+
+organic_base[, `:=`(
+  p_org = pmax(fcoalesce(p1, p2, p3, p_global), 1e-6),
+  pan_frac = pmin(1, pmax(0, fcoalesce(pan1, pan2, pan3, pan_global)))
+)]
+
+organic_base[, rand := {
+  set.seed(config$seed + .BY$year)
+  runif(.N)
+}, by = year]
+
+organic_base[, rank_key := -log(pmax(rand, 1e-12)) / p_org]
+
+# ---- statewide scenario targets ----
+
+read_targets = function(path) {
+  x = fread(path)
+  
+  assert_cols(x, c("Year", "Acres_Total", "Compost acres (CPS 808)",
+                   "Compost N (lbs per acre)", "Compost C (lbs per acre)"), basename(path))
+  
+  x[, `:=`(
+    Year = as.integer(Year),
+    Acres_Total = as.numeric(Acres_Total),
+    compost_acres = as.numeric(`Compost acres (CPS 808)`),
+    compost_n = as.numeric(`Compost N (lbs per acre)`),
+    compost_c = as.numeric(`Compost C (lbs per acre)`)
+  )]
+  
+  out = x[Year %in% config$pred_years, .(
+    total_acres = sum(Acres_Total, na.rm = TRUE),
+    compost_acres = sum(compost_acres, na.rm = TRUE),
+    compost_n_lb_ac = safe_wmean(compost_n, compost_acres),
+    compost_c_lb_ac = safe_wmean(compost_c, compost_acres)
+  ), by = .(year = Year)]
+  
+  out[, compost_share := compost_acres / total_acres]
+  
+  if (out[!is.finite(compost_share) | compost_share < 0 | compost_share > 1, .N])
+    stop(basename(path), " has invalid STATEWIDE annual compost share.")
+  
+  out[, `:=`(
+    compost_n_kg_m2 = PEcAn.utils::ud_convert(compost_n_lb_ac, "lb/acre", "kg/m^2"),
+    compost_c_kg_m2 = PEcAn.utils::ud_convert(compost_c_lb_ac, "lb/acre", "kg/m^2")
+  )]
+  
+  out[]
+}
+
+# ---- scenario events + prediction outputs ----
+
+for (scen in names(scenario_files)) {
+  message("\nProcessing ", scen)
+  targets = read_targets(scenario_files[[scen]])
+  organic_list = list()
+  
+  for (yy in config$pred_years) {
+    d = copy(organic_base[year == yy])
+    t = targets[year == yy]
+    if (!nrow(t)) stop(scen, " missing target year ", yy)
+    
+    target_acres = t$compost_share * sum(d$ACRES, na.rm = TRUE)
+    
+    setorder(d, rank_key)
+    d[, prev_acres := shift(cumsum(ACRES), fill = 0)]
+    d = d[prev_acres < target_acres]
+    
+    set.seed(config$seed + yy + match(scen, names(scenario_files)) * 1000L)
+    
+    d[, offset_days := fifelse(
+      pft_family == "perennial",
+      sample(30:210, .N, replace = TRUE),
+      sample(14:180, .N, replace = TRUE)
+    )]
+    
+    d[, `:=`(
+      date = anchor - offset_days,
+      nh4_n_kg_m2 = t$compost_n_kg_m2 * pan_frac,
+      org_n_kg_m2 = t$compost_n_kg_m2 * (1 - pan_frac),
+      org_c_kg_m2 = t$compost_c_kg_m2
+    )]
+    
+    organic_list[[as.character(yy)]] = d[, .(
+      parcel_id, year, date,
+      nh4_n_kg_m2, org_n_kg_m2, org_c_kg_m2
+    )]
+    
+    realized = sum(d$ACRES, na.rm = TRUE) / sum(organic_base[year == yy]$ACRES, na.rm = TRUE)
+    
+    message(yy, ": target=", round(100 * t$compost_share, 2),
+            "% | realized=", round(100 * realized, 2),
+            "% | organic parcels=", format(nrow(d), big.mark = ","))
+  }
+  
+  organic = rbindlist(organic_list, fill = TRUE)
+  fert = rbindlist(list(synthetic, organic), fill = TRUE)
+  fert[, parcel_id := bit64::as.integer64(parcel_id)]
+  setorder(fert, year, parcel_id, date)
+  
+  out_dir = file.path(config$output_root, scen)
+  dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
+  
+  for (yy in config$pred_years) {
+    out = fert[year == yy, .(
+      event_type = "fertilization",
+      parcel_id = bit64::as.integer64(parcel_id),
+      date = as.Date(date),
+      nh4_n_kg_m2 = as.numeric(nh4_n_kg_m2),
+      org_n_kg_m2 = as.numeric(org_n_kg_m2),
+      org_c_kg_m2 = as.numeric(org_c_kg_m2)
+    )]
+    
+    if (out[!complete.cases(out), .N]) stop(scen, " ", yy, " contains incomplete events.")
+    
+    write_parquet(out,
+                  file.path(out_dir, paste0("fertilization_statewide_", yy, ".parquet")),
+                  compression = "zstd")
+  }
+  
+  message("Finished ", scen)
+}
+
+message("\nFertilization projection complete: ", config$output_root)


### PR DESCRIPTION
Adds the statewide fertilization projection workflow for BAU and NBS targets.
PR includes:
- `fertilization.R` for generating annual fertilization projections
- `05-fertilization_predictions.md` with setup instructions, workflow documentation, assumptions, and output structure

## Files added
- `modules/data.remote/inst/fertilization.R`
- `modules/data.remote/inst/ccmmf/documentation/projections/05-fertilization_predictions.md`