### PR TITLE
Add irrigation projection workflow

### DIFF
--- a/modules/data.remote/inst/ccmmf/documentation/projections/06-irrigation_predictions.md
+++ b/modules/data.remote/inst/ccmmf/documentation/projections/06-irrigation_predictions.md
@@ -1,0 +1,601 @@
+ # Irrigation Projection
+
+This workflow projects irrigation events for California agricultural parcels from 2024–2045.
+
+The workflow has two main steps:
+
+1. Convert the downloaded Cal-Adapt climate design-point data into county-level daily climate.
+2. Combine projected crop identity, planting date, harvest date, crop water requirements, soil water-holding capacity, and daily climate to estimate irrigation events for each parcel.
+
+The final annual irrigation files contain:
+
+```text
+event_type
+parcel_id
+date
+amount_mm
+```
+
+---
+
+# 1. User setup
+
+The user should first define a working directory.
+
+```r
+work_root = "/path/to/your/folder"
+```
+
+This directory is used for intermediate products and final irrigation outputs.
+
+Shared project data are read from:
+
+```r
+ccmmf_root = "/projectnb/dietzelab/ccmmf"
+```
+
+Most users should not need to modify `ccmmf_root`.
+
+The irrigation workflow expects the following upstream projection products inside `work_root`:
+
+```text
+<work_root>/
+├── crop_predictions/
+├── planting_projections/
+├── harvest_projections/
+└── caladapt_county_daily_climate.csv
+```
+
+The irrigation script is currently configured to project:
+
+```text
+2024–2045
+```
+
+and uses historical phenology information from:
+
+```text
+2018–2023
+```
+
+The current climate selection is:
+
+```text
+GCM = CESM2
+SSP = ssp245
+```
+
+---
+
+# 2. Prepare county-level Cal-Adapt climate
+
+The Cal-Adapt climate data needed for irrigation have already been downloaded for 2025–2045.
+
+The raw files are stored under:
+
+```text
+/projectnb/dietzelab/ccmmf/ensemble/CalAdapt_runs/data_raw/CalAdaptWRF
+```
+
+The downloaded data represent approximately 198 Cal-Adapt spatial design points across California.
+
+The goal of this preprocessing step is to convert those design-point climate data into one daily climate series for each county.
+
+The spatial assumption used here is All agricultural parcels within the same county experience the same daily climate.
+
+This is a deliberate spatial simplification. Parcel-level differences in crop identity, phenology, soil properties, and water requirements are retained later in the irrigation calculation, while meteorological forcing is summarized at the county level.
+
+---
+
+## 2.1 Assign climate design points to counties
+
+Each Cal-Adapt design-point folder contains NetCDF files with latitude and longitude coordinates.
+
+The script reads one NetCDF file from each folder and constructs a site index containing:
+
+```text
+site_hash
+latitude
+longitude
+```
+
+The expected number of unique design points is approximately:
+
+```text
+198
+```
+
+California county boundaries are retrieved using `tigris`.
+
+Each design point is spatially assigned to the county containing it.
+
+For counties that do not contain a Cal-Adapt design point, the workflow:
+
+1. projects the county and design-point geometries to California Albers coordinates;
+2. identifies a representative point within the county;
+3. finds the nearest available Cal-Adapt design point;
+4. assigns that design point to the county.
+
+This produces:
+
+```text
+caladapt_county_site_lookup.csv
+```
+
+with the basic mapping:
+
+```text
+County
+site_hash
+```
+
+Every county should have at least one assigned climate site before continuing.
+
+---
+
+## 2.2 Convert hourly NetCDF data to daily climate
+
+Each downloaded NetCDF file is processed independently.
+
+The helper functions:
+
+```text
+specific_humidity_to_ea()
+calculate_net_radiation()
+parse_nc_time()
+calculate_daily_et0()
+process_nc_file()
+```
+
+convert the raw climate variables into daily meteorological values.
+
+The NetCDF files provide variables including:
+
+```text
+air temperature
+wind speed
+precipitation
+specific humidity
+shortwave radiation
+longwave radiation
+air pressure
+```
+
+Temperature is converted from Kelvin to Celsius and precipitation flux is converted to millimeters.
+
+Daily reference evapotranspiration (`ET0_mm`) is then calculated using the FAO-56 Penman-Monteith method.
+
+The resulting daily design-point data include variables such as:
+
+```text
+date
+site_hash
+model
+scenario
+ET0_mm
+precip_mm
+mean_temp_c
+T_min
+T_max
+```
+
+NetCDF processing is parallelized across available CPU cores because this is one of the more computationally expensive preprocessing steps.
+
+---
+
+## 2.3 Collapse design-point climate to county climate
+
+The daily design-point climate is joined to the county-site lookup using `site_hash`.
+
+The data are then grouped by:
+
+```text
+County
+date
+model
+scenario
+```
+
+If multiple Cal-Adapt design points contribute to the same county, the daily values are averaged across those sites.
+
+The county climate product includes:
+
+```text
+ET0_mm
+precip_mm
+mean_temp_c
+min_temp_c
+max_temp_c
+n_climate_sites
+Year
+Week
+GCM
+SSP
+```
+
+The final climate input is written to:
+
+```text
+<work_root>/caladapt_county_daily_climate.csv
+```
+
+This file is then used directly by the irrigation projection.
+
+---
+
+# 3. Load future crop and phenology projections
+
+The irrigation workflow combines three upstream projection products for every year from 2025–2045:
+
+```text
+crop identity
+planting date
+harvest date
+```
+
+The expected files are:
+
+```text
+<work_root>/crop_predictions/crop_identity_statewide_<YEAR>.parquet
+<work_root>/planting_projections/planting_statewide_<YEAR>.parquet
+<work_root>/harvest_projections/harvest_statewide_<YEAR>.parquet
+```
+
+Each active parcel must have:
+
+```text
+parcel_id
+crop identity
+planting date
+harvest date
+```
+
+The script checks that there is only one record per parcel and year and stops if active crops are missing planting or harvest dates.
+
+LandIQ classes representing non-active agricultural land are excluded before irrigation is modeled.
+
+---
+
+# 4. Estimate crop peak date
+
+The irrigation water-demand calculation also requires a crop peak date.
+
+Rather than projecting peak date independently, the workflow estimates the historical relative position of the peak within the growing season.
+
+For each historical observation:
+
+```text
+peak fraction =
+(peak date - planting date) /
+(harvest date - planting date)
+```
+
+Historical peak fractions are calculated from the matched LandIQ/MSLSP phenology records for 2018–2023.
+
+For a future crop, the workflow attempts to estimate the peak fraction using increasingly broad historical groups:
+
+```text
+county + crop code
+        ↓
+county + crop class
+        ↓
+crop code
+        ↓
+crop class
+        ↓
+statewide/global mean
+```
+
+The projected peak date is then:
+
+```text
+planting date +
+peak fraction × growing-season length
+```
+
+The workflow checks that projected peak dates remain between planting and harvest. :contentReference[oaicite:1]{index=1}
+
+---
+
+# 5. Assign crop water parameters
+
+Projected LandIQ crop classes and subclasses are mapped to crop names used by `PEcAn.data.land`.
+
+The workflow uses:
+
+```r
+PEcAn.data.land::bism_kc_by_crop
+```
+
+for crop mappings and:
+
+```r
+PEcAn.data.land::crop_whc
+```
+
+for crop-specific soil-water parameters.
+
+For non-rice crops, the important parameters include:
+
+```text
+rooting_depth_m
+whc_min_frac
+```
+
+`whc_min_frac` controls the soil-water depletion threshold used to determine when irrigation should occur.
+
+A small set of LandIQ classes that do not have an exact BISM mapping are assigned predefined proxy crops.
+
+Rows without a usable crop mapping, rooting depth, or water-depletion parameter are identified before irrigation is modeled. :contentReference[oaicite:2]{index=2}
+
+---
+
+# 6. Calculate and cache soil available water capacity
+
+Non-rice irrigation also depends on the amount of water that can be stored in the soil within the crop rooting zone.
+
+Available water capacity is calculated using shared SSURGO soil information.
+
+The relevant SSURGO inputs are:
+
+```text
+parcel-to-soil-map-unit weights
+soil components
+soil horizons
+available water capacity by horizon
+```
+
+For each unique combination of:
+
+```text
+parcel_id + rooting_depth_m
+```
+
+the workflow calculates effective root-zone water-holding capacity (`whc_mm`).
+
+Because this calculation is relatively expensive, results are cached by county under:
+
+```text
+<work_root>/irrigation_awc_cache/
+```
+
+For example:
+
+```text
+irrigation_awc_cache/
+├── Fresno_awc.parquet
+├── Kern_awc.parquet
+├── Tulare_awc.parquet
+└── ...
+```
+
+On the first run, the required AWC values are calculated from SSURGO.
+
+On later runs:
+
+```text
+already cached parcel/root depth
+    → reuse existing AWC
+
+new parcel/root depth
+    → calculate from SSURGO and add to cache
+```
+
+This prevents the full soil calculation from being repeated every time the irrigation workflow is run. :contentReference[oaicite:3]{index=3}
+
+Rice does not use this soil AWC calculation because it is modeled using a separate flooded-field water balance.
+
+---
+
+# 7. Select future climate
+
+The county climate CSV is filtered to the selected GCM and SSP combination.
+
+The current configuration uses:
+
+```text
+CESM2
+ssp245
+```
+
+The actual Cal-Adapt climate must cover the full 2025–2045 projection period.
+
+Some crop seasons can extend across the boundary of the available climate period. For example, a crop assigned to projection year 2025 may have a planting date in late 2024.
+
+For these boundary cases only, the workflow uses the nearest available boundary year as a climate proxy.
+
+Conceptually:
+
+```text
+required 2024 climate → use 2025 daily climate
+required 2046 climate → use 2045 daily climate
+```
+
+The actual 2025–2045 projection years are always expected to use the downloaded Cal-Adapt climate data. :contentReference[oaicite:4]{index=4}
+
+---
+
+# 8. Calculate daily crop water demand
+
+For each crop season, the model generates a daily sequence from:
+
+```text
+planting date → harvest date
+```
+
+Canopy cover is approximated as increasing from planting to the projected crop peak and decreasing from peak to harvest.
+
+Reference evapotranspiration is converted to crop evapotranspiration using:
+
+```r
+PEcAn.data.land::eto_to_etc_bism()
+```
+
+Conceptually:
+
+```text
+Cal-Adapt ET0
+      +
+crop identity
+      +
+canopy development
+      ↓
+crop ET
+```
+
+Daily crop ET, precipitation, soil water storage, and crop-specific depletion thresholds are then used to estimate irrigation.
+
+---
+
+# 9. Non-rice water balance
+
+For non-rice crops, irrigation is estimated using:
+
+```r
+PEcAn.data.land::calc_water_balance()
+```
+
+The model uses:
+
+```text
+daily crop ET
+daily precipitation
+root-zone water-holding capacity
+crop-specific minimum soil-water fraction
+maximum irrigation amount
+```
+
+The current maximum irrigation event is:
+
+```text
+150 mm
+```
+
+An irrigation event is recorded whenever the modeled daily irrigation amount is greater than zero.
+
+---
+
+# 10. Rice water balance
+
+Rice is modeled separately because flooded rice fields cannot be represented appropriately with the same soil-water bucket model used for other crops.
+
+Rice uses:
+
+```r
+PEcAn.data.land::calc_water_balance_rice()
+```
+
+with the current configuration:
+
+```text
+target flood depth = 125 mm
+minimum flood depth = 62.5 mm
+maximum flood depth = 175 mm
+seepage = 2.5 mm/day
+```
+
+The rice model generates irrigation events needed to maintain the flooded-field water level.
+
+The script therefore internally tracks two irrigation methods:
+
+```text
+canopy    non-rice crops
+flood     rice
+```
+
+The method variable is used during processing but is not required in the final projection product. :contentReference[oaicite:5]{index=5}
+
+---
+
+# 11. Parallel county prediction
+
+The statewide irrigation calculation is divided by county.
+
+Each county is processed independently, allowing the workflow to run several counties in parallel.
+
+Temporary county-level results are stored under:
+
+```text
+<work_root>/irrigation_projections/_county_tmp/
+```
+
+This also allows interrupted runs to resume without recalculating counties that have already completed.
+
+Large counties are processed first and jobs are load-balanced across the available workers. :contentReference[oaicite:6]{index=6}
+
+If the irrigation methodology or code changes, the temporary county directory should be deleted before rerunning so that old county results are not reused.
+
+---
+
+# 12. Final irrigation outputs
+
+After all counties have completed, the temporary county outputs are combined into annual statewide irrigation files.
+
+One parquet is written for each year:
+
+```text
+<work_root>/irrigation_projections/irrigation_statewide_2025.parquet
+<work_root>/irrigation_projections/irrigation_statewide_2026.parquet
+...
+<work_root>/irrigation_projections/irrigation_statewide_2045.parquet
+```
+
+Each irrigation event contains:
+
+```text
+event_type
+parcel_id
+date
+amount_mm
+```
+
+where:
+
+```text
+event_type = "irrigation"
+parcel_id  = LandIQ parcel identifier
+date       = projected irrigation date
+amount_mm  = irrigation applied on that date, in millimeters
+```
+
+The workflow checks that final irrigation amounts are finite, positive, and complete before writing each yearly parquet. :contentReference[oaicite:7]{index=7}
+
+---
+
+# Workflow summary
+
+The complete irrigation projection can be summarized as:
+
+```text
+Projected crop identity
+Projected planting date
+Projected harvest date
+          │
+          ├── historical phenology → projected peak date
+          │
+          ├── crop mapping → crop water parameters
+          │
+          ├── SSURGO → parcel/root-depth AWC
+          │
+Cal-Adapt climate
+          │
+          └── 198 design points
+                  ↓
+              county climate
+                  │
+                  ↓
+        daily crop evapotranspiration
+                  │
+                  ↓
+          daily water balance
+            /             \
+       non-rice           rice
+       soil bucket      flood balance
+            \             /
+                  ↓
+          irrigation events
+                  ↓
+      annual statewide parquets
+```
+
+The major simplifying spatial assumption is that climate is shared among all parcels within a county. Crop identity, planting and harvest timing, projected peak timing, soil water capacity, rooting depth, and crop water parameters remain parcel-specific.

--- a/modules/data.remote/inst/get_climate_data.R
+++ b/modules/data.remote/inst/get_climate_data.R
@@ -1,0 +1,240 @@
+#using the 198 design points that have Cal-Adapt 2025-45 data already downloaded, and collapsing them into
+#county-level daily climate - this uses the spatial assumption that every parcel in a county experiences the same daily climate
+
+pacman::p_load(ncdf4, sf, dplyr, fs, purrr, furrr, future,
+               lubridate, tigris, FAO56, parallelly)
+
+#REQUIRED: Choose a folder where intermediate products will be saved
+#work_root = "/path/to/your/folder"
+
+#Shared Data: Shared project data, most users should not need to change this.
+ccmmf_root = "/projectnb/dietzelab/ccmmf"
+
+##where you want the final output to be saved to
+output_dir = work_root
+
+##the Cal-Adapt 2025-45 info for irrigation estimates are already downloaded
+base_dir = file.path(ccmmf_root, "ensemble", "CalAdapt_runs", "data_raw", "CalAdaptWRF")
+
+dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+
+# ---- helpers ----
+specific_humidity_to_ea = function(q, pressure_pa) {
+  P_kpa = pressure_pa / 1000
+  (q * P_kpa) / (0.622 + 0.378 * q)
+}
+
+calculate_net_radiation = function(sw_rad, lw_rad, temp_c, albedo = 0.23, emissivity = 0.98) {
+  sigma = 5.67e-8
+  Rns = (1 - albedo) * sw_rad
+  Rnl = lw_rad - emissivity * sigma * (temp_c + 273.15)^4
+  (Rns + Rnl) * 0.0036
+}
+
+parse_nc_time = function(time_steps, time_units, year_val) {
+  origin_string = sub("^.*since\\s+", "", time_units)
+  origin_time = lubridate::ymd_hms(origin_string, tz = "UTC", quiet = TRUE)
+  
+  if (is.na(origin_time)) {
+    origin_time = lubridate::ymd_hms(sprintf("%d-01-01 00:00:00", year_val), tz = "UTC")
+  }
+  
+  if (grepl("^seconds", time_units, ignore.case = TRUE)) {
+    origin_time + lubridate::seconds(time_steps)
+  } else if (grepl("^hours", time_units, ignore.case = TRUE)) {
+    origin_time + lubridate::hours(time_steps)
+  } else if (grepl("^days", time_units, ignore.case = TRUE)) {
+    origin_time + lubridate::days(time_steps)
+  } else {
+    stop("Unknown NetCDF time units: ", time_units)
+  }
+}
+
+calculate_daily_et0 = function(df_hourly, wind_height_m = 10) {
+  df_daily = df_hourly |>
+    dplyr::mutate(
+      ea_kpa = specific_humidity_to_ea(.data$spec_hum, .data$pressure),
+      Rn_MJ = calculate_net_radiation(.data$sw_rad, .data$lw_rad, .data$temp_c),
+      date = as.Date(.data$datetime)
+    ) |>
+    dplyr::group_by(.data$date) |>
+    dplyr::summarise(
+      T_min = min(.data$temp_c, na.rm = TRUE),
+      T_max = max(.data$temp_c, na.rm = TRUE),
+      mean_temp_c = mean(.data$temp_c, na.rm = TRUE),
+      R_n = sum(.data$Rn_MJ, na.rm = TRUE),
+      e_a = mean(.data$ea_kpa, na.rm = TRUE),
+      P_kpa = mean(.data$pressure / 1000, na.rm = TRUE),
+      wind = mean(.data$wind_speed, na.rm = TRUE),
+      precip_mm = sum(.data$precip_mm, na.rm = TRUE),
+      .groups = "drop"
+    )
+  
+  df_daily |>
+    dplyr::rowwise() |>
+    dplyr::mutate(
+      ET0_mm = {
+        gamma = 0.000665 * .data$P_kpa
+        if (wind_height_m == 2) {
+          FAO56::ETo_FPM(
+            R_n = .data$R_n, G = 0, gamma = gamma, u_2 = .data$wind,
+            e_a = .data$e_a, T_min = .data$T_min, T_max = .data$T_max
+          )
+        } else {
+          FAO56::ETo_FPM(
+            R_n = .data$R_n, G = 0, gamma = gamma, u_z = .data$wind,
+            z = wind_height_m, e_a = .data$e_a, T_min = .data$T_min, T_max = .data$T_max
+          )
+        }
+      }
+    ) |>
+    dplyr::ungroup()
+}
+
+process_nc_file = function(nc_path, wind_height_m = 10) {
+  nc = tryCatch(
+    ncdf4::nc_open(nc_path),
+    error = function(e) {
+      warning("Could not open: ", nc_path)
+      NULL
+    }
+  )
+  
+  if (is.null(nc)) return(NULL)
+  on.exit(ncdf4::nc_close(nc))
+  
+  file_name = basename(nc_path)
+  site_hash = basename(dirname(nc_path))
+  parts = unlist(strsplit(gsub("\\.nc$", "", file_name), "\\."))
+  
+  if (length(parts) < 3) {
+    warning("Unexpected filename: ", file_name)
+    return(NULL)
+  }
+  
+  model_name = parts[1]
+  scenario_value = parts[2]
+  year_val = as.integer(parts[3])
+  
+  time_steps = as.numeric(ncdf4::ncvar_get(nc, "time"))
+  temp_k = as.numeric(ncdf4::ncvar_get(nc, "air_temperature"))
+  wind_speed = as.numeric(ncdf4::ncvar_get(nc, "wind_speed"))
+  precip = as.numeric(ncdf4::ncvar_get(nc, "precipitation_flux"))
+  spec_hum = as.numeric(ncdf4::ncvar_get(nc, "specific_humidity"))
+  lw_rad = as.numeric(ncdf4::ncvar_get(nc, "surface_downwelling_longwave_flux_in_air"))
+  sw_rad = as.numeric(ncdf4::ncvar_get(nc, "surface_downwelling_shortwave_flux_in_air"))
+  pressure = as.numeric(ncdf4::ncvar_get(nc, "air_pressure"))
+  time_units = ncdf4::ncatt_get(nc, "time", "units")$value
+  datetime = parse_nc_time(time_steps, time_units, year_val)
+  
+  df_hourly = tibble::tibble(
+    datetime = datetime, temp_c = temp_k - 273.15, wind_speed = wind_speed,
+    sw_rad = sw_rad, lw_rad = lw_rad, spec_hum = spec_hum,
+    pressure = pressure, precip_mm = precip * 3600
+  )
+  
+  calculate_daily_et0(df_hourly, wind_height_m) |>
+    dplyr::mutate(
+      site_hash = .env$site_hash,
+      model = .env$model_name,
+      scenario = .env$scenario_value,
+      year = lubridate::year(.data$date),
+      day_of_year = lubridate::yday(.data$date)
+    ) |>
+    dplyr::select(
+      "date", "site_hash", "model", "scenario", "ET0_mm", "precip_mm",
+      "mean_temp_c", "T_min", "T_max", dplyr::everything()
+    )
+}
+
+# ---------- geo assignments ----------
+#convert the Cal-Adapt lat/lon locations into county assignments, attach the county to the climate records,
+#and create a lookup table for the design points
+
+site_dirs = dir_ls(base_dir, type = "directory")
+
+##site_index will store each site_hash and their lat/lon info
+site_index = map_dfr(site_dirs, function(dir_path) {
+  nc_files = dir_ls(dir_path, glob = "*.nc")
+  if (!length(nc_files)) return(NULL)
+  
+  nc = nc_open(nc_files[1])
+  lat = as.numeric(ncvar_get(nc, "latitude"))
+  lon = as.numeric(ncvar_get(nc, "longitude"))
+  nc_close(nc)
+  
+  tibble(site_hash = basename(dir_path), lat = lat, lon = lon)
+})
+
+##just for a check, should say 198
+cat(sprintf("Indexed %d unique Cal-Adapt design-point sites.\n", nrow(site_index)))
+
+##get CA county info
+ca_counties = counties(state = "CA", cb = TRUE, class = "sf") |> select(County = NAME)
+
+##sites_sf now holds each site_hash's lat/lon and point geometry
+sites_sf = st_as_sf(site_index, coords = c("lon", "lat"), crs = 4326, remove = FALSE)
+
+#double check both layers use same CRS
+ca_counties = st_transform(ca_counties, st_crs(sites_sf))
+
+##assign each site hash its county name
+sites_with_county = st_join(sites_sf, ca_counties, join = st_intersects, left = TRUE) |> st_drop_geometry()
+
+##can see the counties that are still not assigned to a site
+missing_counties = ca_counties |> filter(!County %in% sites_with_county$County)
+print(missing_counties$County)
+
+##assign whats leftover using nearest neighbor
+sites_projected = st_transform(sites_sf, 3310)
+missing_counties_projected = st_transform(missing_counties, 3310)
+missing_county_points = st_point_on_surface(missing_counties_projected)
+nearest_site_index = st_nearest_feature(missing_county_points, sites_projected)
+
+missing_county_lookup = tibble(
+  County = missing_counties$County,
+  site_hash = sites_projected$site_hash[nearest_site_index]
+)
+
+internal_site_lookup = sites_with_county |> filter(!is.na(County)) |> select(County, site_hash)
+county_site_lookup = bind_rows(internal_site_lookup, missing_county_lookup) |> distinct()
+
+##now have a lookup table with sites and their county info
+write.csv(county_site_lookup, file.path(output_dir, "caladapt_county_site_lookup.csv"), row.names = FALSE)
+
+#double check every county now has at least one climate site
+unmatched_counties = setdiff(ca_counties$County, county_site_lookup$County)
+print(unmatched_counties)
+if (length(unmatched_counties)) stop("Some counties still have no Cal-Adapt site assignment.")
+
+
+# ---------- process all NetCDF files ----------
+all_nc_files = dir_ls(base_dir, recurse = TRUE, glob = "*.nc")
+cat(sprintf("Found %d NetCDF files.\n", length(all_nc_files)))
+
+plan(multisession, workers = max(1, parallelly::availableCores() - 1))
+
+daily_climate_dataset = future_map_dfr(all_nc_files, process_nc_file,
+  wind_height_m = 10, .progress = TRUE, .options = furrr_options(seed = TRUE))
+
+
+# ---------- attach counties to daily climate records ----------
+daily_climate_county = daily_climate_dataset |> inner_join(county_site_lookup, by = "site_hash")
+
+county_daily_climate = daily_climate_county |>
+  group_by(County, date, model, scenario) |>
+  summarise(
+    ET0_mm = mean(ET0_mm, na.rm = TRUE),
+    precip_mm = mean(precip_mm, na.rm = TRUE),
+    mean_temp_c = mean(mean_temp_c, na.rm = TRUE),
+    min_temp_c = mean(T_min, na.rm = TRUE),
+    max_temp_c = mean(T_max, na.rm = TRUE),
+    n_climate_sites = n_distinct(site_hash),
+    .groups = "drop"
+  ) |>
+  mutate(Year = year(date), Week = isoweek(date)) |>
+  rename(GCM = model, SSP = scenario)
+
+write.csv(county_daily_climate, file.path(output_dir, "caladapt_county_daily_climate.csv"), row.names = FALSE)
+
+message("DONE: ", file.path(output_dir, "caladapt_county_daily_climate.csv"))

--- a/modules/data.remote/inst/irrigation.R
+++ b/modules/data.remote/inst/irrigation.R
@@ -1,0 +1,604 @@
+## Shared irrigation projection
+## Final output schema: event_type, parcel_id, date, amount_mm
+
+pacman::p_load(data.table, arrow, bit64, dplyr, readr, stringr, lubridate, sf,
+               PEcAn.data.land, parallel, parallelly)
+
+# ---------- setup ----------
+#REQUIRED: Choose a folder to define work_root, where you want this framework to save intermediate and output files
+#Uncomment the line below and replace the example path.
+#work_root = "/path/to/your/folder"
+
+#Shared Data: Shared project data, most users should not need to change this.
+ccmmf_root = "/projectnb/dietzelab/ccmmf"
+
+config = list(
+  years = 2024:2045, hist_years = 2018:2023,
+  crop_dir = file.path(work_root, "crop_predictions"),
+  planting_dir = file.path(work_root, "planting_projections"),
+  harvest_dir = file.path(work_root, "harvest_projections"),
+  landiq_path = file.path(ccmmf_root, "LandIQ-harmonized-v4.1.2", "crops_all_years.parq"),
+  matched_dir = file.path(ccmmf_root, "management", "phenology", "matched_landiq_mslsp_v4.1.2", "gapfill_dates"),
+  climate_path = file.path(work_root, "caladapt_county_daily_climate.csv"),
+  
+  ##cache AWC values by county to reduce run time; first run creates these, later runs reuse them
+  ssurgo_weights_path = file.path(ccmmf_root, "data_raw", "ssurgo", "ssurgo-weights.parquet"),
+  ssurgo_gdb_path = file.path(ccmmf_root, "data_raw", "ssurgo", "gSSURGO_CA.gdb"),
+  awc_cache_dir = file.path(work_root, "irrigation_awc_cache"),
+  
+  ##choosing one out of the three gcm/ssp combinations for simplicity
+  gcm = "CESM2", ssp = "ssp245",
+  
+  rice_target = 125, rice_min = 62.5, rice_max = 175, rice_seepage = 2.5, irrigation_max = 150,
+  
+  ##will be used during the actual prediction section to improve run time
+  workers = 6L,
+  
+  output_dir = file.path(work_root, "irrigation_projections")
+)
+
+dir.create(config$output_dir, recursive = TRUE, showWarnings = FALSE)
+dir.create(config$awc_cache_dir, recursive = TRUE, showWarnings = FALSE)
+
+
+# ---------- helpers ----------
+assert_cols = function(x, req, label) {
+  miss = setdiff(req, names(x))
+  if (length(miss)) stop(label, " missing: ", paste(miss, collapse = ", "))
+}
+
+pick_col = function(nms, choices, label) {
+  hit = intersect(choices, nms)
+  if (!length(hit)) stop(label, " missing all of: ", paste(choices, collapse = ", "))
+  hit[1]
+}
+
+safe_mean = function(x) {
+  x = as.numeric(x)
+  x = x[is.finite(x)]
+  if (length(x)) mean(x) else NA_real_
+}
+
+norm_county = function(x) {
+  x = stringr::str_squish(as.character(x))
+  sub("\\s+County$", "", x, ignore.case = TRUE)
+}
+
+norm_subclass = function(x) {
+  x = trimws(as.character(x))
+  x = sub("\\.0+$", "", x)
+  x[x %chin% c("", "NA", "NaN", "NULL")] = NA_character_
+  x
+}
+
+make_code = function(class, subclass) {
+  class = trimws(as.character(class))
+  subclass = norm_subclass(subclass)
+  fifelse(is.na(subclass), class, paste0(class, subclass))
+}
+
+calc_effective_awc = function(hzdept_r, hzdepb_r, awc_r, rooting_depth_cm) {
+  top = pmin(hzdept_r, rooting_depth_cm)
+  bottom = pmin(hzdepb_r, rooting_depth_cm)
+  thickness = pmax(0, bottom - top)
+  sum(awc_r * thickness, na.rm = TRUE) * 10
+}
+
+
+# ---------- future crops / planting / harvest ----------
+read_crop = function(yy) {
+  path = file.path(config$crop_dir, paste0("crop_identity_statewide_", yy, ".parquet"))
+  if (!file.exists(path)) stop("Missing crop projection: ", path)
+  
+  x = as.data.table(read_parquet(path))
+  assert_cols(x, c("parcel_id", "COUNTY", "CLASS", "SUBCLASS"), basename(path))
+  
+  if ("season" %in% names(x)) {
+    x[, season := as.integer(season)]
+    if (x[!is.na(season) & season != 2L, .N]) stop(basename(path), " contains non-season-2 rows.")
+  }
+  
+  x[, .(
+    parcel_id = bit64::as.integer64(as.character(parcel_id)), year = as.integer(yy),
+    county = norm_county(COUNTY), CLASS = trimws(as.character(CLASS)),
+    SUBCLASS = norm_subclass(SUBCLASS), crop_code = make_code(CLASS, SUBCLASS)
+  )]
+}
+
+read_plant = function(yy) {
+  path = file.path(config$planting_dir, paste0("planting_statewide_", yy, ".parquet"))
+  if (!file.exists(path)) stop("Missing planting projection: ", path)
+  
+  x = as.data.table(read_parquet(path))
+  id = pick_col(names(x), c("parcel_id", "site_id"), basename(path))
+  dc = pick_col(names(x), c("date", "planting_date"), basename(path))
+  
+  data.table(parcel_id = bit64::as.integer64(as.character(x[[id]])),
+             year = as.integer(yy), planting_date = as.IDate(x[[dc]]))
+}
+
+read_harvest = function(yy) {
+  path = file.path(config$harvest_dir, paste0("harvest_statewide_", yy, ".parquet"))
+  if (!file.exists(path)) stop("Missing harvest projection: ", path)
+  
+  x = as.data.table(read_parquet(path))
+  id = pick_col(names(x), c("parcel_id", "site_id"), basename(path))
+  dc = pick_col(names(x), c("date", "harvest_date"), basename(path))
+  
+  data.table(parcel_id = bit64::as.integer64(as.character(x[[id]])),
+             year = as.integer(yy), harvest_date = as.IDate(x[[dc]]))
+}
+
+message("Loading future projections...")
+
+future_crop = rbindlist(lapply(config$years, read_crop))
+future_crop = future_crop[!CLASS %chin% c("X", "I") & !is.na(CLASS)]
+planting = rbindlist(lapply(config$years, read_plant))
+harvest = rbindlist(lapply(config$years, read_harvest))
+
+for (nm in c("future_crop", "planting", "harvest")) {
+  z = get(nm)
+  if (z[, .N, by = .(parcel_id, year)][N > 1L, .N]) stop(nm, " contains duplicate parcel-year rows.")
+}
+
+future = merge(future_crop, planting, by = c("parcel_id", "year"), all.x = TRUE)
+future = merge(future, harvest, by = c("parcel_id", "year"), all.x = TRUE)
+
+if (future[is.na(planting_date) | is.na(harvest_date), .N]) stop("Active crops missing planting/harvest dates.")
+if (future[harvest_date <= planting_date, .N]) stop("Harvest must occur after planting.")
+
+rm(future_crop, planting, harvest); gc()
+
+# ---------- historical county ----------
+message("Loading historical county lookup...")
+
+landiq = as.data.table(read_parquet(config$landiq_path, col_select = c("parcel_id", "COUNTY", "year")))
+landiq[, `:=`(
+  parcel_id = bit64::as.integer64(as.character(parcel_id)),
+  COUNTY = norm_county(COUNTY),
+  year = as.integer(year)
+)]
+landiq = landiq[year <= max(config$hist_years) & !is.na(COUNTY)]
+
+parcel_county = landiq[, .SD[which.max(year)], by = parcel_id][, .(parcel_id, county = COUNTY)]
+if (anyDuplicated(parcel_county$parcel_id)) stop("County lookup contains duplicate parcel IDs.")
+
+rm(landiq); gc()
+
+# ---------- historical peak fraction ----------
+message("Calculating historical peak-position lookup...")
+
+peak_hist = rbindlist(lapply(config$hist_years, function(yy) {
+  path = file.path(config$matched_dir, paste0("assigned_year=", yy, "_gapfilled.parquet"))
+  if (!file.exists(path)) stop("Missing phenology file: ", path)
+  
+  x = as.data.table(read_parquet(path))
+  assert_cols(x, c("parcel_id", "landiq_CLASS", "landiq_SUBCLASS",
+                   "mslsp_OGI", "mslsp_Peak", "mslsp_OGMn"), basename(path))
+  
+  if ("season" %in% names(x)) {
+    x[, season := as.integer(season)]
+    x = x[season == 2L]
+  }
+  
+  x[, .(
+    parcel_id = bit64::as.integer64(as.character(parcel_id)),
+    CLASS = trimws(as.character(landiq_CLASS)), SUBCLASS = norm_subclass(landiq_SUBCLASS),
+    hist_plant = as.IDate(mslsp_OGI), hist_peak = as.IDate(mslsp_Peak), hist_end = as.IDate(mslsp_OGMn)
+  )]
+}), fill = TRUE)
+
+peak_hist = merge(peak_hist, parcel_county, by = "parcel_id", all.x = TRUE)
+peak_hist[, crop_code := make_code(CLASS, SUBCLASS)]
+peak_hist[, `:=`(season_days = as.numeric(hist_end - hist_plant),
+                 peak_days = as.numeric(hist_peak - hist_plant))]
+
+peak_hist = peak_hist[
+  is.finite(season_days) & season_days > 0 &
+    is.finite(peak_days) & peak_days >= 0 & peak_days <= season_days
+]
+
+peak_hist[, hist_peak_frac := peak_days / season_days]
+if (!nrow(peak_hist)) stop("No valid historical peak fractions.")
+
+lookup_cc = peak_hist[!is.na(county) & !is.na(crop_code),
+                      .(peak_frac_cc = safe_mean(hist_peak_frac)), by = .(county, crop_code)]
+lookup_cclass = peak_hist[!is.na(county) & !is.na(CLASS),
+                          .(peak_frac_cclass = safe_mean(hist_peak_frac)), by = .(county, CLASS)]
+lookup_code = peak_hist[!is.na(crop_code),
+                        .(peak_frac_code = safe_mean(hist_peak_frac)), by = crop_code]
+lookup_class = peak_hist[!is.na(CLASS),
+                         .(peak_frac_class = safe_mean(hist_peak_frac)), by = CLASS]
+peak_frac_global = safe_mean(peak_hist$hist_peak_frac)
+
+future = merge(future, lookup_cc, by = c("county", "crop_code"), all.x = TRUE)
+future = merge(future, lookup_cclass, by = c("county", "CLASS"), all.x = TRUE)
+future = merge(future, lookup_code, by = "crop_code", all.x = TRUE)
+future = merge(future, lookup_class, by = "CLASS", all.x = TRUE)
+
+future[, peak_frac := as.numeric(peak_frac_cc)]
+future[is.na(peak_frac), peak_frac := as.numeric(peak_frac_cclass)]
+future[is.na(peak_frac), peak_frac := as.numeric(peak_frac_code)]
+future[is.na(peak_frac), peak_frac := as.numeric(peak_frac_class)]
+future[is.na(peak_frac), peak_frac := peak_frac_global]
+future[, peak_frac := pmin(1, pmax(0, peak_frac))]
+
+future[, season_days := as.numeric(harvest_date - planting_date)]
+future[, peak_date := as.IDate(as.Date(planting_date) + as.integer(round(peak_frac * season_days)))]
+
+if (future[is.na(peak_date), .N]) stop("Could not project peak date for all active crops.")
+if (future[peak_date < planting_date | peak_date > harvest_date, .N]) stop("Impossible projected peak date.")
+
+future[, c("peak_frac_cc", "peak_frac_cclass", "peak_frac_code",
+           "peak_frac_class", "season_days") := NULL]
+
+rm(peak_hist, lookup_cc, lookup_cclass, lookup_code, lookup_class, parcel_county); gc()
+
+# ---------- crop-water parameters ----------
+bism = PEcAn.data.land::bism_kc_by_crop |>
+  distinct(landiq_class, landiq_subclass, crop_name) |>
+  slice(1, .by = c("landiq_class", "landiq_subclass")) |>
+  mutate(landiq_class = as.character(landiq_class),
+         landiq_subclass = suppressWarnings(as.integer(landiq_subclass)),
+         mapping_source = "exact")
+
+crop_whc = PEcAn.data.land::crop_whc |>
+  select(crop_name, whc_min_frac, rooting_depth_m) |>
+  slice(1, .by = "crop_name")
+
+proxy = tibble::tribble(
+  ~landiq_class, ~landiq_subclass, ~crop_name,
+  "D",3,"Stone fruits", "D",5,"Stone fruits", "D",7,"Stone fruits",
+  "D",10,"Stone fruits", "D",14,"Almonds", "D",16,"Stone fruits",
+  "C",7,"Avocado", "T",16,"Vegetables", "T",19,"Strawberries w/mulch",
+  "T",31,"Potato", "P",4,"Improved Pasture", "P",7,"Turfgrass (cool-season)",
+  "F",16,"Sorghum", "R",2,"Rice"
+) |>
+  mutate(mapping_source = "proxy")
+
+bism = bind_rows(bism, proxy) |>
+  distinct(landiq_class, landiq_subclass, .keep_all = TRUE)
+
+modeled = as.data.frame(future) |>
+  mutate(
+    CLASS_lookup = as.character(CLASS),
+    SUBCLASS_lookup = suppressWarnings(as.integer(SUBCLASS)),
+    planting_date = as.Date(planting_date),
+    peak_date = as.Date(peak_date),
+    harvest_date = as.Date(harvest_date)
+  ) |>
+  left_join(bism, by = c("CLASS_lookup" = "landiq_class", "SUBCLASS_lookup" = "landiq_subclass")) |>
+  left_join(crop_whc, by = "crop_name") |>
+  mutate(irrigation_status = case_when(
+    is.na(crop_name) ~ "missing_BISM_crop",
+    crop_name != "Rice" & is.na(rooting_depth_m) ~ "missing_root_depth",
+    crop_name != "Rice" & is.na(whc_min_frac) ~ "missing_MAD",
+    is.na(peak_date) ~ "missing_peak",
+    TRUE ~ "ready"
+  ))
+
+print(modeled |> count(irrigation_status))
+modeled = modeled |> filter(irrigation_status == "ready")
+if (!nrow(modeled)) stop("No crops eligible for irrigation.")
+
+rm(future, bism, proxy, crop_whc); gc()
+
+# ---------- soil AWC cache ----------
+##first run calculates missing parcel/root-depth combinations from SSURGO; later runs reuse the county caches
+message("Checking AWC cache...")
+
+ssurgo_weights = read_parquet(config$ssurgo_weights_path)
+assert_cols(ssurgo_weights, c("parcel_id", "mukey", "weight", "area_m2"), "SSURGO weights")
+ssurgo_weights$parcel_id = bit64::as.integer64(as.character(ssurgo_weights$parcel_id))
+
+##load SSURGO tables once instead of once per county
+message("Loading SSURGO component/chorizon tables...")
+
+component = sf::read_sf(config$ssurgo_gdb_path, layer = "component", as_tibble = TRUE)
+if (inherits(component, "sf")) component = st_drop_geometry(component)
+component = component |>
+  select(mukey, cokey, comppct_r) |>
+  semi_join(ssurgo_weights |> distinct(mukey), by = "mukey")
+
+chorizon = sf::read_sf(config$ssurgo_gdb_path, layer = "chorizon", as_tibble = TRUE)
+if (inherits(chorizon, "sf")) chorizon = st_drop_geometry(chorizon)
+chorizon = chorizon |>
+  select(cokey, hzdept_r, hzdepb_r, awc_r) |>
+  semi_join(component |> distinct(cokey), by = "cokey")
+
+nonrice = modeled |> filter(crop_name != "Rice")
+rice = modeled |> filter(crop_name == "Rice") |> mutate(whc_mm = NA_real_)
+
+county_groups = split(nonrice, nonrice$county)
+
+nonrice_awc = lapply(names(county_groups), function(cty) {
+  x = county_groups[[cty]]
+  safe_cty = gsub("[^A-Za-z0-9_-]", "_", cty)
+  cache_file = file.path(config$awc_cache_dir, paste0(safe_cty, "_awc.parquet"))
+  
+  needed = x |> distinct(parcel_id, rooting_depth_m)
+  
+  if (file.exists(cache_file)) {
+    cache = read_parquet(cache_file) |> select(parcel_id, rooting_depth_m, whc_mm)
+    cache$parcel_id = bit64::as.integer64(as.character(cache$parcel_id))
+  } else {
+    cache = tibble::tibble(parcel_id = bit64::integer64(), rooting_depth_m = numeric(), whc_mm = numeric())
+  }
+  
+  missing = needed |> anti_join(cache, by = c("parcel_id", "rooting_depth_m"))
+  
+  if (nrow(missing)) {
+    message("AWC ", cty, ": calculating ", format(nrow(missing), big.mark = ","), " new combinations.")
+    
+    new_awc = ssurgo_weights |>
+      inner_join(missing, by = "parcel_id", relationship = "many-to-many") |>
+      left_join(component, by = "mukey", relationship = "many-to-many") |>
+      left_join(chorizon, by = "cokey", relationship = "many-to-many") |>
+      filter(!is.na(awc_r), !is.na(hzdept_r), !is.na(hzdepb_r), !is.na(rooting_depth_m)) |>
+      mutate(rooting_depth_cm = rooting_depth_m * 100) |>
+      summarise(
+        whc_mm_cmp = calc_effective_awc(hzdept_r, hzdepb_r, awc_r, rooting_depth_cm),
+        .by = c(parcel_id, rooting_depth_m, mukey, cokey, area_m2, weight, comppct_r)
+      ) |>
+      summarise(
+        whc_mm_mu = sum(whc_mm_cmp * comppct_r / sum(comppct_r)),
+        .by = c(parcel_id, rooting_depth_m, mukey, area_m2, weight)
+      ) |>
+      summarise(whc_mm = sum(whc_mm_mu * weight), .by = c(parcel_id, rooting_depth_m))
+    
+    cache = bind_rows(cache, new_awc) |>
+      distinct(parcel_id, rooting_depth_m, .keep_all = TRUE)
+    
+    write_parquet(cache, cache_file, compression = "zstd")
+  }
+  
+  x |> left_join(cache, by = c("parcel_id", "rooting_depth_m"))
+}) |>
+  bind_rows()
+
+missing_awc = nonrice_awc |> filter(!is.finite(whc_mm))
+if (nrow(missing_awc)) message("Skipping non-rice rows without usable SSURGO AWC: ", nrow(missing_awc))
+
+modeled = bind_rows(nonrice_awc |> filter(is.finite(whc_mm)), rice)
+
+rm(ssurgo_weights, component, chorizon, county_groups, nonrice, nonrice_awc, rice, missing_awc); gc()
+message("AWC attached. Continuing irrigation predictions.")
+
+
+# ---------- climate ----------
+message("Loading climate...")
+
+climate = read_csv(config$climate_path, show_col_types = FALSE)
+assert_cols(climate, c("County", "date", "GCM", "SSP", "ET0_mm", "precip_mm"), "Climate")
+
+climate = climate |>
+  mutate(
+    County = norm_county(County),
+    date = as.Date(date),
+    ET0_mm = as.numeric(ET0_mm),
+    precip_mm = as.numeric(precip_mm)
+  ) |>
+  filter(GCM == config$gcm, SSP == config$ssp)
+
+if (!nrow(climate))
+  stop("No climate rows for ", config$gcm, " / ", config$ssp)
+
+if (climate |> count(County, date) |> filter(n > 1) |> nrow())
+  stop("Climate contains duplicate County/date rows.")
+
+real_min = min(year(climate$date), na.rm = TRUE)
+real_max = max(year(climate$date), na.rm = TRUE)
+
+##actual Cal-Adapt data should cover 2025-45
+if (real_min > 2025 || real_max < 2045)
+  stop("Climate file must contain the full 2025-2045 Cal-Adapt period.")
+
+##use 2025 climate as the proxy for 2024
+climate_2024 = climate |>
+  filter(year(date) == 2025) |>
+  mutate(date = suppressWarnings(make_date(2024, month(date), day(date)))) |>
+  filter(!is.na(date))
+
+climate = bind_rows(climate_2024, climate) |>
+  arrange(County, date) |>
+  distinct(County, date, .keep_all = TRUE)
+
+rm(climate_2024); gc()
+# ---------- water balance ----------
+run_group = function(g, cclim) {
+  crop = g$crop_name[[1]]
+  plant = g$planting_date[[1]]
+  peak = g$peak_date[[1]]
+  harvest_date = g$harvest_date[[1]]
+  dates = seq.Date(plant, harvest_date, by = "day")
+  
+  idx = match(dates, cclim$date)
+  
+  ##do not silently substitute another day's climate if a required date is missing
+  if (anyNA(idx)) {
+    missing_dates = dates[is.na(idx)]
+    stop("Missing climate for ", crop, " from ", plant, " to ", harvest_date,
+         ". First missing date: ", missing_dates[[1]])
+  }
+  
+  clim = cclim[idx, , drop = FALSE]
+  before_peak = max(1, as.numeric(peak - plant))
+  after_peak = max(1, as.numeric(harvest_date - peak))
+  
+  canopy = ifelse(
+    dates <= peak,
+    0.15 + 0.85 * as.numeric(dates - plant) / before_peak,
+    1 - 0.85 * as.numeric(dates - peak) / after_peak
+  )
+  canopy = pmin(1, pmax(0, canopy))
+  
+  etc = PEcAn.data.land::eto_to_etc_bism(eto = clim$ET0_mm, crop_name = crop, canopy_cover = canopy)
+  
+  if (crop == "Rice") {
+    wb = PEcAn.data.land::calc_water_balance_rice(
+      et = etc, precip = clim$precip_mm, flood_target = config$rice_target,
+      flood_min = config$rice_min, flood_max = config$rice_max, seepage = config$rice_seepage
+    )
+    
+    keep = which(is.finite(wb$irr) & wb$irr > 0)
+    if (!length(keep)) return(tibble::tibble())
+    
+    return(bind_rows(lapply(seq_len(nrow(g)), function(i) {
+      tibble::tibble(
+        parcel_id = g$parcel_id[[i]], projection_year = g$year[[i]],
+        date = dates[keep], amount_mm = as.numeric(wb$irr[keep]), method = "flood"
+      )
+    })))
+  }
+  
+  bind_rows(lapply(seq_len(nrow(g)), function(i) {
+    wb = PEcAn.data.land::calc_water_balance(
+      et = etc, precip = clim$precip_mm, whc = g$whc_mm[[i]],
+      whc_min_frac = g$whc_min_frac[[i]], irrigation_max = config$irrigation_max
+    )
+    
+    keep = which(is.finite(wb$irr) & wb$irr > 0)
+    if (!length(keep)) return(tibble::tibble())
+    
+    tibble::tibble(
+      parcel_id = g$parcel_id[[i]], projection_year = g$year[[i]],
+      date = dates[keep], amount_mm = as.numeric(wb$irr[keep]), method = "canopy"
+    )
+  }))
+}
+
+# ---------- parallel county predictions ----------
+counties = sort(unique(modeled$county))
+tmp_dir = file.path(config$output_dir, "_county_tmp")
+dir.create(tmp_dir, recursive = TRUE, showWarnings = FALSE)
+
+county_path = function(cty) {
+  safe = gsub("[^A-Za-z0-9_-]", "_", cty)
+  file.path(tmp_dir, paste0("irrigation_", safe, ".parquet"))
+}
+
+done = vapply(counties, function(x) file.exists(county_path(x)), logical(1))
+todo = counties[!done]
+
+message(sum(done), " counties already complete; ", length(todo), " remaining.")
+
+if (length(todo)) {
+  # Build compact county jobs, then release giant statewide tables.
+  jobs = lapply(todo, function(cty) {
+    x = modeled |>
+      filter(county == cty) |>
+      select(parcel_id, year, crop_name, planting_date, peak_date, harvest_date, whc_mm, whc_min_frac)
+    
+    cc = climate |>
+      filter(County == cty) |>
+      select(date, ET0_mm, precip_mm) |>
+      arrange(date)
+    
+    if (!nrow(cc)) stop("No climate rows found for county: ", cty)
+    
+    list(county = cty, data = x, climate = cc, path = county_path(cty))
+  })
+  
+  # Large counties first + load balancing.
+  sizes = vapply(jobs, function(x) nrow(x$data), integer(1))
+  jobs = jobs[order(sizes, decreasing = TRUE)]
+  
+  rm(modeled, climate); gc()
+  
+  n_workers = min(config$workers, as.integer(parallelly::availableCores()), length(jobs))
+  message("Starting ", n_workers, " PSOCK workers.")
+  
+  cl = parallel::makePSOCKcluster(n_workers, outfile = "")
+  
+  parallel::clusterEvalQ(cl, {
+    library(dplyr)
+    library(arrow)
+    library(bit64)
+    library(tibble)
+    library(PEcAn.data.land)
+    NULL
+  })
+  
+  parallel::clusterExport(cl, c("run_group", "config"), envir = .GlobalEnv)
+  
+  results = tryCatch(
+    parallel::parLapplyLB(cl, jobs, function(job) {
+      message("RUN: ", job$county)
+      
+      groups = job$data |>
+        group_by(crop_name, planting_date, peak_date, harvest_date) |>
+        group_split(.keep = TRUE)
+      
+      ans = bind_rows(lapply(groups, run_group, cclim = job$climate))
+      
+      if (!nrow(ans)) {
+        ans = tibble::tibble(
+          parcel_id = bit64::as.integer64(character()), projection_year = integer(),
+          date = as.Date(character()), amount_mm = numeric(), method = character()
+        )
+      } else {
+        ans$parcel_id = bit64::as.integer64(as.character(ans$parcel_id))
+        ans$date = as.Date(ans$date)
+      }
+      
+      arrow::write_parquet(ans, job$path, compression = "zstd")
+      message("DONE: ", job$county, " | ", format(nrow(ans), big.mark = ","), " events")
+      
+      c(county = job$county, events = as.character(nrow(ans)))
+    }),
+    finally = parallel::stopCluster(cl)
+  )
+  
+  rm(jobs, results); gc()
+}
+
+message("All county predictions complete.")
+
+# ---------- final yearly parquets ----------
+parquet_files = list.files(tmp_dir, pattern = "\\.parquet$", full.names = TRUE)
+
+if (!length(parquet_files))
+  stop("No county parquet files found in: ", tmp_dir)
+
+for (yy in config$years) {
+  message("Building ", yy, "...")
+  
+  ##read each county file directly; avoids Arrow open_dataset filesystem issue
+  pieces = lapply(parquet_files, function(f) {
+    x = arrow::read_parquet(
+      f,
+      col_select = c("parcel_id", "projection_year", "date", "amount_mm")
+    )
+    
+    x = x[x$projection_year == yy, , drop = FALSE]
+    
+    if (!nrow(x)) return(NULL)
+    
+    x[, c("parcel_id", "date", "amount_mm")]
+  })
+  
+  out = bind_rows(pieces) |>
+    mutate(
+      event_type = "irrigation",
+      parcel_id = bit64::as.integer64(as.character(parcel_id)),
+      date = as.Date(date),
+      amount_mm = as.numeric(amount_mm)
+    ) |>
+    select(event_type, parcel_id, date, amount_mm) |>
+    arrange(parcel_id, date)
+  
+  if (nrow(out) && any(!complete.cases(out)))
+    stop("Incomplete irrigation output for ", yy)
+  
+  if (nrow(out) && any(!is.finite(out$amount_mm) | out$amount_mm <= 0))
+    stop("Invalid irrigation amounts for ", yy)
+  
+  path = file.path(config$output_dir, paste0("irrigation_statewide_", yy, ".parquet"))
+  arrow::write_parquet(out, path, compression = "zstd")
+  
+  message("Wrote ", yy, ": ", format(nrow(out), big.mark = ","), " events")
+  
+  rm(out, pieces); gc()
+}
+
+message("DONE: ", config$output_dir)


### PR DESCRIPTION
Adds the statewide irrigation projection workflow

PR includes:
- `get_climate_data.R` for converting the downloaded 198 Cal-Adapt design points into county-level daily climate inputs
- `irrigation.R` for generating parcel-level irrigation projections
- `06-irrigation_predictions.md` as a documentation draft 

The workflow combines projected crop identity and phenology with Cal-Adapt climate, crop water parameters, and SSURGO-derived available water capacity to generate annual irrigation events.