### PR TITLE
run.sensitivity.analysis: hoist samples loading outside variables loop (#3859)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 
 ### Fixed
 - Building package documentation sites via `scripts/build_pkgdown.R` no longer exits early when any package gives a build warning (#4034).
+- In `run.sensitivity.analysis()`, load `samples` once before the variables loop and clone per iteration, avoiding repeated disk reads and preventing loop variable shadowing (#3859).
 - The median run's manifest row went in with the literal strings `"NA"` for pft and trait, which `read.csv` turns into real `NA`, so `read.sa.output` never matched the median quantile and `splinefun` silently dropped that knot. Sensitivity analysis output changes as a result: partial variances shift slightly, though rankings are unaffected in the cases checked.
 - Docker GHA workflow no longer fails on pull requests opened from forks (#3618).
 - Removed unused `grid2netcdf()` from `PEcAn.data.remote` and fixed R CMD check reference notes for `download.LandTrendr.AGB()` (#2758).

--- a/modules/uncertainty/NEWS.md
+++ b/modules/uncertainty/NEWS.md
@@ -1,5 +1,6 @@
 # PEcAn.uncertainty 1.9.0.9000
 
+* In `run.sensitivity.analysis()`, load `samples` once before the variables loop and clone per iteration, avoiding repeated disk reads and preventing loop variable shadowing (#3859).
 * Multiple bugfixes in `input.ens.gen()` handling of parent ids (#3783):
     - No longer skips inputs that have a parent but no sampling method.
     - Argument `parent_ids` now accepts integer vectors even if not wrapped in a list.

--- a/modules/uncertainty/R/run.sensitivity.analysis.R
+++ b/modules/uncertainty/R/run.sensitivity.analysis.R
@@ -86,10 +86,10 @@ run.sensitivity.analysis <- function(settings,
   }
   if (is.null(variable)) {
     if ("variable" %in% names(settings$sensitivity.analysis)) {
-      var <- which(names(settings$sensitivity.analysis) == "variable")
-      for (i in seq_along(var)) {
-        variable[i] <- settings$sensitivity.analysis[[var[i]]]
-      }
+      variable <- unlist(
+        settings$sensitivity.analysis[names(settings$sensitivity.analysis) == "variable"],
+        use.names = FALSE
+      )
     }
   }
   if (is.null(variable)) {
@@ -111,48 +111,54 @@ run.sensitivity.analysis <- function(settings,
     }
   }
 
+  # Ensemble ID is expected to be specified in function args or settings.
+  # If none there, create one specific to this site.
+  ensemble.id <- ensemble.id %||%
+    settings$sensitivity.analysis$ensemble.id %||%
+    rlang::hash(settings)
+
+  ### Load samples
+  # Have to load samples.Rdata for the traits.
+  # But can overwrite the run ids if an SA ensemble id provided.
+  # samples.Rdata always has only the most recent ensembles for both ensemble
+  # and sensitivity runs.
+  # Load samples once before looping over variables to avoid repeated disk reads (Issue #3859).
+  fname <- file.path(settings$outdir, "samples.Rdata")
+  if (!file.exists(fname)) {
+    PEcAn.logger::logger.severe("No samples.Rdata file found!")
+  }
+  samples_base <- new.env()
+  load(fname, envir = samples_base)
+
+  fname <- sensitivity.filename(settings, "sensitivity.samples", "Rdata",
+                                ensemble.id = ensemble.id,
+                                all.var.yr = TRUE)
+  if (file.exists(fname)) {
+    load(fname, envir = samples_base)
+  }
+
+  # For backwards compatibility, define some variables if not just loaded
+  if (is.null(samples_base$pft.names)) {
+    samples_base$pft.names <- names(samples_base$trait.samples)
+  }
+  if (is.null(samples_base$trait.names)) {
+    samples_base$trait.names <- lapply(samples_base$trait.samples, names)
+  }
+  if (is.null(samples_base$sa.run.ids)) {
+    samples_base$sa.run.ids <- samples_base$runs.samples$sa
+  }
+
   variables <- variable
   for (variable in variables) {
     PEcAn.logger::logger.warn("Currently performing sensitivity analysis on variable ", variable)
 
-    ### Load samples
-    # Have to load samples.Rdata for the traits.
-    # But can overwrite the run ids if an SA ensemble id provided.
-    # samples.Rdata always has only the most recent ensembles for both ensemble
-    # and sensitivity runs.
-    fname <- file.path(settings$outdir, "samples.Rdata")
-    if (!file.exists(fname)) {
-      PEcAn.logger::logger.severe("No samples.Rdata file found!")
-    }
-    samples <- new.env()
-    load(fname, envir = samples)
-
-    # Ensemble ID is expected to be specified in function args or settings.
-    # If none there, create one specific to this site.
-    ensemble.id <- ensemble.id %||%
-      settings$sensitivity.analysis$ensemble.id %||%
-      rlang::hash(settings)
-    fname <- sensitivity.filename(settings, "sensitivity.samples", "Rdata",
-                                  ensemble.id = ensemble.id,
-                                  all.var.yr = TRUE)
-    if (file.exists(fname)) {
-      load(fname, envir = samples)
-    }
-
-    # For backwards compatibility, define some variables if not just loaded
-    if (is.null(samples$pft.names)) {
-      samples$pft.names <- names(samples$trait.samples)
-    }
-    if (is.null(samples$trait.names)) {
-      samples$trait.names <- lapply(samples$trait.samples, names)
-    }
-    if (is.null(samples$sa.run.ids)) {
-      samples$sa.run.ids <- samples$runs.samples$sa
-    }
+    # Clone base samples for this variable iteration so that in-place modifications
+    # (e.g. unit conversions) do not persist across variable iterations
+    samples <- rlang::env_clone(samples_base)
 
     ### Load parsed model results
-    variables <- PEcAn.utils::convert.expr(variable)
-    variable.fn <- variables$variable.drv
+    parsed_var <- PEcAn.utils::convert.expr(variable)
+    variable.fn <- parsed_var$variable.drv
 
     fname <- sensitivity.filename(
       settings, "sensitivity.output", "Rdata",

--- a/modules/uncertainty/tests/testthat/test-run.sensitivity.analysis.R
+++ b/modules/uncertainty/tests/testthat/test-run.sensitivity.analysis.R
@@ -1,0 +1,76 @@
+test_that("run.sensitivity.analysis returns NULL when sensitivity.analysis is missing", {
+  expect_null(run.sensitivity.analysis(list()))
+})
+
+test_that("run.sensitivity.analysis loads samples once before variables loop and preserves loop variable", {
+  tmpdir <- withr::local_tempdir()
+
+  # Create mock samples.Rdata
+  trait.samples <- list(pft1 = list(sla = c(10, 20)))
+  sa.samples <- list(pft1 = matrix(c(10, 20), nrow = 2, dimnames = list(c("25", "75"), "sla")))
+  runs.samples <- list(sa = c("run1", "run2"))
+  save(trait.samples, sa.samples, runs.samples, file = file.path(tmpdir, "samples.Rdata"))
+
+  settings <- list(
+    outdir = tmpdir,
+    sensitivity.analysis = list(
+      variable = c("NPP", "GPP"),
+      start.year = 2000,
+      end.year = 2001,
+      ensemble.id = "ENS-TEST"
+    ),
+    pfts = list(list(name = "pft1", outdir = tmpdir))
+  )
+
+  # Mock sensitivity output file for both variables
+  for (var in c("NPP", "GPP")) {
+    sens_out_file <- sensitivity.filename(
+      settings, "sensitivity.output", "Rdata",
+      all.var.yr = FALSE,
+      ensemble.id = "ENS-TEST",
+      variable = var,
+      start.year = 2000,
+      end.year = 2001
+    )
+    sensitivity.output <- list(pft1 = data.frame(sla = c(1.0, 2.0)))
+    dir.create(dirname(sens_out_file), showWarnings = FALSE, recursive = TRUE)
+    save(sensitivity.output, file = sens_out_file)
+  }
+
+  # Mock trait.lookup, convert.expr, sensitivity.analysis
+  mockery::stub(run.sensitivity.analysis, "PEcAn.utils::trait.lookup", function(...) data.frame(units = "m2/kg"))
+  mockery::stub(run.sensitivity.analysis, "PEcAn.utils::convert.expr", function(var) list(variable.drv = var))
+  mockery::stub(run.sensitivity.analysis, "sensitivity.analysis", function(...) list(
+    variance.decomposition.output = list(),
+    sensitivity.output = list()
+  ))
+
+  # Track load calls to verify samples.Rdata is only loaded once
+  load_count <- 0
+  mock_load <- function(file, envir) {
+    if (grepl("samples\\.Rdata$", file)) {
+      load_count <<- load_count + 1
+    }
+    base::load(file, envir = envir)
+  }
+  mockery::stub(run.sensitivity.analysis, "load", mock_load)
+
+  run.sensitivity.analysis(settings, plot = FALSE)
+
+  # samples.Rdata should be loaded exactly once despite multiple variables
+  expect_equal(load_count, 1)
+
+  # Both variable results should be generated
+  for (var in c("NPP", "GPP")) {
+    res_file <- sensitivity.filename(
+      settings, "sensitivity.results", "Rdata",
+      all.var.yr = FALSE,
+      pft = NULL,
+      ensemble.id = "ENS-TEST",
+      variable = var,
+      start.year = 2000,
+      end.year = 2001
+    )
+    expect_true(file.exists(res_file))
+  }
+})


### PR DESCRIPTION
## Description
Hoists loading of `samples.Rdata` and `sensitivity.samples` out of the `variables` loop in `run.sensitivity.analysis()`, loading them once into a base environment and cloning it per iteration. Also resolves variable shadowing where `variables <- PEcAn.utils::convert.expr(variable)` mutated the outer loop collection, and improves multi-variable extraction from `settings$sensitivity.analysis`.

## Motivation and Context
Closes #3859.

Previously, `run.sensitivity.analysis()` executed `load(fname, envir = samples)` for both `samples.Rdata` and `sensitivity.samples` inside `for (variable in variables)`. In multi-variable sensitivity analyses, this repeatedly re-read the same large sample files from disk on every iteration.

Additionally:
1. `variables <- PEcAn.utils::convert.expr(variable)` was executed inside the loop, shadowing and overwriting the outer `variables` vector on the first iteration. This has been renamed to `parsed_var <- PEcAn.utils::convert.expr(variable)`.
2. In-place unit conversions (e.g. Celsius adjustments) modify `samples$trait.samples`. To prevent mutations from bleeding across iterations without re-reading from disk, each loop iteration now clones the loaded base environment using `rlang::env_clone(samples_base)`.
3. Extracting `variable` from `settings$sensitivity.analysis` now uses `unlist(..., use.names = FALSE)` so it properly handles vector inputs as well as repeated XML keys.

## Review Time Estimate
- [x] When possible

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) <!-- #3859 -->

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [x] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [x] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
