### PR TITLE
Add roxygen installation instructions to Makefile roxygen2 version error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,9 @@ doc_R_pkg = \
 			Rscript -e "devtools::document('"$(strip $(1))"')", \
 		$(error Roxygen2 version is ${INSTALLED_ROXYGEN_VERSION}, \
 			but PEcAn package documentation must be built with exactly \
-			version ${EXPECTED_ROXYGEN_VERSION}))
+			version ${EXPECTED_ROXYGEN_VERSION} \
+			Restart R and run: \
+			remotes::install_version("roxygen2", version = "${EXPECTED_ROXYGEN_VERSION}", upgrade = "never")))
 
 
 depends = .doc/$(1) .install/$(1) .check/$(1) .test/$(1)

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ doc_R_pkg = \
 		$(error Roxygen2 version is ${INSTALLED_ROXYGEN_VERSION}, \
 			but PEcAn package documentation must be built with exactly \
 			version ${EXPECTED_ROXYGEN_VERSION} \
-			Restart R and run: \
+			In R, run: \
 			remotes::install_version("roxygen2", version = "${EXPECTED_ROXYGEN_VERSION}", upgrade = "never")))
 
 


### PR DESCRIPTION
Add more helpful error message when incorrect version of roxygen2 is used.

Include the command to install the expected roxygen2 version in the `make documentation` build error message.