### PR TITLE
Fix broken and outdated links in developer workflows (#4071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ For more information about this file see also [Keep a Changelog](http://keepacha
 - Added statewide synthetic fertilization and compost amendment event workflows for CA ag parcels. Outputs share an ensemble naming so a downstream cleaner unions them into one fertilization event type for SIPNET.
 
 ### Fixed
+- Fixed broken and outdated links across developer workflows in the PEcAn book and DEV-INTRO.md (#4071).
 - Building package documentation sites via `scripts/build_pkgdown.R` no longer exits early when any package gives a build warning (#4034).
 - The median run's manifest row went in with the literal strings `"NA"` for pft and trait, which `read.csv` turns into real `NA`, so `read.sa.output` never matched the median quantile and `splinefun` silently dropped that knot. Sensitivity analysis output changes as a result: partial variances shift slightly, though rankings are unaffected in the cases checked.
 - Docker GHA workflow no longer fails on pull requests opened from forks (#3618).

--- a/DEV-INTRO.md
+++ b/DEV-INTRO.md
@@ -53,7 +53,7 @@ sudo adduser ${USER} docker
 
 ### Deploying PEcAn in Docker
 
-To get started with development in docker we need to bring up the docker stack first. In the main pecan folder you will find the [docker-compose.yml](docker-compose.yml) file that can be used to bring up the pecan stack. There is also the [docker-compose.dev.yaml](docker-compose.dev.yaml) file that adds additional containers, and changes some services to make it easier for development.
+To get started with development in docker we need to bring up the docker stack first. In the main pecan folder you will find the [docker-compose.yml](docker-compose.yml) file that can be used to bring up the pecan stack. There is also the [docker-compose.dev.yml](docker-compose.dev.yml) file that adds additional containers, and changes some services to make it easier for development.
 
 By default Compose will use the files `docker-compose.yml` and `docker-compose.override.yml`. We will use the default `docker-compose.yml` file from PEcAn. The `docker-compose.override.yml` file can be used to configure it for your specific environment, in our case we will use it to setup the docker environment for development. Copy the `docker-compose.dev.yml` file to `docker-compose.override.yml` to start working with your own override file, i.e. :
 

--- a/book_source/02_demos_tutorials_workflows/05_developer_workflows/02_git/01_using-git.Rmd
+++ b/book_source/02_demos_tutorials_workflows/05_developer_workflows/02_git/01_using-git.Rmd
@@ -16,12 +16,12 @@ history and full revision tracking capabilities, not dependent on
 network access or a central server. Branching and merging are fast and
 easy to do.
 
-A good place to start is the [GitHub 5 minute illustrated tutorial](https://guides.github.com/introduction/flow/). 
-In addition, there are three fun tutorials for learning git:
+A good place to start is the [GitHub Flow tutorial](https://docs.github.com/en/get-started/quickstart/github-flow). 
+In addition, there are several helpful tutorials for learning git:
   
-* [Learn Git](https:k//www.codecademy.com/learn/learn-git) is a great web-based interactive tutorial.
+* [Learn Git](https://www.codecademy.com/learn/learn-git) is a web-based interactive tutorial.
 * [LearnGitBranching](https://learngitbranching.js.org/)
-* [TryGit](http://tryk.github.com).
+* [Git Tutorial](https://git-scm.com/docs/gittutorial) is the official introduction to Git.
 
 
 **URLs** In the rest of the document will use specific URL’s to clone the code.
@@ -242,10 +242,10 @@ the https or git url to check out the code.
 
 Rstudio is nicely integrated with many development tools, including git and GitHub. 
 It is quite easy to check out source code from within the Rstudio program or browser.
-The Rstudio documentation includes useful overviews of [version control](http://www.rstudio.com/ide/docs/version_control/overview) 
-and [R package development](http://www.rstudio.com/ide/docs/packages/overview). 
+The Rstudio documentation includes useful overviews of [version control](https://docs.posit.co/ide/user/ide/guide/tools/version-control.html) 
+and [R package development](https://docs.posit.co/ide/user/ide/guide/pkg-devel/writing-packages.html). 
 
-Once you have git installed on your computer (see the [Rstudio version control](http://www.rstudio.com/ide/docs/version_control/overview) documentation for instructions), you can use the following steps to install the PEcAn source code in Rstudio.
+Once you have git installed on your computer (see the [Rstudio version control](https://docs.posit.co/ide/user/ide/guide/tools/version-control.html) documentation for instructions), you can use the following steps to install the PEcAn source code in Rstudio.
 
 ### Advanced
 
@@ -308,14 +308,14 @@ To tag an earlier commit, just append the commit SHA to the command, e.g.
 #### Git Documentation
   
 * Scott Chacon, ‘Pro Git book’,
-[http://git-scm.com/book](http://git-scm.com/book)
+[https://git-scm.com/book](https://git-scm.com/book)
 * GitHub help pages,
-[https://help.github.com](https://help.github.com)/
+[https://docs.github.com](https://docs.github.com)/
 * Main GIT page
 [https://git-scm.com/doc](https://git-scm.com/doc)
 * Another set of pages about branching,
-[http://sandofsky.com/blog/git-workflow.html](http://sandofsky.com/blog/git-workflow.html)
-* [Stackoverflow highest voted questions tagged "git"](http://stackoverflow.com/questions/tagged/git?sort=votes&pagesize=50)
+[https://www.sandofsky.com/git-workflow/](https://www.sandofsky.com/git-workflow/)
+* [Stack Overflow highest voted questions tagged "git"](https://stackoverflow.com/questions/tagged/git?tab=Votes)
 
 
 #### GitHub Documentation
@@ -323,6 +323,6 @@ To tag an earlier commit, just append the commit SHA to the command, e.g.
 When in doubt, the first step is to click the "Help" button at the top of the page.
 
 * [GitHub Flow](https://docs.github.com/en/get-started/quickstart/github-flow)
-* [GitHub FAQ](https://help.github.com/)
-* [Using Pull Requests](https://help.github.com/articles/using-pull-requests)
-* [SSH Keys](https://help.github.com/articles/generating-ssh-keys)
+* [GitHub Documentation](https://docs.github.com/)
+* [Using Pull Requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
+* [SSH Keys](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)

--- a/book_source/02_demos_tutorials_workflows/05_developer_workflows/03_coding_practices/02-logging.Rmd
+++ b/book_source/02_demos_tutorials_workflows/05_developer_workflows/03_coding_practices/02-logging.Rmd
@@ -5,7 +5,7 @@ During development we often add many print statements to check to see how the co
 PEcAn provides a set of `logger.*` functions that should be used in place of base R's `stop`, `warn`, `print`, and similar functions. The `logger` functions make it easier to print to a system log file, and to control the level of output produced by PEcAn.
 
 * The file [test.logger.R](https://github.com/PecanProject/pecan/blob/develop/base/logger/tests/testthat/test.logger.R) provides descriptive examples
-* This query provides an current overview of [functions that use logging](https://github.com/PecanProject/pecan/search?q=logger&ref=cmdform)
+* The [PEcAn.logger package](https://pecanproject.github.io/package-documentation/develop/PEcAn.logger/) provides the implementation and package documentation
 * Logger functions and their corresponding levels (in order of increasing level):
  * `logger.debug` (`"DEBUG"`) -- Low-level diagnostic messages that are hidden by default. Good examples of this are expanded file paths and raw results from database queries or other analyses.
  * `logger.info` (`"INFO"`) -- Informational messages that regular users may want to see, but which do not indicate anything unexpected. Good examples of this are progress updates updates for long-running processes, or brief summaries of queries or analyses.

--- a/book_source/02_demos_tutorials_workflows/05_developer_workflows/04-testing.Rmd
+++ b/book_source/02_demos_tutorials_workflows/05_developer_workflows/04-testing.Rmd
@@ -151,7 +151,7 @@ Each build starts by launching a separate clean virtual machine for each R versi
 * Run a simple integration test using SIPNET model
 * Create the docker images
   - Once your PR is merged, it will push them to DockerHub and github container repository.
-* Compiles the PEcAn documentation book (`book_source`) and the tutorials (`documentation/tutorials`) and uploads them to the [PEcAn website](https://pecanproject.github.io/pecan-documentation).
+* Compiles the PEcAn documentation book (`book_source`) and the tutorials (`documentation/tutorials`) and uploads them to the [PEcAn website](https://pecanproject.github.io/pecan-documentation/develop/).
     - This is only done for commits to the `master` or `develop` branch, so changes to in-progress pull requests never change the live documentation until after they are merged.
 
 If your build fails and indicates that files have been modified there are a few common causes. It should also list the files that have changes, and what has changed.

--- a/book_source/02_demos_tutorials_workflows/05_developer_workflows/04_docker/09_rabbitmq.Rmd
+++ b/book_source/02_demos_tutorials_workflows/05_developer_workflows/04_docker/09_rabbitmq.Rmd
@@ -2,7 +2,7 @@
 
 This section provides additional details about how PEcAn uses RabbitMQ to manage communication between its Docker containers.
 
-In PEcAn, we use the Python [`pika`](http://www.rabbitmq.com/tutorials/tutorial-one-python.html) client to retrieve messages from RabbitMQ. The PEcAn.remote library has convenience functions that wrap the API to post and read messages. The executor and models use the python version of the RabbitMQ scripts to retrieve messages, and launch the appropriate code.
+In PEcAn, we use the Python [`pika`](https://www.rabbitmq.com/tutorials/tutorial-one-python.html) client to retrieve messages from RabbitMQ. The PEcAn.remote library has convenience functions that wrap the API to post and read messages. The executor and models use the python version of the RabbitMQ scripts to retrieve messages, and launch the appropriate code.
 
 ### Producer -- `PEcAn.remote::rabbitmq_post_message` {#rabbitmq-basics-sender}
 
@@ -10,7 +10,7 @@ The `PEcAn.remote::rabbitmq_post_message` function allows you to post messages t
 
 The function has three required arguments and two optional ones:
 
-- `uri` -- This is the URI used to connect to RabbitMQ, it will have the form `amqp://username:password\@server:5672/vhost`. Most containers will have this injected using the environment variable `RABBITMQ_URI`.
+- `uri` -- This is the URI used to connect to RabbitMQ, it will have the form `amqp://username:password@server:5672/vhost`. Most containers will have this injected using the environment variable `RABBITMQ_URI`.
 - `queue` -- The queue to post the message on, this is either `pecan` for a workflow to be exected, the name of the model and version to be executed, for example `SIPNET_r136`.
 - `message` -- The actual message to be send, this is of type list and will be converted to a json string representation.
 - `prefix` -- The code will talk to the rest api, this is the prefix of the rest api. In the case of the default docker-compse file, this will be `/rabbitmq` and will be injected as `RABBITMQ_PREFIX`.


### PR DESCRIPTION
## Description
Addresses part of #4071 by repairing broken and outdated documentation links in developer workflows:
- `DEV-INTRO.md`: Corrected `.yaml` typo in `docker-compose.dev.yml` link to match the repository file name.
- `book_source/02_demos_tutorials_workflows/05_developer_workflows/02_git/01_using-git.Rmd`:
  - Fixed `https:k//` typo in Codecademy URL.
  - Replaced dead TryGit link with the official [Git Tutorial](https://git-scm.com/docs/gittutorial).
  - Updated legacy RStudio documentation paths to active Posit documentation guides.
  - Upgraded git-scm and Sandofsky workflow guides to HTTPS.
  - Updated GitHub help links to `docs.github.com`.
- `book_source/02_demos_tutorials_workflows/05_developer_workflows/03_coding_practices/02-logging.Rmd`:
  - Replaced rate-limited GitHub search link with a direct link to `PEcAn.logger` package documentation.
- `book_source/02_demos_tutorials_workflows/05_developer_workflows/04-testing.Rmd`:
  - Fixed 404 documentation book link to canonical `develop/` path.
- `book_source/02_demos_tutorials_workflows/05_developer_workflows/04_docker/09_rabbitmq.Rmd`:
  - Fixed backslash escape in AMQP URI template and upgraded RabbitMQ tutorial link to HTTPS.
- Updated `CHANGELOG.md`.

## Motivation and Context
Addresses part of #4071.

Issue #4071 is an automated report tracking hundreds of broken links across the repository. Fixing these in focused increments keeps reviews manageable and ensures steady progress on documentation health.

## Review Time Estimate
- [ ] Immediately
- [ ] Within one week
- [x] When possible

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) <!-- #4071 -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [x] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [x] I have updated the CHANGELOG.md.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
